### PR TITLE
chore: rebuild examples

### DIFF
--- a/scripts/build-example.sh
+++ b/scripts/build-example.sh
@@ -39,7 +39,7 @@ do
   then
     rm -f examples/compiled/$name.svg
     rm -f examples/compiled/$name.png
-    npx vg2svg --base site --seed 123456789 examples/compiled/$name.vg.json > examples/compiled/$name.svg
-    npx vg2png --base site --seed 123456789 examples/compiled/$name.vg.json > examples/compiled/$name.png
+    npx vg2svg --base ./site --seed 123456789 examples/compiled/$name.vg.json > examples/compiled/$name.svg
+    npx vg2png --base ./site --seed 123456789 examples/compiled/$name.vg.json > examples/compiled/$name.png
   fi
 done


### PR DESCRIPTION
Since we do not need symlink to `examples/compiled/data` anymore, should we remove it?