### PR TITLE
refactor: export directly instead of importing first, don't export from package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import {version} from '../package.json';
-import {normalize} from './normalize';
+import pkg from '../package.json';
+export const version = pkg.version;
 
 export {compile} from './compile/compile';
 export type {Config} from './config';
+export {normalize} from './normalize';
 export type {TopLevelSpec} from './spec';
 export * from './util';
-export {normalize, version};


### PR DESCRIPTION
To support webpack 5. See https://webpack.js.org/migrate/5/#cleanup-the-code. 