### PR TITLE
fix: errorbar thickness and size

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -6021,6 +6021,14 @@
             }
           ]
         },
+        "size": {
+          "description": "Size of the ticks of an error bar",
+          "type": "number"
+        },
+        "thickness": {
+          "description": "Thickness of the ticks and the bar of an error bar",
+          "type": "number"
+        },
         "ticks": {
           "anyOf": [
             {
@@ -6073,6 +6081,14 @@
               "$ref": "#/definitions/MarkConfig"
             }
           ]
+        },
+        "size": {
+          "description": "Size of the ticks of an error bar",
+          "type": "number"
+        },
+        "thickness": {
+          "description": "Thickness of the ticks and the bar of an error bar",
+          "type": "number"
         },
         "ticks": {
           "anyOf": [

--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -75,6 +75,12 @@ export type ErrorEncoding<F extends Field> = Pick<Encoding<F>, PositionChannel |
 export type ErrorBarPartsMixins = PartsMixins<ErrorBarPart>;
 
 export interface ErrorBarConfig extends ErrorBarPartsMixins {
+  /** Size of the ticks of an error bar */
+  size?: number;
+
+  /** Thickness of the ticks and the bar of an error bar */
+  thickness?: number;
+
   /**
    * The center of the errorbar. Available options include:
    * - `"mean"`: the mean of the data points.
@@ -136,6 +142,7 @@ export function normalizeErrorBar(
     outerSpec,
     tooltipEncoding
   } = errorBarParams(spec, ERRORBAR, config);
+  delete encodingWithoutContinuousAxis['size'];
 
   const makeErrorBarPart = makeCompositeAggregatePartFactory<ErrorBarPartsMixins>(
     markDef,
@@ -145,7 +152,15 @@ export function normalizeErrorBar(
     config.errorbar
   );
 
-  const tick: MarkDef = {type: 'tick', orient: ticksOrient, aria: false};
+  const thickness = markDef.thickness;
+  const size = markDef.size;
+  const tick: MarkDef = {
+    type: 'tick',
+    orient: ticksOrient,
+    aria: false,
+    ...(thickness !== undefined ? {thickness} : {}),
+    ...(size !== undefined ? {size} : {})
+  };
 
   const layer = [
     ...makeErrorBarPart({
@@ -164,7 +179,8 @@ export function normalizeErrorBar(
       partName: 'rule',
       mark: {
         type: 'rule',
-        ariaRoleDescription: 'errorbar'
+        ariaRoleDescription: 'errorbar',
+        ...(thickness !== undefined ? {size: thickness} : {})
       },
       positionPrefix: 'lower',
       endPositionPrefix: 'upper',

--- a/test/compositemark/errorbar.test.ts
+++ b/test/compositemark/errorbar.test.ts
@@ -2,13 +2,13 @@ import {AggregateOp} from 'vega';
 import {ErrorBarCenter, ErrorBarExtent} from '../../src/compositemark/errorbar';
 import {defaultConfig} from '../../src/config';
 import * as log from '../../src/log';
-import {isMarkDef} from '../../src/mark';
+import {isMarkDef, TickConfig} from '../../src/mark';
 import {normalize} from '../../src/normalize';
 import {isLayerSpec, isUnitSpec} from '../../src/spec';
 import {TopLevelUnitSpec} from '../../src/spec/unit';
 import {isAggregate, isCalculate, Transform} from '../../src/transform';
 import {some} from '../../src/util';
-import {assertIsUnitSpec} from '../util';
+import {assertIsLayerSpec, assertIsUnitSpec} from '../util';
 
 describe('normalizeErrorBar with raw data input', () => {
   it('should produce correct layered specs for mean point and vertical error bar', () => {
@@ -365,6 +365,121 @@ describe('normalizeErrorBar with raw data input', () => {
       {field: 'center_people', title: 'Median of people', type: 'quantitative'},
       {field: 'age', type: 'ordinal'}
     ]);
+  });
+
+  it('should drop size in encoding channel', () => {
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {type: 'errorbar'},
+        encoding: {x: {field: 'age', type: 'quantitative'}, size: {value: 3}}
+      },
+      defaultConfig
+    );
+
+    assertIsUnitSpec(outputSpec);
+    expect(outputSpec.encoding.size).toBeFalsy();
+  });
+
+  it('should apply mark.size to only size of ticks', () => {
+    const size = 10;
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {type: 'errorbar', size, ticks: true},
+        encoding: {x: {field: 'age', type: 'quantitative'}}
+      },
+      defaultConfig
+    );
+
+    assertIsLayerSpec(outputSpec);
+    for (const layer of outputSpec.layer) {
+      if (layer['mark']) {
+        if (layer['mark']['type'] === 'tick') {
+          expect(layer['mark']['size']).toBe(size);
+        } else {
+          expect(layer['mark']['size']).toBeFalsy();
+        }
+      }
+    }
+  });
+
+  it('should override mark.size with mark.ticks.size', () => {
+    const size = 10;
+    const tickSize = 5;
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {type: 'errorbar', size, ticks: {size: tickSize}},
+        encoding: {x: {field: 'age', type: 'quantitative'}}
+      },
+      defaultConfig
+    );
+
+    assertIsLayerSpec(outputSpec);
+    for (const layer of outputSpec.layer) {
+      if (layer['mark']) {
+        if (layer['mark']['type'] === 'tick') {
+          expect(layer['mark']['size']).toBe(tickSize);
+        } else {
+          expect(layer['mark']['size']).toBeFalsy();
+        }
+      }
+    }
+  });
+
+  it('should apply mark.thickness to both thickness of ticks and size of rule', () => {
+    const thickness = 10;
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {type: 'errorbar', thickness, ticks: true},
+        encoding: {x: {field: 'age', type: 'quantitative'}}
+      },
+      defaultConfig
+    );
+
+    assertIsLayerSpec(outputSpec);
+    for (const layer of outputSpec.layer) {
+      if (layer['mark']) {
+        if (layer['mark']['type'] === 'tick') {
+          expect(layer['mark']['thickness']).toBe(thickness);
+        } else {
+          expect(layer['mark']['size']).toBe(thickness);
+        }
+      }
+    }
+  });
+
+  it('should override mark.thickness with mark.ticks.thickness and mark.rule.size', () => {
+    const thickness = 10;
+    const tickThickness = 5;
+    const ruleSize = 7;
+
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {
+          type: 'errorbar',
+          thickness,
+          ticks: {thickness: tickThickness} as TickConfig,
+          rule: {size: ruleSize}
+        },
+        encoding: {x: {field: 'age', type: 'quantitative'}}
+      },
+      defaultConfig
+    );
+
+    assertIsLayerSpec(outputSpec);
+    for (const layer of outputSpec.layer) {
+      if (layer['mark']) {
+        if (layer['mark']['type'] === 'tick') {
+          expect(layer['mark']['thickness']).toBe(tickThickness);
+        } else {
+          expect(layer['mark']['size']).toBe(ruleSize);
+        }
+      }
+    }
   });
 });
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -16,7 +16,9 @@ import {
   NormalizedUnitSpec,
   TopLevel,
   TopLevelSpec,
-  isUnitSpec
+  isUnitSpec,
+  isLayerSpec,
+  GenericLayerSpec
 } from '../src/spec';
 import {FrameMixins} from '../src/spec/base';
 import {contains} from '../src/util';
@@ -85,6 +87,12 @@ export function parseConcatModel(spec: TopLevel<NormalizedConcatSpec>) {
 export function assertIsUnitSpec(spec: BaseSpec): asserts spec is FacetedUnitSpec | NormalizedUnitSpec {
   if (!isUnitSpec(spec)) {
     throw new Error('Spec is not a unit spec!');
+  }
+}
+
+export function assertIsLayerSpec(spec: BaseSpec): asserts spec is GenericLayerSpec<any> {
+  if (!isLayerSpec(spec)) {
+    throw new Error('Spec is not a layer spec!');
   }
 }
 


### PR DESCRIPTION
Fix #6495 from the discussion in #6502 
- Drop size encoding in errorbar
- `mark.size` sets `mark.ticks.size` if `mark.ticks.size` is not specified
- `mark.thickness` sets:
  - `mark.ticks.thickness` if `mark.ticks.thickness` is not specified
  - `mark.rule.size` if `mark.rule.size` is not specified