### PR TITLE
docs: add BBC Visual and Data Journalism cookbook port to examples page

### DIFF
--- a/site/examples/index.md
+++ b/site/examples/index.md
@@ -56,3 +56,4 @@ Here we list great examples of Vega-Lite visualizations that were created by the
 - [Top-K Plot with Others](https://beta.observablehq.com/@manzt/top-k-plot-with-others-vega-lite-example) by @manzt
 - [Trafford Data Lab's Vega-Lite graphics companion](https://www.trafforddatalab.io/interactive_graphics_companion/) by @trafforddatalab
 - [International Flight Map](https://observablehq.com/@alhenry/international-flight-map) by [@alhenry](https://twitter.com/maha_albert)
+- [BBC Visual and Data Journalism cookbook port to Vega-Lite](https://github.com/aezarebski/vegacookbook) by @aezarebski


### PR DESCRIPTION
I add a link to a collection of examples described below to the list of external examples on the website.

**Project description** 

This project is a port of the [BBC ggplot2 cookbook](https://bbc.github.io/rcookbook/) into Vega-Lite. This
makes use of the `gapminder` dataset which is included as a CSV in this
repository. The goal is to have useful examples of vega-lite specifications
recreating the main plots in the BBC cookbook. These /should/ be are easy to
reuse. If getting the last 20% of the visualisation to agree makes up 80% of the
code, then I will opt for only getting it 80% correct.
