### PR TITLE
docs: typo in joinaggregate_mean_difference_by_year example

### DIFF
--- a/examples/compiled/joinaggregate_mean_difference_by_year.vg.json
+++ b/examples/compiled/joinaggregate_mean_difference_by_year.vg.json
@@ -9,11 +9,11 @@
     {
       "name": "source_0",
       "url": "data/movies.json",
-      "format": {"type": "json", "parse": {"Release_Date": "date"}},
+      "format": {"type": "json", "parse": {"Release Date": "date"}},
       "transform": [
         {"type": "filter", "expr": "datum['IMDB Rating'] != null"},
         {
-          "field": "Release_Date",
+          "field": "Release Date",
           "type": "timeunit",
           "units": ["year"],
           "as": ["year", "year_end"]

--- a/examples/specs/joinaggregate_mean_difference_by_year.vl.json
+++ b/examples/specs/joinaggregate_mean_difference_by_year.vl.json
@@ -6,7 +6,7 @@
   },
   "transform": [
       {"filter": "datum['IMDB Rating'] != null"},
-      {"timeUnit": "year", "field": "Release_Date", "as": "year"},
+      {"timeUnit": "year", "field": "Release Date", "as": "year"},
       {
         "joinaggregate": [{
           "op": "mean",


### PR DESCRIPTION
Small typo in jthe oinaggregate_mean_difference_by_year.vl.json  example. I believe there is no "Release_Date" field in the movies dataset, instead it is "Release Date". 
