### PR TITLE
fix: Remove <null> from Value to fix TopLevelSpec consumed by code using strict mode.

### DIFF
--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -90,7 +90,7 @@ import {isSignalRef} from './vega.schema';
 
 export type PrimitiveValue = number | string | boolean | null;
 
-export type Value<ES extends ExprRef | SignalRef | null = ExprRef | SignalRef | null> =
+export type Value<ES extends ExprRef | SignalRef = ExprRef | SignalRef> =
   | PrimitiveValue
   | number[]
   | Gradient

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -90,7 +90,7 @@ import {isSignalRef} from './vega.schema';
 
 export type PrimitiveValue = number | string | boolean | null;
 
-export type Value<ES extends ExprRef | SignalRef = ExprRef | SignalRef> =
+export type Value<ES extends ExprRef | SignalRef | null = ExprRef | SignalRef | null> =
   | PrimitiveValue
   | number[]
   | Gradient

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -92,6 +92,8 @@ export function isSignalRef(o: any): o is SignalRef {
 
 // TODO: add type of value (Make it VgValueRef<V extends ValueOrGradient> {value?:V ...})
 export interface VgValueRef {
+  // Alternative that removes the generic `null` to fall back to the default provided by the type itself
+  // value?: Value;
   value?: Value<null>;
   field?:
     | string

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -92,9 +92,7 @@ export function isSignalRef(o: any): o is SignalRef {
 
 // TODO: add type of value (Make it VgValueRef<V extends ValueOrGradient> {value?:V ...})
 export interface VgValueRef {
-  // Alternative that removes the generic `null` to fall back to the default provided by the type itself
-  // value?: Value;
-  value?: Value<null>;
+  value?: Value;
   field?:
     | string
     | {


### PR DESCRIPTION
Related to #6912.

When you consume `TopLevelSpec` like `import type { TopLevelSpec } from 'vega-lite';` in a project with `strictNullChecks` set to `true`, you'll run into the following error:

```
ERROR
      node_modules/vega-lite/build/src/vega.schema.d.ts:34:19 - error TS2344: Type 'null' does not satisfy the constraint 'SignalRef | ExprRef'.

      34     value?: Value<null>;
                           ~~~~

      Found 1 error.
```

The problem seems to be that the generic `ES` for the `Value` type doesn't include `null`. Changing that type to `Value<ES extends ExprRef | SignalRef | null = ExprRef | SignalRef | null>` fixes it.

An alternative would be to remove the `<null>` from the code that references `Value` since the type definition includes `ExprRef | SignalRef` as a default anyway.

Let me know which version would make more sense and I'll update the PR.
