### PR TITLE
docs: add Jekyll Diagrams & Liquid Diagrams to ecosystem

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -48,8 +48,8 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [hvega](https://hackage.haskell.org/package/hvega) generates Vega-Lite specifications in Haskell and is based on Elm-Vega.
 - [Vega-Lite "bindings" for Rust](https://github.com/procyon-rs/vega_lite_3.rs), create vega-lite v3, or [v4](https://github.com/procyon-rs/vega_lite_4.rs), vizualizations in Rust A high-level like Altair in under construction at [procyon](https://github.com/procyon-rs/procyon)
 - [Vega.rb](https://github.com/ankane/vega) brings Vega and Vega-Lite to Ruby.
-- [Jekyll Diagrams](https://github.com/zhustec/jekyll-diagrams) A Jekyll plugin with support for Vega & Vega-Lite and others diagrams libraries.
-- [Liquid Diagrams](https://github.com/zhustec/liquid-diagrams) A Liquid plugin with support for Vega & Vega-Lite and others diagrams libraries.
+- [Jekyll Diagrams](https://github.com/zhustec/jekyll-diagrams) A Jekyll plugin with support for Vega & Vega-Lite and others diagramming libraries.
+- [Liquid Diagrams](https://github.com/zhustec/liquid-diagrams) A Liquid plugin with support for Vega & Vega-Lite and others diagramming libraries.
 
 ## Programming / Data Science Environment that supports Vega-Lite
 

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -48,6 +48,8 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [hvega](https://hackage.haskell.org/package/hvega) generates Vega-Lite specifications in Haskell and is based on Elm-Vega.
 - [Vega-Lite "bindings" for Rust](https://github.com/procyon-rs/vega_lite_3.rs), create vega-lite v3, or [v4](https://github.com/procyon-rs/vega_lite_4.rs), vizualizations in Rust A high-level like Altair in under construction at [procyon](https://github.com/procyon-rs/procyon)
 - [Vega.rb](https://github.com/ankane/vega) brings Vega and Vega-Lite to Ruby.
+- [Jekyll Diagrams](https://github.com/zhustec/jekyll-diagrams) A Jekyll plugin with support for Vega & Vega-Lite and others diagrams libraries.
+- [Liquid Diagrams](https://github.com/zhustec/liquid-diagrams) A Liquid plugin with support for Vega & Vega-Lite and others diagrams libraries.
 
 ## Programming / Data Science Environment that supports Vega-Lite
 


### PR DESCRIPTION
add Jekyll Diagrams & Liquid Diagrams to the ecosystem page.