### PR TITLE
fix: correctly flatten nested field references for scale bindings

### DIFF
--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -4,7 +4,7 @@ import {selectionCompilers, SelectionComponent, STORE} from '.';
 import {warn} from '../../log';
 import {LogicalComposition} from '../../logical';
 import {BaseSelectionConfig, SelectionDef, SelectionExtent} from '../../selection';
-import {Dict, duplicate, entries, logicalExpr, varName} from '../../util';
+import {Dict, duplicate, entries, logicalExpr, replacePathInField, varName} from '../../util';
 import {DataFlowNode, OutputNode} from '../data/dataflow';
 import {FilterNode} from '../data/filter';
 import {Model} from '../model';
@@ -120,7 +120,7 @@ export function parseSelectionBinExtent(selCmpt: SelectionComponent, extent: Sel
     }
   }
 
-  return `${selCmpt.name}[${stringValue(field)}]`;
+  return `${selCmpt.name}[${stringValue(replacePathInField(field))}]`;
 }
 
 export function materializeSelections(model: UnitModel, main: OutputNode) {

--- a/src/compile/selection/scales.ts
+++ b/src/compile/selection/scales.ts
@@ -7,6 +7,7 @@ import {isLayerModel, Model} from '../model';
 import {UnitModel} from '../unit';
 import {SelectionProjection} from './project';
 import {SelectionCompiler} from '.';
+import {replacePathInField} from '../../util';
 
 const scaleBindings: SelectionCompiler<'interval'> = {
   defined: selCmpt => {
@@ -55,10 +56,12 @@ const scaleBindings: SelectionCompiler<'interval'> = {
     const namedSg = signals.filter(s => s.name === selCmpt.name)[0];
     let update = namedSg.update;
     if (update.indexOf(VL_SELECTION_RESOLVE) >= 0) {
-      namedSg.update = `{${bound.map(proj => `${stringValue(proj.field)}: ${proj.signals.data}`).join(', ')}}`;
+      namedSg.update = `{${bound
+        .map(proj => `${stringValue(replacePathInField(proj.field))}: ${proj.signals.data}`)
+        .join(', ')}}`;
     } else {
       for (const proj of bound) {
-        const mapping = `${stringValue(proj.field)}: ${proj.signals.data}`;
+        const mapping = `${stringValue(replacePathInField(proj.field))}: ${proj.signals.data}`;
         if (!update.includes(mapping)) {
           update = `${update.substring(0, update.length - 1)}, ${mapping}}`;
         }


### PR DESCRIPTION
Fixes #6882. 

In #5351, we began to support flattened fields in selection signals. However, code review caught some good issues that were fixed in https://github.com/vega/vega-lite/pull/5351/commits/ea6f407d099ca9b15149111d31d71d5245a3f3a4 but weren't propagated through to the way scale bindings reference fields. This PR fixes that bug. 