### PR TITLE
ci: use pat to build automated commits

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -54,7 +56,7 @@ jobs:
       - name: Setup Git remote
         run: ./scripts/setup-git-ci.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Check and Commit
         run: ./scripts/check-and-commit.sh
@@ -66,6 +68,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -104,7 +108,7 @@ jobs:
       - name: Setup Git remote
         run: ./scripts/setup-git-ci.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Check and Commit
         run: ./scripts/check-and-commit-toc.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-
     name: Lint, Format, Schema, and Examples
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -62,9 +61,9 @@ jobs:
         run: ./scripts/check-and-commit.sh
 
   toc:
-    runs-on: ubuntu-latest
-
     name: TOC
+    if: "!contains(github.event.head_commit.message, '[CI]')"
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,8 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-
     name: Release
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   test-matrix:
+    name: Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [10, 12, 14]
-
-    name: Node ${{ matrix.node }}
 
     steps:
       - uses: actions/checkout@v2
@@ -55,9 +54,8 @@ jobs:
         run: yarn build
 
   build-site:
-    runs-on: ubuntu-latest
-
     name: Build Site
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -121,12 +119,11 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-cli:
+    name: CLI
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-
-    name: CLI
 
     steps:
       - uses: actions/checkout@v2

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import {version} from '../package.json';
 import {normalize} from './normalize';
 
-
 export {compile} from './compile/compile';
 export {Config} from './config';
 export {TopLevelSpec} from './spec';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {version} from '../package.json';
 import {normalize} from './normalize';
 
+
 export {compile} from './compile/compile';
 export {Config} from './config';
 export {TopLevelSpec} from './spec';


### PR DESCRIPTION
With this change, we are now building even automated commits so that we don't end up in a situation where we miss that a test failed but not in the last commit. 