### PR TITLE
fix: support discretizing scales for shape

### DIFF
--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -188,8 +188,12 @@ export function invalidEncodingChannel(channel: ExtendedChannel) {
   return `${channel}-encoding is dropped as ${channel} is not a valid encoding channel.`;
 }
 
-export function facetChannelShouldBeDiscrete(channel: FacetChannel) {
+export function channelShouldBeDiscrete(channel: ExtendedChannel) {
   return `${channel} encoding should be discrete (ordinal / nominal / binned).`;
+}
+
+export function channelShouldBeDiscreteOrDiscretizing(channel: ExtendedChannel) {
+  return `${channel} encoding should be discrete (ordinal / nominal / binned) or use a discretizing scale (e.g. threshold).`;
 }
 
 export function facetChannelDropped(channels: FacetChannel[]) {

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -70,7 +70,7 @@ export const SCALE_CATEGORY_INDEX: Record<ScaleType, ScaleType | 'numeric' | 'or
   threshold: 'discretizing'
 };
 
-export const SCALE_TYPES = keys(SCALE_CATEGORY_INDEX) as ScaleType[];
+export const SCALE_TYPES: ScaleType[] = keys(SCALE_CATEGORY_INDEX);
 
 /**
  * Whether the two given scale types can be merged together.
@@ -839,8 +839,7 @@ export function channelSupportScaleType(channel: Channel, scaleType: ScaleType):
     case CHANNEL.STROKE:
       return scaleType !== 'band'; // band does not make sense with color
     case CHANNEL.STROKEDASH:
-      return scaleType === 'ordinal' || isContinuousToDiscrete(scaleType);
     case CHANNEL.SHAPE:
-      return scaleType === 'ordinal'; // shape = lookup only
+      return scaleType === 'ordinal' || isContinuousToDiscrete(scaleType);
   }
 }

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -40,7 +40,7 @@ describe('FacetModel', () => {
           }
         });
         expect(model.facet).toEqual({row: {field: 'a', type: 'quantitative'}});
-        expect(localLogger.warns[0]).toEqual(log.message.facetChannelShouldBeDiscrete(ROW));
+        expect(localLogger.warns[0]).toEqual(log.message.channelShouldBeDiscrete(ROW));
       })
     );
 

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,6 +1,12 @@
 import {ScaleChannel, SCALE_CHANNELS} from '../src/channel';
 import * as scale from '../src/scale';
-import {channelSupportScaleType, CONTINUOUS_TO_CONTINUOUS_SCALES, ScaleType, SCALE_TYPES} from '../src/scale';
+import {
+  channelSupportScaleType,
+  CONTINUOUS_TO_CONTINUOUS_SCALES,
+  CONTINUOUS_TO_DISCRETE_SCALES,
+  ScaleType,
+  SCALE_TYPES
+} from '../src/scale';
 import {some} from '../src/util';
 import {without} from './util';
 
@@ -51,11 +57,25 @@ describe('scale', () => {
       }
     });
 
-    it('shape should support only ordinal', () => {
-      expect(channelSupportScaleType('shape', 'ordinal')).toBeTruthy();
-      const nonOrdinal = without<ScaleType>(SCALE_TYPES, ['ordinal']);
-      for (const scaleType of nonOrdinal) {
+    it('shape should support only ordinal and discretizing scales', () => {
+      const supportedScales = [ScaleType.ORDINAL, ...CONTINUOUS_TO_DISCRETE_SCALES] as const;
+      for (const scaleType of supportedScales) {
+        expect(channelSupportScaleType('shape', scaleType)).toBeTruthy();
+      }
+      const unsupported = without(SCALE_TYPES, supportedScales);
+      for (const scaleType of unsupported) {
         expect(!channelSupportScaleType('shape', scaleType)).toBeTruthy();
+      }
+    });
+
+    it('strokeDash should support only ordinal and discretizing scales', () => {
+      const supportedScales = [ScaleType.ORDINAL, ...CONTINUOUS_TO_DISCRETE_SCALES] as const;
+      for (const scaleType of supportedScales) {
+        expect(channelSupportScaleType('strokeDash', scaleType)).toBeTruthy();
+      }
+      const unsupported = without(SCALE_TYPES, supportedScales);
+      for (const scaleType of unsupported) {
+        expect(!channelSupportScaleType('strokeDash', scaleType)).toBeTruthy();
       }
     });
 


### PR DESCRIPTION
fixes #7167

In https://github.com/vega/vega-lite/pull/6201/files#diff-245098c24d290d1cd456956b3a74d688f56ec8a89e28ca9851ddd21067d8518aR828, we only allowed discretizing scales for stroke dash. This pull request also enables support for shape. 