### PR TITLE
docs: add link to vega-lite-api

### DIFF
--- a/site/_layouts/plain.html
+++ b/site/_layouts/plain.html
@@ -10,6 +10,7 @@ layout: base
         <div class="dropdown-content">
           <a href="https://vega.github.io/vega/">Vega</a>
           <a href="https://altair-viz.github.io/">Altair</a>
+          <a href="https://vega.github.io/vega-lite-api/">Vega-Lite API</a>
         </div>
       </div>
       <div class="vl-links">

--- a/site/static/main.css
+++ b/site/static/main.css
@@ -324,6 +324,7 @@ nav > .dropdown {
 
 .vl-title {
   padding: 0 20px 2px 20px;
+  width: 124px;
   font-weight: bold;
   font-size: 1.4em;
   color: #eee;
@@ -688,7 +689,7 @@ footer .edit-page {
 nav .dropdown-content {
   position: absolute;
   display: none;
-  min-width: 141px;
+  min-width: 164px;
   top: 54px; /* For Firefox */
 }
 


### PR DESCRIPTION
fix #7020

Note: I also need to adjust CSS so the menu is wide enough to say "Vega-Lite API".
