### PR TITLE
docs: explain why there will be fewer bins than specified in `maxbins`

### DIFF
--- a/site/docs/transform/bin.md
+++ b/site/docs/transform/bin.md
@@ -110,7 +110,7 @@ If `bin` is `true`, default binning parameters are used. To customize binning pa
 
 ### Example: Customizing Max Bins
 
-Setting the `maxbins` parameter changes the number of output bins.
+Setting the `maxbins` parameter changes the maximum number of output bins. There will often be fewer bins since the domain get sliced at "nicely-rounded" values.
 
 <div class="vl-example" data-name="histogram_bin_change"></div>
 


### PR DESCRIPTION
I find this a bit unclear currently, and also often get asked what determines the actual number of bins. This PR is my understanding of https://observablehq.com/@d3/d3-bin, particularly this section:

> Unexpected? The result is not guaranteed to yield the exact number of buckets we asked for. That number is only an indication, passed to the threshold generator. As you change that value with the slider, you might notice the reason why this happens: the domain gets sliced at “nicely-rounded” values — using d3.ticks — and these rounded values do not fall exactly on the bin’s domain.

Also PRed in vega https://github.com/vega/vega/pull/2944

---

Please:

- [x] Make the pull requests (PRs) atomic (fix one issue at a time). Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.
- [x] Provide a concise title as a [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties") so we can easily copy it to the release note.
  - Use imperative mood and present tense.
- Mention relevant issues in the description (e.g., `Fixes #1` / `Fixes part of #1`).
- [ ] Lint and test (Run `yarn test`).
- [x] Rebase onto the latest `master` branch.
- [x] Review your changes before sending the PR (to ensure code quality).
- For new features:
  - [ ] Add new unit tests.
  - [x] Update the documentation under `site/docs/` + add examples.
