### PR TITLE
fix: correct which specs are normalized

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -10653,109 +10653,6 @@
         }
       ]
     },
-    "NormalizedConcatSpec<GenericSpec>": {
-      "additionalProperties": false,
-      "description": "Base interface for a generalized concatenation specification.",
-      "properties": {
-        "align": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LayoutAlign"
-            },
-            {
-              "$ref": "#/definitions/RowCol<LayoutAlign>"
-            }
-          ],
-          "description": "The alignment to apply to grid rows and columns. The supported string values are `\"all\"`, `\"each\"`, and `\"none\"`.\n\n- For `\"none\"`, a flow layout will be used, in which adjacent subviews are simply placed one after the other. - For `\"each\"`, subviews will be aligned into a clean grid structure, but each row or column may be of variable size. - For `\"all\"`, subviews will be aligned and each row or column will be sized identically based on the maximum observed size. String values for this property will be applied to both grid rows and columns.\n\nAlternatively, an object value of the form `{\"row\": string, \"column\": string}` can be used to supply different alignments for rows and columns.\n\n__Default value:__ `\"all\"`."
-        },
-        "bounds": {
-          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used. - If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
-          "enum": [
-            "full",
-            "flush"
-          ],
-          "type": "string"
-        },
-        "center": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/definitions/RowCol<boolean>"
-            }
-          ],
-          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\nAn object value of the form `{\"row\": boolean, \"column\": boolean}` can be used to supply different centering values for rows and columns.\n\n__Default value:__ `false`"
-        },
-        "columns": {
-          "description": "The number of columns to include in the view composition layout.\n\n__Default value__: `undefined` -- An infinite number of columns (a single row) will be assumed. This is equivalent to `hconcat` (for `concat`) and to using the `column` channel (for `facet` and `repeat`).\n\n__Note__:\n\n1) This property is only for: - the general (wrappable) `concat` operator (not `hconcat`/`vconcat`) - the `facet` and `repeat` operator with one field/repetition definition (without row/column nesting)\n\n2) Setting the `columns` to `1` is equivalent to `vconcat` (for `concat`) and to using the `row` channel (for `facet` and `repeat`).",
-          "type": "number"
-        },
-        "concat": {
-          "description": "A list of views to be concatenated.",
-          "items": {
-            "$ref": "#/definitions/NormalizedSpec"
-          },
-          "type": "array"
-        },
-        "data": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Data"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "resolve": {
-          "$ref": "#/definitions/Resolve",
-          "description": "Scale, axis, and legend resolutions for view composition specifications."
-        },
-        "spacing": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/RowCol<number>"
-            }
-          ],
-          "description": "The spacing in pixels between sub-views of the composition operator. An object of the form `{\"row\": number, \"column\": number}` can be used to set different spacing values for rows and columns.\n\n__Default value__: Depends on `\"spacing\"` property of [the view composition configuration](https://vega.github.io/vega-lite/docs/config.html#view-config) (`20` by default)"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Text"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "concat"
-      ],
-      "type": "object"
-    },
     "ConcatSpec<GenericSpec>": {
       "additionalProperties": false,
       "description": "Base interface for a generalized concatenation specification.",
@@ -10859,7 +10756,110 @@
       ],
       "type": "object"
     },
-    "NormalizedFacetSpec": {
+    "NormalizedConcatSpec<GenericSpec>": {
+      "additionalProperties": false,
+      "description": "Base interface for a generalized concatenation specification.",
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LayoutAlign"
+            },
+            {
+              "$ref": "#/definitions/RowCol<LayoutAlign>"
+            }
+          ],
+          "description": "The alignment to apply to grid rows and columns. The supported string values are `\"all\"`, `\"each\"`, and `\"none\"`.\n\n- For `\"none\"`, a flow layout will be used, in which adjacent subviews are simply placed one after the other. - For `\"each\"`, subviews will be aligned into a clean grid structure, but each row or column may be of variable size. - For `\"all\"`, subviews will be aligned and each row or column will be sized identically based on the maximum observed size. String values for this property will be applied to both grid rows and columns.\n\nAlternatively, an object value of the form `{\"row\": string, \"column\": string}` can be used to supply different alignments for rows and columns.\n\n__Default value:__ `\"all\"`."
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used. - If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/RowCol<boolean>"
+            }
+          ],
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\nAn object value of the form `{\"row\": boolean, \"column\": boolean}` can be used to supply different centering values for rows and columns.\n\n__Default value:__ `false`"
+        },
+        "columns": {
+          "description": "The number of columns to include in the view composition layout.\n\n__Default value__: `undefined` -- An infinite number of columns (a single row) will be assumed. This is equivalent to `hconcat` (for `concat`) and to using the `column` channel (for `facet` and `repeat`).\n\n__Note__:\n\n1) This property is only for: - the general (wrappable) `concat` operator (not `hconcat`/`vconcat`) - the `facet` and `repeat` operator with one field/repetition definition (without row/column nesting)\n\n2) Setting the `columns` to `1` is equivalent to `vconcat` (for `concat`) and to using the `row` channel (for `facet` and `repeat`).",
+          "type": "number"
+        },
+        "concat": {
+          "description": "A list of views to be concatenated.",
+          "items": {
+            "$ref": "#/definitions/NormalizedSpec"
+          },
+          "type": "array"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Data"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for view composition specifications."
+        },
+        "spacing": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/RowCol<number>"
+            }
+          ],
+          "description": "The spacing in pixels between sub-views of the composition operator. An object of the form `{\"row\": number, \"column\": number}` can be used to set different spacing values for rows and columns.\n\n__Default value__: Depends on `\"spacing\"` property of [the view composition configuration](https://vega.github.io/vega-lite/docs/config.html#view-config) (`20` by default)"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Text"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "concat"
+      ],
+      "type": "object"
+    },
+    "FacetSpec": {
       "additionalProperties": false,
       "description": "Base interface for a facet specification.",
       "properties": {
@@ -10978,7 +10978,7 @@
       ],
       "type": "object"
     },
-    "FacetSpec": {
+    "NormalizedFacetSpec": {
       "additionalProperties": false,
       "description": "Base interface for a facet specification.",
       "properties": {
@@ -11097,80 +11097,6 @@
       ],
       "type": "object"
     },
-    "NormalizedHConcatSpec<GenericSpec>": {
-      "additionalProperties": false,
-      "description": "Base interface for a horizontal concatenation specification.",
-      "properties": {
-        "bounds": {
-          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used. - If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
-          "enum": [
-            "full",
-            "flush"
-          ],
-          "type": "string"
-        },
-        "center": {
-          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
-          "type": "boolean"
-        },
-        "data": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Data"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "hconcat": {
-          "description": "A list of views to be concatenated and put into a row.",
-          "items": {
-            "$ref": "#/definitions/NormalizedSpec"
-          },
-          "type": "array"
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "resolve": {
-          "$ref": "#/definitions/Resolve",
-          "description": "Scale, axis, and legend resolutions for view composition specifications."
-        },
-        "spacing": {
-          "description": "The spacing in pixels between sub-views of the concat operator.\n\n__Default value__: `10`",
-          "type": "number"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Text"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "hconcat"
-      ],
-      "type": "object"
-    },
     "HConcatSpec<GenericSpec>": {
       "additionalProperties": false,
       "description": "Base interface for a horizontal concatenation specification.",
@@ -11245,61 +11171,9 @@
       ],
       "type": "object"
     },
-    "NormalizedSpec": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/FacetedUnitSpec"
-        },
-        {
-          "$ref": "#/definitions/LayerSpec"
-        },
-        {
-          "$ref": "#/definitions/RepeatSpec"
-        },
-        {
-          "$ref": "#/definitions/NormalizedFacetSpec"
-        },
-        {
-          "$ref": "#/definitions/NormalizedConcatSpec<GenericSpec>"
-        },
-        {
-          "$ref": "#/definitions/NormalizedVConcatSpec<GenericSpec>"
-        },
-        {
-          "$ref": "#/definitions/NormalizedHConcatSpec<GenericSpec>"
-        }
-      ],
-      "description": "Any specification in Vega-Lite."
-    },
-    "Spec": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/FacetedUnitSpec"
-        },
-        {
-          "$ref": "#/definitions/LayerSpec"
-        },
-        {
-          "$ref": "#/definitions/RepeatSpec"
-        },
-        {
-          "$ref": "#/definitions/FacetSpec"
-        },
-        {
-          "$ref": "#/definitions/ConcatSpec<GenericSpec>"
-        },
-        {
-          "$ref": "#/definitions/VConcatSpec<GenericSpec>"
-        },
-        {
-          "$ref": "#/definitions/HConcatSpec<GenericSpec>"
-        }
-      ],
-      "description": "Any specification in Vega-Lite."
-    },
-    "NormalizedVConcatSpec<GenericSpec>": {
+    "NormalizedHConcatSpec<GenericSpec>": {
       "additionalProperties": false,
-      "description": "Base interface for a vertical concatenation specification.",
+      "description": "Base interface for a horizontal concatenation specification.",
       "properties": {
         "bounds": {
           "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used. - If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
@@ -11327,6 +11201,13 @@
         "description": {
           "description": "Description of this mark for commenting purpose.",
           "type": "string"
+        },
+        "hconcat": {
+          "description": "A list of views to be concatenated and put into a row.",
+          "items": {
+            "$ref": "#/definitions/NormalizedSpec"
+          },
+          "type": "array"
         },
         "name": {
           "description": "Name of the visualization for later reference.",
@@ -11357,19 +11238,64 @@
             "$ref": "#/definitions/Transform"
           },
           "type": "array"
-        },
-        "vconcat": {
-          "description": "A list of views to be concatenated and put into a column.",
-          "items": {
-            "$ref": "#/definitions/NormalizedSpec"
-          },
-          "type": "array"
         }
       },
       "required": [
-        "vconcat"
+        "hconcat"
       ],
       "type": "object"
+    },
+    "Spec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FacetedUnitSpec"
+        },
+        {
+          "$ref": "#/definitions/LayerSpec"
+        },
+        {
+          "$ref": "#/definitions/RepeatSpec"
+        },
+        {
+          "$ref": "#/definitions/FacetSpec"
+        },
+        {
+          "$ref": "#/definitions/ConcatSpec<GenericSpec>"
+        },
+        {
+          "$ref": "#/definitions/VConcatSpec<GenericSpec>"
+        },
+        {
+          "$ref": "#/definitions/HConcatSpec<GenericSpec>"
+        }
+      ],
+      "description": "Any specification in Vega-Lite."
+    },
+    "NormalizedSpec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FacetedUnitSpec"
+        },
+        {
+          "$ref": "#/definitions/LayerSpec"
+        },
+        {
+          "$ref": "#/definitions/RepeatSpec"
+        },
+        {
+          "$ref": "#/definitions/NormalizedFacetSpec"
+        },
+        {
+          "$ref": "#/definitions/NormalizedConcatSpec<GenericSpec>"
+        },
+        {
+          "$ref": "#/definitions/NormalizedVConcatSpec<GenericSpec>"
+        },
+        {
+          "$ref": "#/definitions/NormalizedHConcatSpec<GenericSpec>"
+        }
+      ],
+      "description": "Any specification in Vega-Lite."
     },
     "VConcatSpec<GenericSpec>": {
       "additionalProperties": false,
@@ -11436,6 +11362,80 @@
           "description": "A list of views to be concatenated and put into a column.",
           "items": {
             "$ref": "#/definitions/Spec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "vconcat"
+      ],
+      "type": "object"
+    },
+    "NormalizedVConcatSpec<GenericSpec>": {
+      "additionalProperties": false,
+      "description": "Base interface for a vertical concatenation specification.",
+      "properties": {
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used. - If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Data"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for view composition specifications."
+        },
+        "spacing": {
+          "description": "The spacing in pixels between sub-views of the concat operator.\n\n__Default value__: `10`",
+          "type": "number"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Text"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "vconcat": {
+          "description": "A list of views to be concatenated and put into a column.",
+          "items": {
+            "$ref": "#/definitions/NormalizedSpec"
           },
           "type": "array"
         }
@@ -19192,7 +19192,7 @@
           "description": "The spacing in pixels between sub-views of the composition operator. An object of the form `{\"row\": number, \"column\": number}` can be used to set different spacing values for rows and columns.\n\n__Default value__: Depends on `\"spacing\"` property of [the view composition configuration](https://vega.github.io/vega-lite/docs/config.html#view-config) (`20` by default)"
         },
         "spec": {
-          "$ref": "#/definitions/Spec",
+          "$ref": "#/definitions/NormalizedSpec",
           "description": "A specification of the view that gets repeated."
         },
         "title": {
@@ -29371,7 +29371,7 @@
       ],
       "type": "object"
     },
-    "TopLevelNormalizedConcatSpec<GenericSpec>": {
+    "TopLevelConcatSpec<GenericSpec>": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -29438,7 +29438,7 @@
         "concat": {
           "description": "A list of views to be concatenated.",
           "items": {
-            "$ref": "#/definitions/NormalizedSpec"
+            "$ref": "#/definitions/Spec"
           },
           "type": "array"
         },
@@ -29530,7 +29530,7 @@
       ],
       "type": "object"
     },
-    "TopLevelNormalizedHConcatSpec<GenericSpec>": {
+    "TopLevelHConcatSpec<GenericSpec>": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -29598,7 +29598,7 @@
         "hconcat": {
           "description": "A list of views to be concatenated and put into a row.",
           "items": {
-            "$ref": "#/definitions/NormalizedSpec"
+            "$ref": "#/definitions/Spec"
           },
           "type": "array"
         },
@@ -29660,7 +29660,7 @@
       ],
       "type": "object"
     },
-    "TopLevelNormalizedVConcatSpec<GenericSpec>": {
+    "TopLevelVConcatSpec<GenericSpec>": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -29780,7 +29780,7 @@
         "vconcat": {
           "description": "A list of views to be concatenated and put into a column.",
           "items": {
-            "$ref": "#/definitions/NormalizedSpec"
+            "$ref": "#/definitions/Spec"
           },
           "type": "array"
         }
@@ -30094,7 +30094,7 @@
               "description": "The spacing in pixels between sub-views of the composition operator. An object of the form `{\"row\": number, \"column\": number}` can be used to set different spacing values for rows and columns.\n\n__Default value__: Depends on `\"spacing\"` property of [the view composition configuration](https://vega.github.io/vega-lite/docs/config.html#view-config) (`20` by default)"
             },
             "spec": {
-              "$ref": "#/definitions/Spec",
+              "$ref": "#/definitions/NormalizedSpec",
               "description": "A specification of the view that gets repeated."
             },
             "title": {
@@ -30487,13 +30487,13 @@
           "$ref": "#/definitions/TopLevelRepeatSpec"
         },
         {
-          "$ref": "#/definitions/TopLevelNormalizedConcatSpec<GenericSpec>"
+          "$ref": "#/definitions/TopLevelConcatSpec<GenericSpec>"
         },
         {
-          "$ref": "#/definitions/TopLevelNormalizedVConcatSpec<GenericSpec>"
+          "$ref": "#/definitions/TopLevelVConcatSpec<GenericSpec>"
         },
         {
-          "$ref": "#/definitions/TopLevelNormalizedHConcatSpec<GenericSpec>"
+          "$ref": "#/definitions/TopLevelHConcatSpec<GenericSpec>"
         }
       ],
       "description": "A Vega-Lite top-level specification. This is the root class for all Vega-Lite specifications. (The json schema is generated from this type.)"

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -9,8 +9,8 @@ perl -pi -e s,'<ExprRef>','',g build/vega-lite-schema.json
 perl -pi -e s,'\,ExprRef>','>',g build/vega-lite-schema.json
 
 perl -pi -e s,'CompositeEncoding','Encoding',g build/vega-lite-schema.json
-perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec\,?.*\,FieldName>','\1',g build/vega-lite-schema.json
-perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec\,?.*\,Field>','Normalized\1',g build/vega-lite-schema.json
+perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec\,?.*\,FieldName>','Normalized\1',g build/vega-lite-schema.json
+perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec\,?.*\,Field>','\1',g build/vega-lite-schema.json
 
 perl -pi -e s,'ValueDef(.*)<Value>','ValueDef\1',g build/vega-lite-schema.json
 perl -pi -e s,'Conditional<(.*)>','Conditional\1',g build/vega-lite-schema.json


### PR DESCRIPTION
Repeat specs are normalized by filling in the field name.

Part of https://github.com/vega/vega-lite/issues/6823