### PR TITLE
fix: set `defaultLabelOverlap` to "greedy" for symlog scale type

### DIFF
--- a/src/compile/axis/properties.ts
+++ b/src/compile/axis/properties.ts
@@ -277,7 +277,7 @@ export function defaultLabelFlush(type: Type, channel: PositionScaleChannel) {
 export function defaultLabelOverlap(type: Type, scaleType: ScaleType, hasTimeUnit: boolean, sort?: Sort<string>) {
   // do not prevent overlap for nominal data because there is no way to infer what the missing labels are
   if ((hasTimeUnit && !isObject(sort)) || (type !== 'nominal' && type !== 'ordinal')) {
-    if (scaleType === 'log') {
+    if (scaleType === 'log' || scaleType === 'symlog') {
       return 'greedy';
     }
     return true;

--- a/src/compile/legend/properties.ts
+++ b/src/compile/legend/properties.ts
@@ -237,7 +237,7 @@ function gradientLengthSignal(model: Model, sizeType: 'width' | 'height', min: n
 }
 
 export function defaultLabelOverlap(scaleType: ScaleType): LabelOverlap {
-  if (contains(['quantile', 'threshold', 'log'], scaleType)) {
+  if (contains(['quantile', 'threshold', 'log', 'symlog'], scaleType)) {
     return 'greedy';
   }
   return undefined;

--- a/test/compile/axis/properties.test.ts
+++ b/test/compile/axis/properties.test.ts
@@ -428,8 +428,9 @@ describe('compile/axis/properties', () => {
       expect(properties.defaultLabelOverlap('nominal', 'band', false)).toBeUndefined();
     });
 
-    it('returns greedy for log scale', () => {
+    it('returns greedy for log and symlog scale', () => {
       expect(properties.defaultLabelOverlap('quantitative', 'log', false)).toBe('greedy');
+      expect(properties.defaultLabelOverlap('quantitative', 'symlog', false)).toBe('greedy');
     });
   });
 

--- a/test/compile/legend/properties.test.ts
+++ b/test/compile/legend/properties.test.ts
@@ -84,6 +84,11 @@ describe('compile/legend', () => {
       expect(overlap).toBe('greedy');
     });
 
+    it('should return greedy for symlog', () => {
+      const overlap = properties.defaultLabelOverlap('symlog');
+      expect(overlap).toBe('greedy');
+    });
+
     it('should return greedy for threshold', () => {
       const overlap = properties.defaultLabelOverlap('threshold');
       expect(overlap).toBe('greedy');


### PR DESCRIPTION
Closes #6934 

- Set `defaultLabelOverlap` in Axis and Legend to "greedy" for symlog scale type
- Add corresponding tests

Thanks for reviewing!