### PR TITLE
docs: update Facet Bullet Chart

### DIFF
--- a/examples/specs/facet_bullet.vl.json
+++ b/examples/specs/facet_bullet.vl.json
@@ -12,7 +12,7 @@
   "facet": {
     "row": {
       "field": "title", "type": "ordinal",
-      "header": {"labelAngle": 0, "title": ""}
+      "header": {"labelAngle": 0, "title": "", "labelAlign": "left"}
     }
   },
   "spacing": 10,


### PR DESCRIPTION
Currently, the faceted bullet chart example looks like this

![visualization (54)](https://user-images.githubusercontent.com/2041969/93117434-d786a000-f68c-11ea-8a51-23e018e0fd00.png)

I added the `labelAlign` parameter to clean up the y axis

![visualization (53)](https://user-images.githubusercontent.com/2041969/93117448-de151780-f68c-11ea-8a49-f7eb37be7a39.png)
