### PR TITLE
refactor: make DataSourceType an Enum

### DIFF
--- a/src/compile/data/lookup.ts
+++ b/src/compile/data/lookup.ts
@@ -7,6 +7,7 @@ import {Model} from '../model';
 import {DataFlowNode, OutputNode} from './dataflow';
 import {findSource} from './parse';
 import {SourceNode} from './source';
+import {DataSourceType} from '../../data';
 
 export class LookupNode extends DataFlowNode {
   public clone() {
@@ -31,7 +32,7 @@ export class LookupNode extends DataFlowNode {
       }
 
       const fromOutputName = model.getName(`lookup_${counter}`);
-      fromOutputNode = new OutputNode(fromSource, fromOutputName, 'lookup', model.component.data.outputNodeRefCounts);
+      fromOutputNode = new OutputNode(fromSource, fromOutputName, DataSourceType.Lookup, model.component.data.outputNodeRefCounts);
       model.component.data.outputNodes[fromOutputName] = fromOutputNode;
     } else if (isLookupSelection(from)) {
       const selName = from.selection;

--- a/src/compile/data/optimizers.ts
+++ b/src/compile/data/optimizers.ts
@@ -1,4 +1,4 @@
-import {MAIN, Parse} from '../../data';
+import {DataSourceType, Parse} from '../../data';
 import {Dict, fieldIntersection, hash, hasIntersection, isEmpty, keys, some} from '../../util';
 import {Model} from '../model';
 import {requiresSelectionId} from '../selection';
@@ -244,7 +244,7 @@ export function moveFacetDown(node: DataFlowNode) {
 }
 
 function moveMainDownToFacet(node: DataFlowNode) {
-  if (node instanceof OutputNode && node.type === MAIN) {
+  if (node instanceof OutputNode && node.type === DataSourceType.Main) {
     if (node.numChildren() === 1) {
       const child = node.children[0];
       if (!(child instanceof FacetNode)) {

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -358,7 +358,7 @@ export function parseData(model: Model): DataComponent {
   }
 
   // add an output node pre aggregation
-  const rawName = model.getName(DataSourceType.Raw);
+  const rawName = model.getDataName(DataSourceType.Raw);
   const raw = new OutputNode(head, rawName, DataSourceType.Raw, outputNodeRefCounts);
   outputNodes[rawName] = raw;
   head = raw;
@@ -381,7 +381,7 @@ export function parseData(model: Model): DataComponent {
   }
 
   // output node for marks
-  const mainName = model.getName(DataSourceType.Main);
+  const mainName = model.getDataName(DataSourceType.Main);
   const main = new OutputNode(head, mainName, DataSourceType.Main, outputNodeRefCounts);
   outputNodes[mainName] = main;
   head = main;

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -7,9 +7,8 @@ import {
   isNamedData,
   isSequenceGenerator,
   isUrlData,
-  MAIN,
+  DataSourceType,
   ParseValue,
-  RAW
 } from '../../data';
 import * as log from '../../log';
 import {
@@ -359,8 +358,8 @@ export function parseData(model: Model): DataComponent {
   }
 
   // add an output node pre aggregation
-  const rawName = model.getName(RAW);
-  const raw = new OutputNode(head, rawName, RAW, outputNodeRefCounts);
+  const rawName = model.getName(DataSourceType.Raw);
+  const raw = new OutputNode(head, rawName, DataSourceType.Raw, outputNodeRefCounts);
   outputNodes[rawName] = raw;
   head = raw;
 
@@ -382,8 +381,8 @@ export function parseData(model: Model): DataComponent {
   }
 
   // output node for marks
-  const mainName = model.getName(MAIN);
-  const main = new OutputNode(head, mainName, MAIN, outputNodeRefCounts);
+  const mainName = model.getName(DataSourceType.Main);
+  const main = new OutputNode(head, mainName, DataSourceType.Main, outputNodeRefCounts);
   outputNodes[mainName] = main;
   head = main;
 

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -1,6 +1,6 @@
 import {isArray} from 'vega-util';
 import {FieldRefOption, isFieldDef, isValueDef, vgField} from '../../channeldef';
-import {MAIN} from '../../data';
+import {DataSourceType} from '../../data';
 import {isAggregate, pathGroupingFields} from '../../encoding';
 import {AREA, BAR, isPathMark, LINE, Mark, TRAIL} from '../../mark';
 import {isSortByEncoding, isSortField} from '../../sort';
@@ -68,8 +68,8 @@ function getPathGroups(model: UnitModel, details: string[]) {
       type: 'group',
       from: {
         facet: {
-          name: FACETED_PATH_PREFIX + model.requestDataName(MAIN),
-          data: model.requestDataName(MAIN),
+          name: FACETED_PATH_PREFIX + model.requestDataName(DataSourceType.Main),
+          data: model.requestDataName(DataSourceType.Main),
           groupby: details
         }
       },
@@ -211,8 +211,8 @@ function getGroupsForStackedBarWithCornerRadius(model: UnitModel) {
       type: 'group',
       from: {
         facet: {
-          data: model.requestDataName(MAIN),
-          name: STACK_GROUP_PREFIX + model.requestDataName(MAIN),
+          data: model.requestDataName(DataSourceType.Main),
+          name: STACK_GROUP_PREFIX + model.requestDataName(DataSourceType.Main),
           groupby,
           aggregate: {
             fields: [
@@ -320,14 +320,14 @@ function getMarkGroup(model: UnitModel, opt: {fromPrefix: string} = {fromPrefix:
       ...(sort ? {sort} : {}),
       ...(interactive ? interactive : {}),
       ...(aria === false ? {aria} : {}),
-      from: {data: opt.fromPrefix + model.requestDataName(MAIN)},
+      from: {data: opt.fromPrefix + model.requestDataName(DataSourceType.Main)},
       encode: {
         update: markCompiler[mark].encodeEntry(model)
       },
       ...(postEncodingTransform
         ? {
-            transform: postEncodingTransform
-          }
+          transform: postEncodingTransform
+        }
         : {})
     }
   ];

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -470,13 +470,7 @@ export abstract class Model {
   }
 
   public getDataName(type: DataSourceType) {
-    switch (type) {
-      case DataSourceType.Raw: return this.getName("raw");
-      case DataSourceType.Main: return this.getName("main");
-      case DataSourceType.Row: return this.getName("row");
-      case DataSourceType.Column: return this.getName("column");
-      case DataSourceType.Lookup: return this.getName("lookup");
-    }
+    return DataSourceType[type];
   }
 
   /**

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -469,13 +469,23 @@ export abstract class Model {
     return varName((this.name ? this.name + '_' : '') + text);
   }
 
+  public getDataName(type: DataSourceType) {
+    switch (type) {
+      case DataSourceType.Raw: return this.getName("raw");
+      case DataSourceType.Main: return this.getName("main");
+      case DataSourceType.Row: return this.getName("row");
+      case DataSourceType.Column: return this.getName("column");
+      case DataSourceType.Lookup: return this.getName("lookup");
+    }
+  }
+
   /**
    * Request a data source name for the given data source type and mark that data source as required.
    * This method should be called in parse, so that all used data source can be correctly instantiated in assembleData().
    * You can lookup the correct dataset name in assemble with `lookupDataSource`.
    */
   public requestDataName(name: DataSourceType) {
-    const fullName = this.getName(name);
+    const fullName = this.getDataName(name);
 
     // Increase ref count. This is critical because otherwise we won't create a data source.
     // We also increase the ref counts on OutputNode.getSource() calls.

--- a/src/compile/projection/parse.ts
+++ b/src/compile/projection/parse.ts
@@ -2,7 +2,7 @@ import {SignalRef} from 'vega';
 import {hasOwnProperty} from 'vega-util';
 import {LATITUDE, LATITUDE2, LONGITUDE, LONGITUDE2, SHAPE} from '../../channel';
 import {getFieldOrDatumDef} from '../../channeldef';
-import {MAIN} from '../../data';
+import {DataSourceType} from '../../data';
 import {PROJECTION_PROPERTIES} from '../../projection';
 import {GEOJSON} from '../../type';
 import {duplicate, every, stringify} from '../../util';
@@ -59,7 +59,7 @@ function gatherFitData(model: UnitModel) {
 
   if (data.length === 0) {
     // main source is geojson, so we can just use that
-    data.push(model.requestDataName(MAIN));
+    data.push(model.requestDataName(DataSourceType.Main));
   }
 
   return data;

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -22,7 +22,7 @@ import {
   valueExpr,
   vgField
 } from '../../channeldef';
-import {MAIN, RAW} from '../../data';
+import {DataSourceType} from '../../data';
 import {DateTime} from '../../datetime';
 import * as log from '../../log';
 import {Domain, hasDiscreteDomain, isDomainUnionWith, isSelectionDomain, ScaleConfig, ScaleType} from '../../scale';
@@ -261,7 +261,7 @@ function parseSingleChannelDomain(
       return makeImplicit([[0, 1]]);
     }
 
-    const data = model.requestDataName(MAIN);
+    const data = model.requestDataName(DataSourceType.Main);
     return makeImplicit([
       {
         data,
@@ -284,7 +284,7 @@ function parseSingleChannelDomain(
 
   const fieldDef = fieldOrDatumDef; // now we can be sure it's a fieldDef
   if (domain === 'unaggregated') {
-    const data = model.requestDataName(MAIN);
+    const data = model.requestDataName(DataSourceType.Main);
     const {field} = fieldOrDatumDef;
     return makeImplicit([
       {
@@ -309,16 +309,16 @@ function parseSingleChannelDomain(
         {
           // If sort by aggregation of a specified sort field, we need to use RAW table,
           // so we can aggregate values for the scale independently from the main aggregation.
-          data: util.isBoolean(sort) ? model.requestDataName(MAIN) : model.requestDataName(RAW),
+          data: util.isBoolean(sort) ? model.requestDataName(DataSourceType.Main) : model.requestDataName(DataSourceType.Raw),
           // Use range if we added it and the scale does not support computing a range as a signal.
           field: model.vgField(channel, binRequiresRange(fieldDef, channel) ? {binSuffix: 'range'} : {}),
           // we have to use a sort object if sort = true to make the sort correct by bin start
           sort:
             sort === true || !isObject(sort)
               ? {
-                  field: model.vgField(channel, {}),
-                  op: 'min' // min or max doesn't matter since we sort by the start of the bin range
-                }
+                field: model.vgField(channel, {}),
+                op: 'min' // min or max doesn't matter since we sort by the start of the bin range
+              }
               : sort
         }
       ]);
@@ -336,7 +336,7 @@ function parseSingleChannelDomain(
       } else {
         return makeImplicit([
           {
-            data: model.requestDataName(MAIN),
+            data: model.requestDataName(DataSourceType.Main),
             field: model.vgField(channel, {})
           }
         ]);
@@ -354,7 +354,7 @@ function parseSingleChannelDomain(
       model.config
     )
   ) {
-    const data = model.requestDataName(MAIN);
+    const data = model.requestDataName(DataSourceType.Main);
     return makeImplicit([
       {
         data,
@@ -370,7 +370,7 @@ function parseSingleChannelDomain(
       {
         // If sort by aggregation of a specified sort field, we need to use RAW table,
         // so we can aggregate values for the scale independently from the main aggregation.
-        data: util.isBoolean(sort) ? model.requestDataName(MAIN) : model.requestDataName(RAW),
+        data: util.isBoolean(sort) ? model.requestDataName(DataSourceType.Main) : model.requestDataName(DataSourceType.Raw),
         field: model.vgField(channel),
         sort: sort
       }
@@ -378,7 +378,7 @@ function parseSingleChannelDomain(
   } else {
     return makeImplicit([
       {
-        data: model.requestDataName(MAIN),
+        data: model.requestDataName(DataSourceType.Main),
         field: model.vgField(channel)
       }
     ]);

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -24,7 +24,7 @@ import {
 } from '../../channel';
 import {getFieldOrDatumDef, ScaleDatumDef, ScaleFieldDef} from '../../channeldef';
 import {Config, getViewConfigDiscreteSize, getViewConfigDiscreteStep, ViewConfig} from '../../config';
-import {MAIN} from '../../data';
+import {DataSourceType} from '../../data';
 import * as log from '../../log';
 import {Mark} from '../../mark';
 import {
@@ -132,7 +132,7 @@ export function parseRangeForChannel(channel: ScaleChannel, model: UnitModel): E
               }
             } else if (isObject(range)) {
               return makeExplicit({
-                data: model.requestDataName(MAIN),
+                data: model.requestDataName(DataSourceType.Main),
                 field: range.field,
                 sort: {op: 'min', field: model.vgField(channel)}
               });

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -10,6 +10,7 @@ import {FilterNode} from '../data/filter';
 import {Model} from '../model';
 import {UnitModel} from '../unit';
 import {forEachTransform} from './transforms/transforms';
+import {DataSourceType} from '../../data';
 
 export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>) {
   const selCmpts: Dict<SelectionComponent<any /* this has to be "any" so typing won't fail in test files*/>> = {};
@@ -102,7 +103,7 @@ export function parseSelectionBinExtent(selCmpt: SelectionComponent, extent: Sel
     if (selCmpt.project.items.length > 1) {
       warn(
         'A "field" or "encoding" must be specified when using a selection as a scale domain. ' +
-          `Using "field": ${stringValue(field)}.`
+        `Using "field": ${stringValue(field)}.`
       );
     }
   } else if (encoding && !field) {
@@ -111,8 +112,8 @@ export function parseSelectionBinExtent(selCmpt: SelectionComponent, extent: Sel
       field = selCmpt.project.items[0].field;
       warn(
         (!encodings.length ? 'No ' : 'Multiple ') +
-          `matching ${stringValue(encoding)} encoding found for selection ${stringValue(extent.selection)}. ` +
-          `Using "field": ${stringValue(field)}.`
+        `matching ${stringValue(encoding)} encoding found for selection ${stringValue(extent.selection)}. ` +
+        `Using "field": ${stringValue(field)}.`
       );
     } else {
       field = encodings[0].field;
@@ -129,7 +130,7 @@ export function materializeSelections(model: UnitModel, main: OutputNode) {
     model.component.data.outputNodes[lookupName] = selCmpt.materialized = new OutputNode(
       new FilterNode(main, model, {selection}),
       lookupName,
-      'lookup',
+      DataSourceType.Lookup,
       model.component.data.outputNodeRefCounts
     );
   });

--- a/src/data.ts
+++ b/src/data.ts
@@ -155,9 +155,6 @@ export enum DataSourceType {
   Lookup = 'lookup',
 };
 
-export const MAIN = DataSourceType.Main as const;
-export const RAW = DataSourceType.Raw as const;
-
 export type Generator = SequenceGenerator | SphereGenerator | GraticuleGenerator;
 
 export interface GeneratorBase {

--- a/src/data.ts
+++ b/src/data.ts
@@ -148,11 +148,11 @@ export function isGraticuleGenerator(data: Partial<Data> | Partial<VgData>): dat
 }
 
 export enum DataSourceType {
-  Raw = 'raw',
-  Main = 'main',
-  Row = 'row',
-  Column = 'column',
-  Lookup = 'lookup'
+  Raw,
+  Main,
+  Row,
+  Column,
+  Lookup
 }
 
 export type Generator = SequenceGenerator | SphereGenerator | GraticuleGenerator;

--- a/src/data.ts
+++ b/src/data.ts
@@ -147,10 +147,16 @@ export function isGraticuleGenerator(data: Partial<Data> | Partial<VgData>): dat
   return 'graticule' in data;
 }
 
-export type DataSourceType = 'raw' | 'main' | 'row' | 'column' | 'lookup';
+export enum DataSourceType {
+  Raw = 'raw',
+  Main = 'main',
+  Row = 'row',
+  Column = 'column',
+  Lookup = 'lookup',
+};
 
-export const MAIN = 'main' as const;
-export const RAW = 'raw' as const;
+export const MAIN = DataSourceType.Main as const;
+export const RAW = DataSourceType.Raw as const;
 
 export type Generator = SequenceGenerator | SphereGenerator | GraticuleGenerator;
 


### PR DESCRIPTION
Use an enum with string values, instead of using an union type
with string literals. This should give better compile time type checking
and error messages.

Fixes #6609
