### PR TITLE
docs: fix documentation for mark text baseline

### DIFF
--- a/src/mark.ts
+++ b/src/mark.ts
@@ -234,7 +234,7 @@ export interface MarkConfig<ES extends ExprRef | SignalRef>
   align?: Align | ES;
 
   /**
-   * For text marks, the vertical text baseline. One of `"alphabetic"` (default), `"top"`, `"middle"`, `"bottom"`, `"line-top"`, `"line-bottom", or an expression reference that provides one of the valid values.
+   * For text marks, the vertical text baseline. One of `"alphabetic"` (default), `"top"`, `"middle"`, `"bottom"`, `"line-top"`, `"line-bottom"`, or an expression reference that provides one of the valid values.
    * The `"line-top"` and `"line-bottom"` values operate similarly to `"top"` and `"bottom"`,
    * but are calculated relative to the `lineHeight` rather than `fontSize` alone.
    *


### PR DESCRIPTION
The documentation was broken for the [mark text baseline property](https://vega.github.io/vega-lite/docs/text.html) the documentation formatting was broken. Took me a lot of time to figure this out, but I think this should fix it