### PR TITLE
docs: add example with custom tick label strings

### DIFF
--- a/examples/specs/circle_custom_tick_labels.vl.json
+++ b/examples/specs/circle_custom_tick_labels.vl.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "data": {
+    "url": "data/movies.json"
+  },
+  "mark": {"size": 80, "type": "circle"},
+  "encoding": {
+    "x": {
+      "aggregate": "mean",
+      "axis": {
+        "labelExpr": "datum.label == 0 ? 'Poor' : datum.label == 5 ? 'Neutral' : 'Great'",
+        "labelFlush": false,
+        "values": [0, 5, 10]
+      },
+      "field": "IMDB Rating",
+      "scale": {"domain": [0, 10]},
+      "title": null
+    },
+    "y": {"field": "Major Genre", "sort": "x", "title": null}
+  }
+}

--- a/site/_data/examples.json
+++ b/site/_data/examples.json
@@ -199,6 +199,11 @@
       {
         "name": "scatter_image",
         "title": "Image-based Scatter Plot"
+      },
+      {
+        "name": "circle_custom_tick_labels",
+        "description": "After using the numerical values to calculate the average rating, they are replaced by string labels.",
+        "title": "Strip plot with custom axis tick labels"
       }
     ],
     "Line Charts": [


### PR DESCRIPTION
This adds an example of how to replace numerical tick labels with custom strings using a nested ternary expression inside `labelExpr`. Let me know if I missed something for adding an example, I wasn't sure about adding the `<span>` tagged line to the site docs as mentioned in the contributor guidelines since other examples did not seems to do this.

close #7045 

- [x] Make the pull requests (PRs) atomic (fix one issue at a time). Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.
- [x] Provide a concise title as a [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties") so we can easily copy it to the release note.
  - Use imperative mood and present tense.
- Mention relevant issues in the description (e.g., `Fixes #1` / `Fixes part of #1`).
- [ ] Lint and test (Run `yarn test`).
- [x] Rebase onto the latest `master` branch.
- [x] Review your changes before sending the PR (to ensure code quality).
- For new features:
  - [ ] Add new unit tests.
  - [x] Update the documentation under `site/docs/` + add examples.