### PR TITLE
Fix TIMEUNIT_PARTS typed as any

### DIFF
--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -20,7 +20,7 @@ export const LOCAL_SINGLE_TIMEUNIT_INDEX = {
 
 export type LocalSingleTimeUnit = keyof typeof LOCAL_SINGLE_TIMEUNIT_INDEX;
 
-export const TIMEUNIT_PARTS = keys(LOCAL_SINGLE_TIMEUNIT_INDEX);
+export const TIMEUNIT_PARTS: LocalSingleTimeUnit[] = keys(LOCAL_SINGLE_TIMEUNIT_INDEX);
 
 export function isLocalSingleTimeUnit(timeUnit: string): timeUnit is LocalSingleTimeUnit {
   return !!LOCAL_SINGLE_TIMEUNIT_INDEX[timeUnit];


### PR DESCRIPTION
When imported into a project, TIMEUNIT_PARTS has type any. I added a type declaration to the export.

Please:

- [x] Make the pull requests (PRs) atomic (fix one issue at a time). Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.
- [x] Provide a concise title as a [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties") so we can easily copy it to the release note.
  - Use imperative mood and present tense.
- Mention relevant issues in the description (e.g., `Fixes #1` / `Fixes part of #1`).
- [x] Lint and test (Run `yarn test`).
- [x] Rebase onto the latest `master` branch.
- [x] Review your changes before sending the PR (to ensure code quality).
- For new features:
  - [ ] Add new unit tests.
  - [ ] Update the documentation under `site/docs/` + add examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
