### PR TITLE
docs: Adding title example to tooltip docs

### DIFF
--- a/examples/specs/bar_tooltip_title.vl.json
+++ b/examples/specs/bar_tooltip_title.vl.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "data": {
+    "values": [
+      {"a": "A", "b": 28},
+      {"a": "B", "b": 55},
+      {"a": "C", "b": 43},
+      {"a": "D", "b": 91},
+      {"a": "E", "b": 81},
+      {"a": "F", "b": 53},
+      {"a": "G", "b": 19},
+      {"a": "H", "b": 87},
+      {"a": "I", "b": 52}
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "a", "type": "ordinal"},
+    "y": {"field": "b", "type": "quantitative"},
+    "tooltip": [
+      {"field": "a", "type": "ordinal", "title": "Field A"},
+      {"field": "b", "type": "quantitative", "title": "Field B"}
+    ]
+  }
+}

--- a/site/docs/tooltip.md
+++ b/site/docs/tooltip.md
@@ -50,6 +50,10 @@ To show more than one field, you can provide an array of field definitions. [Veg
 
 Alternatively, you can [calculate](calculate.html) a new field that concatenates multiple fields (and use a single field definition).
 
+<div class="vl-example" data-name="bar_tooltip_title"></div>
+
+You can also give the fields in the tooltip a label that is different from the field name by using the `title` parameter.
+
 ## Disable tooltips
 
 To disable tooltips for a particular single view specification, you can set the `"tooltip"` property of a mark definition block to `null`.


### PR DESCRIPTION
The documentation for `tooltip` did not make any references to the `title` parameter, so I am adding an example here.