### PR TITLE
fix: selection compatibility normalizer should run first

### DIFF
--- a/src/normalize/index.ts
+++ b/src/normalize/index.ts
@@ -53,7 +53,7 @@ function normalizeGenericSpec(
 ) {
   const normParams = {config};
   return topLevelSelectionNormalizer.map(
-    selectionCompatNormalizer.map(coreNormalizer.map(spec, normParams), normParams),
+    coreNormalizer.map(selectionCompatNormalizer.map(spec, normParams), normParams),
     normParams
   );
 }

--- a/src/normalize/selectioncompat.ts
+++ b/src/normalize/selectioncompat.ts
@@ -1,10 +1,16 @@
+import {Field} from '../channeldef';
 import {SelectionDef} from '../selection';
-import {NormalizedUnitSpec} from '../spec';
+import {FacetedUnitSpec, LayerSpec, UnitSpec} from '../spec';
 import {SpecMapper} from '../spec/map';
 import {NormalizerParams} from './base';
 
-export class SelectionCompatibilityNormalizer extends SpecMapper<NormalizerParams, NormalizedUnitSpec> {
-  public mapUnit(spec: NormalizedUnitSpec) {
+export class SelectionCompatibilityNormalizer extends SpecMapper<
+  NormalizerParams,
+  FacetedUnitSpec<Field>,
+  LayerSpec<Field>,
+  UnitSpec<Field>
+> {
+  public mapUnit(spec: UnitSpec<Field>) {
     const selections = (spec as any).selection;
     const params: SelectionDef[] = [];
 

--- a/test/normalize/selectioncompat.test.ts
+++ b/test/normalize/selectioncompat.test.ts
@@ -1,3 +1,4 @@
+import {normalize} from '../../src';
 import {SelectionCompatibilityNormalizer} from '../../src/normalize/selectioncompat';
 import {NormalizedUnitSpec} from '../../src/spec';
 
@@ -84,5 +85,31 @@ describe('SelectionCompatibilityNormalizer', () => {
     expect(normedUnit.params[1]).toHaveProperty('name', 'grid');
     expect(normedUnit.params[0]).toHaveProperty('value', {x: [55, 160], y: [13, 37]});
     expect(normedUnit.params[1]).toHaveProperty('bind', 'scales');
+  });
+
+  it('should be the first normalizer run', () => {
+    const spec: any = {
+      data: {url: 'data/cars.json'},
+      selection: {
+        brush: {
+          type: 'interval',
+          init: {x: [55, 160], y: [13, 37]}
+        }
+      },
+      mark: {type: 'line', point: true},
+      encoding: {
+        row: {field: 'Origin', type: 'nominal'},
+        x: {field: 'Horsepower', type: 'quantitative'},
+        y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+        color: {
+          condition: {selection: 'brush', field: 'Cylinders', type: 'ordinal'},
+          value: 'grey'
+        }
+      }
+    };
+
+    const normalized = normalize(spec) as any;
+    expect(normalized.spec.layer[0]).toHaveProperty('params');
+    expect(normalized.spec.layer[0].params[0].name).toBe('brush');
   });
 });


### PR DESCRIPTION
In https://github.com/vega/vega-lite/pull/7114, we introduced a normalizer to automatically transition from the old selection syntax to the new selection parameters. Unfortunately, in te previous PR, this new normalizer incorrectly ran _after_ the core normalizer. As a result, it could not correctly transition selections for specs that were themselves normalized (e.g., those that use `row`/`column` or `line` marks with `"point": true`). 

This PR switches the order such that the selection compatibility normalizer runs _first_, with an corresponding unit test to ensure we correctly transition selections for generic/extended specs. 