### PR TITLE
fix: remove labelExpr from formatters

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2326,7 +2326,7 @@
           ]
         },
         "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
+          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
           "type": "string"
         },
         "labelFlush": {
@@ -6501,10 +6501,6 @@
           "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
           "type": "string"
         },
-        "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
-          "type": "string"
-        },
         "test": {
           "$ref": "#/definitions/PredicateComposition",
           "description": "Predicate for triggering the condition"
@@ -7087,10 +7083,6 @@
         },
         "formatType": {
           "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
-          "type": "string"
-        },
-        "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
           "type": "string"
         },
         "selection": {
@@ -10244,10 +10236,6 @@
           "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
           "type": "string"
         },
-        "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
-          "type": "string"
-        },
         "type": {
           "$ref": "#/definitions/Type",
           "description": "The type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`) for the encoded field or constant value (`datum`). It can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).\n\nVega-Lite automatically infers data types in many cases as discussed below. However, type is required for a field if: (1) the field is not nominal and the field encoding has no specified `aggregate` (except `argmin` and `argmax`), `bin`, scale type, custom `sort` order, nor `timeUnit` or (2) if you wish to use an ordinal scale for a field with `bin` or `timeUnit`.\n\n__Default value:__\n\n1) For a data `field`, `\"nominal\"` is the default data type unless the field encoding has `aggregate`, `channel`, `bin`, scale type, `sort`, or `timeUnit` that satisfies the following criteria: - `\"quantitative\"` is the default type if (1) the encoded field contains `bin` or `aggregate` except `\"argmin\"` and `\"argmax\"`, (2) the encoding channel is `latitude` or `longitude` channel or (3) if the specified scale type is [a quantitative scale](https://vega.github.io/vega-lite/docs/scale.html#type). - `\"temporal\"` is the default type if (1) the encoded field contains `timeUnit` or (2) the specified scale type is a time or utc scale - `ordinal\"\"` is the default type if (1) the encoded field contains a [custom `sort` order](https://vega.github.io/vega-lite/docs/sort.html#specifying-custom-sort-order), (2) the specified scale type is an ordinal/point/band scale, or (3) the encoding channel is `order`.\n\n2) For a constant value in data domain (`datum`): - `\"quantitative\"` if the datum is a number - `\"nominal\"` if the datum is a string - `\"temporal\"` if the datum is [a date time object](https://vega.github.io/vega-lite/docs/datetime.html)\n\n__Note:__ - Data `type` describes the semantics of the data rather than the primitive data types (number, string, etc.). The same primitive data type can have different types of measurement. For example, numeric data can represent quantitative, ordinal, or nominal data. - Data values for a temporal field can be either a date-time string (e.g., `\"2015-03-07 12:32:17\"`, `\"17:01\"`, `\"2015-03-16\"`. `\"2015\"`) or a timestamp number (e.g., `1552199579097`). - When using with [`bin`](https://vega.github.io/vega-lite/docs/bin.html), the `type` property can be either `\"quantitative\"` (for using a linear bin scale) or [`\"ordinal\"` (for using an ordinal bin scale)](https://vega.github.io/vega-lite/docs/type.html#cast-bin). - When using with [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html), the `type` property can be either `\"temporal\"` (default, for using a temporal scale) or [`\"ordinal\"` (for using an ordinal scale)](https://vega.github.io/vega-lite/docs/type.html#cast-bin). - When using with [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html), the `type` property refers to the post-aggregation data type. For example, we can calculate count `distinct` of a categorical field `\"cat\"` using `{\"aggregate\": \"distinct\", \"field\": \"cat\"}`. The `\"type\"` of the aggregate output is `\"quantitative\"`. - Secondary channels (e.g., `x2`, `y2`, `xError`, `yError`) do not have `type` as they must have exactly the same type as their primary channels (e.g., `x`, `y`).\n\n__See also:__ [`type`](https://vega.github.io/vega-lite/docs/type.html) documentation."
@@ -10318,10 +10306,6 @@
         },
         "formatType": {
           "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
-          "type": "string"
-        },
-        "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
           "type": "string"
         },
         "timeUnit": {
@@ -10416,10 +10400,6 @@
         },
         "formatType": {
           "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
-          "type": "string"
-        },
-        "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
           "type": "string"
         },
         "timeUnit": {
@@ -23839,10 +23819,6 @@
               "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
               "type": "string"
             },
-            "labelExpr": {
-              "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
-              "type": "string"
-            },
             "timeUnit": {
               "anyOf": [
                 {
@@ -24308,10 +24284,6 @@
             },
             "formatType": {
               "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
-              "type": "string"
-            },
-            "labelExpr": {
-              "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
               "type": "string"
             },
             "timeUnit": {
@@ -26216,10 +26188,6 @@
               "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
               "type": "string"
             },
-            "labelExpr": {
-              "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
-              "type": "string"
-            },
             "timeUnit": {
               "anyOf": [
                 {
@@ -26597,10 +26565,6 @@
             },
             "formatType": {
               "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
-              "type": "string"
-            },
-            "labelExpr": {
-              "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
               "type": "string"
             },
             "timeUnit": {
@@ -27869,10 +27833,6 @@
         },
         "formatType": {
           "description": "The format type for labels. One of `\"number\"`, `\"time\"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).\n\n__Default value:__ - `\"time\"` for temporal fields and ordinal and nominal fields with `timeUnit`. - `\"number\"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.",
-          "type": "string"
-        },
-        "labelExpr": {
-          "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
           "type": "string"
         },
         "timeUnit": {

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -51,7 +51,7 @@ import {Config} from './config';
 import {DateTime, dateTimeToExpr, isDateTime} from './datetime';
 import {Encoding} from './encoding';
 import {ExprRef, isExprRef} from './expr';
-import {FormatMixins, Guide, GuideEncodingConditionalValueDef, TitleMixins} from './guide';
+import {Guide, GuideEncodingConditionalValueDef, TitleMixins} from './guide';
 import {ImputeParams} from './impute';
 import {Legend} from './legend';
 import * as log from './log';
@@ -73,6 +73,7 @@ import {
 import {AggregatedFieldDef, WindowFieldDef} from './transform';
 import {getFullName, QUANTITATIVE, StandardType, Type} from './type';
 import {
+  Dict,
   flatAccessWithDatum,
   getFirstDefined,
   internalField,
@@ -386,6 +387,31 @@ export interface DatumDef<
   // only apply Repeatref if field (F) can be RepeatRef
   // FIXME(https://github.com/microsoft/TypeScript/issues/37586):
   // `F extends RepeatRef` probably should be `RepeatRef extends F` but there is likely a bug in TS.
+}
+
+export interface FormatMixins {
+  /**
+   * When used with the default `"number"` and `"time"` format type, the text formatting pattern for labels of guides (axes, legends, headers) and text marks.
+   *
+   * - If the format type is `"number"` (e.g., for quantitative fields), this is D3's [number format pattern](https://github.com/d3/d3-format#locale_format).
+   * - If the format type is `"time"` (e.g., for temporal fields), this is D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format).
+   *
+   * See the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more examples.
+   *
+   * When used with a [custom `formatType`](https://vega.github.io/vega-lite/docs/config.html#custom-format-type), this value will be passed as `format` alongside `datum.value` to the registered function.
+   *
+   * __Default value:__  Derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for number format and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for time format.
+   */
+  format?: string | Dict<unknown>;
+
+  /**
+   * The format type for labels. One of `"number"`, `"time"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).
+   *
+   * __Default value:__
+   * - `"time"` for temporal fields and ordinal and nominal fields with `timeUnit`.
+   * - `"number"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.
+   */
+  formatType?: 'number' | 'time' | string;
 }
 
 export type StringDatumDef<F extends Field = string> = DatumDef<F> & FormatMixins;

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -1,7 +1,6 @@
 import {SignalRef, Text} from 'vega';
-import {ConditionValueDefMixins, ValueDef} from './channeldef';
+import {ConditionValueDefMixins, FormatMixins, ValueDef} from './channeldef';
 import {LegendConfig} from './legend';
-import {Dict} from './util';
 import {VgEncodeChannel} from './vega.schema';
 
 export interface TitleMixins {
@@ -17,31 +16,6 @@ export interface TitleMixins {
    * 2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.
    */
   title?: Text | null | SignalRef;
-}
-
-export interface FormatMixins {
-  /**
-   * When used with the default `"number"` and `"time"` format type, the text formatting pattern for labels of guides (axes, legends, headers) and text marks.
-   *
-   * - If the format type is `"number"` (e.g., for quantitative fields), this is D3's [number format pattern](https://github.com/d3/d3-format#locale_format).
-   * - If the format type is `"time"` (e.g., for temporal fields), this is D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format).
-   *
-   * See the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more examples.
-   *
-   * When used with a [custom `formatType`](https://vega.github.io/vega-lite/docs/config.html#custom-format-type), this value will be passed as `format` alongside `datum.value` to the registered function.
-   *
-   * __Default value:__  Derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for number format and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for time format.
-   */
-  format?: string | Dict<unknown>;
-
-  /**
-   * The format type for labels. One of `"number"`, `"time"`, or a [registered custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type).
-   *
-   * __Default value:__
-   * - `"time"` for temporal fields and ordinal and nominal fields with `timeUnit`.
-   * - `"number"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.
-   */
-  formatType?: 'number' | 'time' | string;
 }
 
 export interface Guide extends TitleMixins, FormatMixins {}

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -42,13 +42,6 @@ export interface FormatMixins {
    * - `"number"` for quantitative fields as well as ordinal and nominal fields without `timeUnit`.
    */
   formatType?: 'number' | 'time' | string;
-
-  /**
-   * [Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels text.
-   *
-   * __Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.
-   */
-  labelExpr?: string;
 }
 
 export interface Guide extends TitleMixins, FormatMixins {}

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,6 +1,7 @@
 import {Align, Color, FontStyle, FontWeight, Orient, SignalRef, TextBaseline, TitleAnchor, TitleConfig} from 'vega';
+import {FormatMixins} from './channeldef';
 import {ExprRef} from './expr';
-import {FormatMixins, Guide, VlOnlyGuideConfig} from './guide';
+import {Guide, VlOnlyGuideConfig} from './guide';
 import {Flag, keys} from './util';
 
 export const HEADER_TITLE_PROPERTIES_MAP: Partial<Record<keyof CoreHeader<any>, keyof TitleConfig>> = {


### PR DESCRIPTION
it wasn't supposed to be there in the first place
