### PR TITLE
fix: make encoding null override parent encoding

### DIFF
--- a/src/normalize/core.ts
+++ b/src/normalize/core.ts
@@ -361,7 +361,7 @@ function mergeEncoding({
             ...channelDef.condition
           }
         };
-      } else if (channelDef) {
+      } else if (channelDef || channelDef === null) {
         merged[channel] = channelDef;
       } else if (
         layer ||


### PR DESCRIPTION
Fix https://github.com/vega/vega-lite/issues/6762

The encoding: null now override parent encoding like expected: 

<img width="797" alt="image" src="https://user-images.githubusercontent.com/111269/88864348-d7544300-d1b9-11ea-9eee-d8c1e52b0035.png">
 