### PR TITLE
fix: incorrect boxplot when using temporal field

### DIFF
--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -1070,4 +1070,31 @@ describe('normalizeBoxIQR', () => {
     const {tooltip} = normalizedSpecWithTooltip['layer'][0]['layer'][0]['encoding'];
     expect(tooltip).toEqual({field: 'year', type: 'quantitative'});
   });
+
+  it("should include timeUnit transform in filteredLayerMixins' transform", () => {
+    const field = 'Date';
+    const timeUnit = 'year';
+    const normalizedSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: 'boxplot',
+        encoding: {
+          x: {
+            field,
+            type: 'temporal',
+            timeUnit
+          },
+          y: {field: 'Anomaly', type: 'quantitative'}
+        }
+      },
+      defaultConfig
+    );
+
+    const filteredLayerMixins = normalizedSpec['layer'][1];
+    expect(filteredLayerMixins.transform[0]).toEqual({
+      timeUnit: {unit: 'year'},
+      field,
+      as: `${timeUnit}_${field}`
+    });
+  });
 });


### PR DESCRIPTION
Fix #4524 
Fix #4925

Boxplot did not include `bins` and `timeUnits` transform into `filteredLayersMixins`' transform. So, I included them.