### PR TITLE
refactor: rename `Parameter/SelectionDef` -> `Variable/SelectionParameter`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -7542,10 +7542,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/TopLevelSelectionDef"
+                "$ref": "#/definitions/TopLevelSelectionParameter"
               }
             ]
           },
@@ -9122,10 +9122,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/SelectionDef"
+                "$ref": "#/definitions/SelectionParameter"
               }
             ]
           },
@@ -19485,34 +19485,6 @@
       ],
       "minimum": 0
     },
-    "Parameter": {
-      "additionalProperties": false,
-      "properties": {
-        "bind": {
-          "$ref": "#/definitions/Binding",
-          "description": "Binds the parameter to an external input element such as a slider, selection list or radio button group."
-        },
-        "description": {
-          "description": "A text description of the parameter, useful for inline documentation.",
-          "type": "string"
-        },
-        "expr": {
-          "$ref": "#/definitions/Expr",
-          "description": "An expression for the value of the parameter. This expression may include other parameters, in which case the parameter will automatically update in response to upstream parameter changes."
-        },
-        "name": {
-          "description": "Required. A unique name for the parameter. Parameter names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or \"$\", or \"_\") and may not start with a digit. Reserved keywords that may not be used as parameter names are \"datum\", \"event\", \"item\", and \"parent\".",
-          "type": "string"
-        },
-        "value": {
-          "description": "The initial value of the parameter.\n\n__Default value:__ `undefined`"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "type": "object"
-    },
     "Parse": {
       "additionalProperties": {
         "$ref": "#/definitions/ParseValue"
@@ -22327,7 +22299,77 @@
       },
       "type": "object"
     },
-    "SelectionDef": {
+    "SelectionExtent": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "field": {
+              "$ref": "#/definitions/FieldName",
+              "description": "The field name to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html) over multiple fields or encodings."
+            },
+            "selection": {
+              "description": "The name of a selection.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "selection"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encoding": {
+              "$ref": "#/definitions/SingleDefUnitChannel",
+              "description": "The encoding channel to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html) over multiple fields or encodings."
+            },
+            "selection": {
+              "description": "The name of a selection.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "selection"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SelectionInit": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PrimitiveValue"
+        },
+        {
+          "$ref": "#/definitions/DateTime"
+        }
+      ]
+    },
+    "SelectionInitInterval": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Vector2<boolean>"
+        },
+        {
+          "$ref": "#/definitions/Vector2<number>"
+        },
+        {
+          "$ref": "#/definitions/Vector2<string>"
+        },
+        {
+          "$ref": "#/definitions/Vector2<DateTime>"
+        }
+      ]
+    },
+    "SelectionInitIntervalMapping": {
+      "$ref": "#/definitions/Dict<SelectionInitInterval>"
+    },
+    "SelectionInitMapping": {
+      "$ref": "#/definitions/Dict<SelectionInit>"
+    },
+    "SelectionParameter": {
       "additionalProperties": false,
       "properties": {
         "bind": {
@@ -22351,8 +22393,12 @@
           ],
           "description": "When set, a selection is populated by input elements (also known as dynamic query widgets) or by interacting with the corresponding legend. Direct manipulation interaction is disabled by default; to re-enable it, set the selection's [`on`](https://vega.github.io/vega-lite/docs/selection.html#common-selection-properties) property.\n\nLegend bindings are restricted to selections that only specify a single field or encoding.\n\nQuery widget binding takes the form of Vega's [input element binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a mapping between projected field/encodings and binding definitions.\n\n__See also:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation."
         },
+        "description": {
+          "description": "A text description of the parameter, useful for inline documentation.",
+          "type": "string"
+        },
         "name": {
-          "description": "Required. A unique name for the selection. Selection names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or \"$\", or \"_\") and may not start with a digit. Reserved keywords that may not be used as parameter names are \"datum\", \"event\", \"item\", and \"parent\".",
+          "description": "Required. A unique name for the parameter. Parameter names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or \"$\", or \"_\") and may not start with a digit. Reserved keywords that may not be used as parameter names are \"datum\", \"event\", \"item\", and \"parent\".",
           "type": "string"
         },
         "select": {
@@ -22538,76 +22584,6 @@
         "select"
       ],
       "type": "object"
-    },
-    "SelectionExtent": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "field": {
-              "$ref": "#/definitions/FieldName",
-              "description": "The field name to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html) over multiple fields or encodings."
-            },
-            "selection": {
-              "description": "The name of a selection.",
-              "type": "string"
-            }
-          },
-          "required": [
-            "selection"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "encoding": {
-              "$ref": "#/definitions/SingleDefUnitChannel",
-              "description": "The encoding channel to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html) over multiple fields or encodings."
-            },
-            "selection": {
-              "description": "The name of a selection.",
-              "type": "string"
-            }
-          },
-          "required": [
-            "selection"
-          ],
-          "type": "object"
-        }
-      ]
-    },
-    "SelectionInit": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PrimitiveValue"
-        },
-        {
-          "$ref": "#/definitions/DateTime"
-        }
-      ]
-    },
-    "SelectionInitInterval": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Vector2<boolean>"
-        },
-        {
-          "$ref": "#/definitions/Vector2<number>"
-        },
-        {
-          "$ref": "#/definitions/Vector2<string>"
-        },
-        {
-          "$ref": "#/definitions/Vector2<DateTime>"
-        }
-      ]
-    },
-    "SelectionInitIntervalMapping": {
-      "$ref": "#/definitions/Dict<SelectionInitInterval>"
-    },
-    "SelectionInitMapping": {
-      "$ref": "#/definitions/Dict<SelectionInit>"
     },
     "SelectionPredicate": {
       "additionalProperties": false,
@@ -28748,10 +28724,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/TopLevelSelectionDef"
+                "$ref": "#/definitions/TopLevelSelectionParameter"
               }
             ]
           },
@@ -28892,10 +28868,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/TopLevelSelectionDef"
+                "$ref": "#/definitions/TopLevelSelectionParameter"
               }
             ]
           },
@@ -29022,10 +28998,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/TopLevelSelectionDef"
+                "$ref": "#/definitions/TopLevelSelectionParameter"
               }
             ]
           },
@@ -29180,10 +29156,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/TopLevelSelectionDef"
+                "$ref": "#/definitions/TopLevelSelectionParameter"
               }
             ]
           },
@@ -29353,10 +29329,10 @@
               "items": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Parameter"
+                    "$ref": "#/definitions/VariableParameter"
                   },
                   {
-                    "$ref": "#/definitions/TopLevelSelectionDef"
+                    "$ref": "#/definitions/TopLevelSelectionParameter"
                   }
                 ]
               },
@@ -29531,10 +29507,10 @@
               "items": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Parameter"
+                    "$ref": "#/definitions/VariableParameter"
                   },
                   {
-                    "$ref": "#/definitions/TopLevelSelectionDef"
+                    "$ref": "#/definitions/TopLevelSelectionParameter"
                   }
                 ]
               },
@@ -29719,10 +29695,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/TopLevelSelectionDef"
+                "$ref": "#/definitions/TopLevelSelectionParameter"
               }
             ]
           },
@@ -29784,7 +29760,7 @@
       ],
       "type": "object"
     },
-    "TopLevelSelectionDef": {
+    "TopLevelSelectionParameter": {
       "additionalProperties": false,
       "properties": {
         "bind": {
@@ -29808,8 +29784,12 @@
           ],
           "description": "When set, a selection is populated by input elements (also known as dynamic query widgets) or by interacting with the corresponding legend. Direct manipulation interaction is disabled by default; to re-enable it, set the selection's [`on`](https://vega.github.io/vega-lite/docs/selection.html#common-selection-properties) property.\n\nLegend bindings are restricted to selections that only specify a single field or encoding.\n\nQuery widget binding takes the form of Vega's [input element binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a mapping between projected field/encodings and binding definitions.\n\n__See also:__ [`bind`](https://vega.github.io/vega-lite/docs/bind.html) documentation."
         },
+        "description": {
+          "description": "A text description of the parameter, useful for inline documentation.",
+          "type": "string"
+        },
         "name": {
-          "description": "Required. A unique name for the selection. Selection names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or \"$\", or \"_\") and may not start with a digit. Reserved keywords that may not be used as parameter names are \"datum\", \"event\", \"item\", and \"parent\".",
+          "description": "Required. A unique name for the parameter. Parameter names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or \"$\", or \"_\") and may not start with a digit. Reserved keywords that may not be used as parameter names are \"datum\", \"event\", \"item\", and \"parent\".",
           "type": "string"
         },
         "select": {
@@ -30165,10 +30145,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/SelectionDef"
+                "$ref": "#/definitions/SelectionParameter"
               }
             ]
           },
@@ -30468,10 +30448,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/SelectionDef"
+                "$ref": "#/definitions/SelectionParameter"
               }
             ]
           },
@@ -30574,10 +30554,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Parameter"
+                "$ref": "#/definitions/VariableParameter"
               },
               {
-                "$ref": "#/definitions/SelectionDef"
+                "$ref": "#/definitions/SelectionParameter"
               }
             ]
           },
@@ -30967,6 +30947,34 @@
           "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
         }
       },
+      "type": "object"
+    },
+    "VariableParameter": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "$ref": "#/definitions/Binding",
+          "description": "Binds the parameter to an external input element such as a slider, selection list or radio button group."
+        },
+        "description": {
+          "description": "A text description of the parameter, useful for inline documentation.",
+          "type": "string"
+        },
+        "expr": {
+          "$ref": "#/definitions/Expr",
+          "description": "An expression for the value of the parameter. This expression may include other parameters, in which case the parameter will automatically update in response to upstream parameter changes."
+        },
+        "name": {
+          "description": "Required. A unique name for the parameter. Parameter names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or \"$\", or \"_\") and may not start with a digit. Reserved keywords that may not be used as parameter names are \"datum\", \"event\", \"item\", and \"parent\".",
+          "type": "string"
+        },
+        "value": {
+          "description": "The initial value of the parameter.\n\n__Default value:__ `undefined`"
+        }
+      },
+      "required": [
+        "name"
+      ],
       "type": "object"
     },
     "Vector2<DateTime>": {

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -6,6 +6,7 @@ import {
   LegendBinding,
   SelectionInit,
   SelectionInitInterval,
+  SelectionParameter,
   SelectionResolution,
   SelectionType,
   SELECTION_ID
@@ -15,16 +16,14 @@ import {OutputNode} from '../data/dataflow';
 import {FacetModel} from '../facet';
 import {isFacetModel, Model} from '../model';
 import {UnitModel} from '../unit';
-import interval from './interval';
-import point from './point';
-import {SelectionProjection, SelectionProjectionComponent} from './project';
-import {SelectionDef} from '../../selection';
 import clear from './clear';
 import inputs from './inputs';
-import nearest from './nearest';
-import project from './project';
-import scales from './scales';
+import interval from './interval';
 import legends from './legends';
+import nearest from './nearest';
+import point from './point';
+import project, {SelectionProjection, SelectionProjectionComponent} from './project';
+import scales from './scales';
 import toggle from './toggle';
 import translate from './translate';
 import zoom from './zoom';
@@ -59,7 +58,7 @@ export interface SelectionComponent<T extends SelectionType = SelectionType> {
 
 export interface SelectionCompiler<T extends SelectionType = SelectionType> {
   defined: (selCmpt: SelectionComponent) => boolean;
-  parse?: (model: UnitModel, selCmpt: SelectionComponent<T>, def: SelectionDef<T>) => void;
+  parse?: (model: UnitModel, selCmpt: SelectionComponent<T>, def: SelectionParameter<T>) => void;
   signals?: (model: UnitModel, selCmpt: SelectionComponent<T>, signals: NewSignal[]) => Signal[]; // the output can be a new or a push signal
   topLevelSignals?: (model: Model, selCmpt: SelectionComponent<T>, signals: NewSignal[]) => NewSignal[];
   modifyExpr?: (model: UnitModel, selCmpt: SelectionComponent<T>, expr: string) => string;
@@ -116,7 +115,7 @@ export function requiresSelectionId(model: Model) {
 
 // Binding a point selection to query widgets or legends disables default direct manipulation interaction.
 // A user can choose to re-enable it by explicitly specifying triggering input events.
-export function disableDirectManipulation(selCmpt: SelectionComponent, selDef: SelectionDef<'point'>) {
+export function disableDirectManipulation(selCmpt: SelectionComponent, selDef: SelectionParameter<'point'>) {
   if (isString(selDef.select) || !selDef.select.on) delete selCmpt.events;
   if (isString(selDef.select) || !selDef.select.clear) delete selCmpt.clear;
   if (isString(selDef.select) || !selDef.select.toggle) delete selCmpt.toggle;

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -1,17 +1,17 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {array, isObject, isString, stringValue} from 'vega-util';
 import {selectionCompilers, SelectionComponent, STORE} from '.';
+import {DataSourceType} from '../../data';
 import {warn} from '../../log';
 import {LogicalComposition} from '../../logical';
-import {BaseSelectionConfig, SelectionDef, SelectionExtent} from '../../selection';
+import {BaseSelectionConfig, SelectionExtent, SelectionParameter} from '../../selection';
 import {Dict, duplicate, entries, logicalExpr, varName} from '../../util';
 import {DataFlowNode, OutputNode} from '../data/dataflow';
 import {FilterNode} from '../data/filter';
 import {Model} from '../model';
 import {UnitModel} from '../unit';
-import {DataSourceType} from '../../data';
 
-export function parseUnitSelection(model: UnitModel, selDefs: SelectionDef[]) {
+export function parseUnitSelection(model: UnitModel, selDefs: SelectionParameter[]) {
   const selCmpts: Dict<SelectionComponent<any /* this has to be "any" so typing won't fail in test files*/>> = {};
   const selectionConfig = model.config.selection;
 

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -32,7 +32,7 @@ import {LegendInternal} from '../legend';
 import {GEOSHAPE, isMarkDef, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
 import {Domain, Scale} from '../scale';
-import {isParameterSelection, SelectionDef} from '../selection';
+import {isInteractiveParameter, SelectionParameter} from '../selection';
 import {LayoutSizeMixins, NormalizedUnitSpec} from '../spec';
 import {isFrameMixins} from '../spec/base';
 import {stack, StackProperties} from '../stack';
@@ -76,7 +76,7 @@ export class UnitModel extends ModelWithField {
 
   public specifiedProjection: Projection = {};
 
-  public readonly selection: SelectionDef[] = [];
+  public readonly selection: SelectionParameter[] = [];
   public children: Model[] = [];
 
   constructor(
@@ -121,7 +121,7 @@ export class UnitModel extends ModelWithField {
     this.specifiedProjection = spec.projection;
 
     // Selections will be initialized upon parse.
-    this.selection = (spec.params ?? []).filter(p => isParameterSelection(p)) as SelectionDef[];
+    this.selection = (spec.params ?? []).filter(p => isInteractiveParameter(p)) as SelectionParameter[];
   }
 
   public get hasProjection(): boolean {

--- a/src/normalize/base.ts
+++ b/src/normalize/base.ts
@@ -3,7 +3,7 @@ import {FieldName} from '../channeldef';
 import {Config} from '../config';
 import {Encoding} from '../encoding';
 import {Projection} from '../projection';
-import {TopLevelSelectionDef} from '../selection';
+import {TopLevelSelectionParameter} from '../selection';
 import {GenericSpec, NormalizedSpec} from '../spec';
 import {GenericLayerSpec, NormalizedLayerSpec} from '../spec/layer';
 import {GenericUnitSpec, NormalizedUnitSpec} from '../spec/unit';
@@ -42,6 +42,6 @@ export interface NormalizerParams {
   parentProjection?: Projection;
   repeater?: RepeaterValue;
   repeaterPrefix?: string;
-  selections?: TopLevelSelectionDef[];
+  selections?: TopLevelSelectionParameter[];
   path?: string[];
 }

--- a/src/normalize/selectioncompat.ts
+++ b/src/normalize/selectioncompat.ts
@@ -1,4 +1,4 @@
-import {SelectionDef} from '../selection';
+import {SelectionParameter} from '../selection';
 import {NormalizedUnitSpec} from '../spec';
 import {SpecMapper} from '../spec/map';
 import {NormalizerParams} from './base';
@@ -6,7 +6,7 @@ import {NormalizerParams} from './base';
 export class SelectionCompatibilityNormalizer extends SpecMapper<NormalizerParams, NormalizedUnitSpec> {
   public mapUnit(spec: NormalizedUnitSpec) {
     const selections = (spec as any).selection;
-    const params: SelectionDef[] = [];
+    const params: SelectionParameter[] = [];
 
     if (!selections) return spec;
 

--- a/src/normalize/toplevelselection.ts
+++ b/src/normalize/toplevelselection.ts
@@ -1,7 +1,7 @@
 import {isArray, isString} from 'vega';
 import {Field} from '../channeldef';
-import {Parameter} from '../parameter';
-import {isParameterSelection, SelectionDef} from '../selection';
+import {VariableParameter} from '../parameter';
+import {isInteractiveParameter, SelectionParameter} from '../selection';
 import {
   BaseSpec,
   isUnitSpec,
@@ -18,9 +18,9 @@ export class TopLevelSelectionsNormalizer extends SpecMapper<NormalizerParams, N
   public map(spec: TopLevel<NormalizedSpec>, normParams: NormalizerParams): TopLevel<NormalizedSpec> {
     const selections = normParams.selections ?? [];
     if (spec.params && !isUnitSpec(spec)) {
-      const params: Parameter[] = [];
+      const params: VariableParameter[] = [];
       for (const param of spec.params) {
-        if (isParameterSelection(param)) {
+        if (isInteractiveParameter(param)) {
           selections.push(param);
         } else {
           params.push(param);
@@ -39,7 +39,7 @@ export class TopLevelSelectionsNormalizer extends SpecMapper<NormalizerParams, N
     if (!selections || !selections.length) return spec as NormalizedUnitSpec;
 
     const path = (normParams.path ?? []).concat(spec.name);
-    const params: SelectionDef[] = [];
+    const params: SelectionParameter[] = [];
 
     for (const selection of selections) {
       // By default, apply selections to all unit views.

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -1,7 +1,7 @@
 import {Binding, Expr, InitSignal, NewSignal} from 'vega';
-import {isParameterSelection, TopLevelSelectionDef} from './selection';
+import {isInteractiveParameter, TopLevelSelectionParameter} from './selection';
 
-export interface Parameter {
+export interface ParameterBase {
   /**
    * Required. A unique name for the parameter. Parameter names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or "$", or "_") and may not start with a digit. Reserved keywords that may not be used as parameter names are "datum", "event", "item", and "parent".
    */
@@ -11,7 +11,9 @@ export interface Parameter {
    * A text description of the parameter, useful for inline documentation.
    */
   description?: string;
+}
 
+export interface VariableParameter extends ParameterBase {
   /**
    * The initial value of the parameter.
    *
@@ -30,12 +32,12 @@ export interface Parameter {
   bind?: Binding;
 }
 
-export function assembleParameterSignals(params: (Parameter | TopLevelSelectionDef)[]) {
+export function assembleParameterSignals(params: (VariableParameter | TopLevelSelectionParameter)[]) {
   const signals: (NewSignal | InitSignal)[] = [];
   for (const param of params || []) {
     // Selection parameters are handled separately via assembleSelectionTopLevelSignals
     // and assembleSignals methods registered on the Model.
-    if (isParameterSelection(param)) continue;
+    if (isInteractiveParameter(param)) continue;
     const {expr, bind, ...rest} = param;
 
     if (bind && expr) {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -3,6 +3,7 @@ import {isObject} from 'vega-util';
 import {SingleDefUnitChannel} from './channel';
 import {FieldName, PrimitiveValue} from './channeldef';
 import {DateTime} from './datetime';
+import {ParameterBase} from './parameter';
 import {Dict} from './util';
 
 export const SELECTION_ID = '_vgsid_';
@@ -177,12 +178,7 @@ export interface IntervalSelectionConfig extends BaseSelectionConfig {
 
 export type SelectionTypeConfig = PointSelectionConfig | IntervalSelectionConfig;
 
-export interface SelectionDef<T extends SelectionType = SelectionType> {
-  /**
-   * Required. A unique name for the selection. Selection names should be valid JavaScript identifiers: they should contain only alphanumeric characters (or "$", or "_") and may not start with a digit. Reserved keywords that may not be used as parameter names are "datum", "event", "item", and "parent".
-   */
-  name: string;
-
+export interface SelectionParameter<T extends SelectionType = SelectionType> extends ParameterBase {
   /**
    * Determines the default event processing and data query for the selection. Vega-Lite currently supports two selection types:
    *
@@ -221,7 +217,7 @@ export interface SelectionDef<T extends SelectionType = SelectionType> {
     : never;
 }
 
-export type TopLevelSelectionDef = SelectionDef & {
+export type TopLevelSelectionParameter = SelectionParameter & {
   /**
    * By default, top-level selections are applied to every view in the visualization.
    * If this property is specified, selections will only be applied to views with the given names.
@@ -299,6 +295,6 @@ export function isLegendStreamBinding(bind: any): bind is LegendStreamBinding {
   return isLegendBinding(bind) && isObject(bind);
 }
 
-export function isParameterSelection(param: any): param is SelectionDef {
+export function isInteractiveParameter(param: any): param is SelectionParameter {
   return !!param['select'];
 }

--- a/src/spec/toplevel.ts
+++ b/src/spec/toplevel.ts
@@ -5,8 +5,8 @@ import {signalRefOrValue} from '../compile/common';
 import {Config} from '../config';
 import {InlineDataset} from '../data';
 import {ExprRef} from '../expr';
-import {Parameter} from '../parameter';
-import {TopLevelSelectionDef} from '../selection';
+import {VariableParameter} from '../parameter';
+import {TopLevelSelectionParameter} from '../selection';
 import {Dict} from '../util';
 
 /**
@@ -72,7 +72,7 @@ export interface TopLevelProperties<ES extends ExprRef | SignalRef = ExprRef | S
   /**
    * Dynamic variables that parameterize a visualization.
    */
-  params?: (Parameter | TopLevelSelectionDef)[];
+  params?: (VariableParameter | TopLevelSelectionParameter)[];
 }
 
 export type FitType = 'fit' | 'fit-x' | 'fit-y';

--- a/src/spec/unit.ts
+++ b/src/spec/unit.ts
@@ -1,11 +1,11 @@
-import {Field} from './../channeldef';
 import {FieldName} from '../channeldef';
 import {CompositeEncoding, FacetedCompositeEncoding} from '../compositemark';
 import {Encoding} from '../encoding';
 import {AnyMark, Mark, MarkDef} from '../mark';
-import {Parameter} from '../parameter';
+import {VariableParameter} from '../parameter';
 import {Projection} from '../projection';
-import {SelectionDef} from '../selection';
+import {SelectionParameter} from '../selection';
+import {Field} from './../channeldef';
 import {
   BaseSpec,
   DataMixins,
@@ -39,7 +39,7 @@ export interface GenericUnitSpec<E extends Encoding<any>, M> extends BaseSpec {
   /**
    * An array of interactive selections, such as discrete points and continuous intervals.
    */
-  params?: (Parameter | SelectionDef)[];
+  params?: (VariableParameter | SelectionParameter)[];
 }
 
 /**


### PR DESCRIPTION
If we gonna make selection a kind of parameter, we should do this.

That said, as I try to write docs for this, I'm having second thoughts about this. 
I'm no longer liking this unification. (Thus, I'm making just a draft PR.)