### PR TITLE
fix(docs): point "create a histogram" link to proper id on Binning documentation

### DIFF
--- a/site/docs/transform/bin.md
+++ b/site/docs/transform/bin.md
@@ -4,7 +4,7 @@ title: Binning
 permalink: /docs/bin.html
 ---
 
-Binning discretizes numeric values into a set of bins. A common use case is to [create a histogram](#example).
+Binning discretizes numeric values into a set of bins. A common use case is to [create a histogram](#histogram).
 
 There are two ways to define binning in Vega-Lite: [the `bin` property in encoding field definitions](#encoding) and [the `bin` transform](#transform).
 


### PR DESCRIPTION
This fixes the "create a histogram" link in the Binning documentation (https://vega.github.io/vega-lite/docs/bin.html)

Before:
- https://vega.github.io/vega-lite/docs/bin.html#example

After:
- https://vega.github.io/vega-lite/docs/bin.html#histogram
