### PR TITLE
fix: use correct expression functions to pan/zoom symlog scales

### DIFF
--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -91,6 +91,8 @@ function onDelta(
     ? 'panLinear'
     : scaleType === 'log'
     ? 'panLog'
+    : scaleType === 'symlog'
+    ? 'panSymlog'
     : scaleType === 'pow'
     ? 'panPow'
     : 'panLinear';

--- a/src/compile/selection/zoom.ts
+++ b/src/compile/selection/zoom.ts
@@ -93,6 +93,8 @@ function onDelta(
     ? 'zoomLinear'
     : scaleType === 'log'
     ? 'zoomLog'
+    : scaleType === 'symlog'
+    ? 'zoomSymlog'
     : scaleType === 'pow'
     ? 'zoomPow'
     : 'zoomLinear';


### PR DESCRIPTION
Fixes #6840.