### PR TITLE
fix: scale-bound selections should respect reversals

### DIFF
--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -8,7 +8,7 @@ import {BinTransform} from '../../transform';
 import {Dict, duplicate, hash, isEmpty, keys, replacePathInField, unique, vals, varName} from '../../util';
 import {binFormatExpression} from '../format';
 import {isUnitModel, Model, ModelWithField} from '../model';
-import {parseSelectionBinExtent} from '../selection/parse';
+import {parseSelectionExtent} from '../selection/parse';
 import {NonPositionScaleChannel, PositionChannel} from './../../channel';
 import {DataFlowNode} from './dataflow';
 
@@ -69,7 +69,7 @@ function createBinComponent(t: TypedFieldDef<string> | BinTransform, bin: boolea
   if (isSelectionExtent(normalizedBin.extent)) {
     const ext = normalizedBin.extent;
     const selName = ext.selection;
-    span = parseSelectionBinExtent(model.getSelectionComponent(varName(selName), selName), ext);
+    span = parseSelectionExtent(model.getSelectionComponent(varName(selName), selName), ext);
     delete normalizedBin.extent; // Vega-Lite selection extent map to Vega's span property.
   }
 

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -31,12 +31,10 @@ export function assembleScalesForModel(model: Model): VgScale[] {
     const {name, type, selectionExtent, domains: _d, range: _r, reverse, ...otherScaleProps} = scale;
     const range = assembleScaleRange(scale.range, name, channel, model);
 
-    let domainRaw;
-    if (selectionExtent) {
-      domainRaw = assembleSelectionScaleDomain(model, selectionExtent);
-    }
-
     const domain = assembleDomain(model, channel);
+    const domainRaw = selectionExtent
+      ? assembleSelectionScaleDomain(model, selectionExtent, scaleComponent, domain)
+      : null;
 
     scales.push({
       name,

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -94,7 +94,7 @@ export function parseSelectionPredicate(
   );
 }
 
-export function parseSelectionBinExtent(selCmpt: SelectionComponent, extent: SelectionExtent) {
+export function parseSelectionExtent(selCmpt: SelectionComponent, extent: SelectionExtent) {
   const encoding = extent['encoding'];
   let field = extent['field'];
 

--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -96,10 +96,14 @@ function onDelta(
     : scaleType === 'pow'
     ? 'panPow'
     : 'panLinear';
-  const update =
-    `${panFn}(${extent}, ${offset}` +
-    (hasScales && scaleType === 'pow' ? `, ${scaleCmpt.get('exponent') ?? 1}` : '') +
-    ')';
+  const arg = !hasScales
+    ? ''
+    : scaleType === 'pow'
+    ? `, ${scaleCmpt.get('exponent') ?? 1}`
+    : scaleType === 'symlog'
+    ? `, ${scaleCmpt.get('constant') ?? 1}`
+    : '';
+  const update = `${panFn}(${extent}, ${offset}${arg})`;
 
   signal.on.push({
     events: {signal: delta},

--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -84,7 +84,8 @@ function onDelta(
   const sizeSg = model.getSizeSignalRef(size).signal;
   const scaleCmpt = model.getScaleComponent(channel);
   const scaleType = scaleCmpt.get('type');
-  const sign = hasScales && channel === X ? '-' : ''; // Invert delta when panning x-scales.
+  const reversed = scaleCmpt.get('reverse'); // scale parsing sets this flag for fieldDef.sort
+  const sign = !hasScales ? '' : channel === X ? (reversed ? '' : '-') : reversed ? '-' : '';
   const extent = `${anchor}.extent_${channel}`;
   const offset = `${sign}${delta}.${channel} / ` + (hasScales ? `${sizeSg}` : `span(${extent})`);
   const panFn = !hasScales

--- a/src/compile/selection/zoom.ts
+++ b/src/compile/selection/zoom.ts
@@ -98,10 +98,14 @@ function onDelta(
     : scaleType === 'pow'
     ? 'zoomPow'
     : 'zoomLinear';
-  const update =
-    `${zoomFn}(${base}, ${anchor}, ${delta}` +
-    (hasScales && scaleType === 'pow' ? `, ${scaleCmpt.get('exponent') ?? 1}` : '') +
-    ')';
+  const arg = !hasScales
+    ? ''
+    : scaleType === 'pow'
+    ? `, ${scaleCmpt.get('exponent') ?? 1}`
+    : scaleType === 'symlog'
+    ? `, ${scaleCmpt.get('constant') ?? 1}`
+    : '';
+  const update = `${zoomFn}(${base}, ${anchor}, ${delta}${arg})`;
 
   signal.on.push({
     events: {signal: delta},


### PR DESCRIPTION
Fixes #5386, #5413, as well as an incomplete implementation of #7158. 