### PR TITLE
Modified pointPositionDefaultRef as to always set the scale of x2 to x.

### DIFF
--- a/src/compile/mark/encode/position-point.ts
+++ b/src/compile/mark/encode/position-point.ts
@@ -52,19 +52,19 @@ export function pointPosition(
   const valueRef =
     !channelDef && isXorY(channel) && (encoding.latitude || encoding.longitude)
       ? // use geopoint output if there are lat/long and there is no point position overriding lat/long.
-        {field: model.getName(channel)}
+      {field: model.getName(channel)}
       : positionRef({
-          channel,
-          channelDef,
-          channel2Def,
-          markDef,
-          config,
-          scaleName,
-          scale,
-          stack,
-          offset,
-          defaultRef
-        });
+        channel,
+        channelDef,
+        channel2Def,
+        markDef,
+        config,
+        scaleName,
+        scale,
+        stack,
+        offset,
+        defaultRef
+      });
 
   return valueRef ? {[vgChannel || channel]: valueRef} : undefined;
 }
@@ -154,7 +154,7 @@ export function pointPositionDefaultRef({
         }
 
         if (defaultPos === 'zeroOrMin') {
-          return mainChannel === 'y' ? {field: {group: 'height'}} : {value: 0};
+          return mainChannel === 'y' ? {field: {group: 'height'}} : {scale: scaleName, value: 0};
         } else {
           // zeroOrMax
           switch (mainChannel) {

--- a/src/compile/mark/encode/position-rect.ts
+++ b/src/compile/mark/encode/position-rect.ts
@@ -183,10 +183,10 @@ function positionAndSize(
     bandPosition: center
       ? 0.5
       : isSignalRef(bandSize)
-      ? {signal: `(1-${bandSize})/2`}
-      : isRelativeBandSize(bandSize)
-      ? (1 - bandSize.band) / 2
-      : 0
+        ? {signal: `(1-${bandSize})/2`}
+        : isRelativeBandSize(bandSize)
+          ? (1 - bandSize.band) / 2
+          : 0
   });
 
   if (vgSizeChannel) {
@@ -204,9 +204,9 @@ function positionAndSize(
       [vgChannel2]: isArray(posRef)
         ? [posRef[0], {...posRef[1], offset: sizeOffset}]
         : {
-            ...posRef,
-            offset: sizeOffset
-          }
+          ...posRef,
+          offset: sizeOffset
+        }
     };
   }
 }
@@ -275,8 +275,8 @@ export function rectBinPosition({
   const bandPosition = isSignalRef(bandSize)
     ? {signal: `(1-${bandSize.signal})/2`}
     : isRelativeBandSize(bandSize)
-    ? (1 - bandSize.band) / 2
-    : 0.5;
+      ? (1 - bandSize.band) / 2
+      : 0.5;
 
   if (isBinning(fieldDef.bin) || fieldDef.timeUnit) {
     return {

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -198,7 +198,35 @@ describe('Mark: Bar', () => {
     expect(props.x2).toEqual({scale: 'x', value: 0});
     expect(props.height).toBeUndefined();
   });
+  describe("horizontal bar with domain w/o zero and stack false", () => {
+    const model = parseUnitModelWithScaleAndLayoutSize(
+      {
+        mark: {type: 'bar'},
+        encoding: {
+          x: {
+            field: 'x', type: 'quantitative',
+            scale: {
+              domain: [1, 4],
+              reverse: true,
+            },
+            stack: false
+          },
+          y: {field: 'y', type: 'nominal'}
+        },
+        data: {
+          values: [
+            {"x": 2, "y": "A"},
+            {"x": 3, "y": "B"}
+          ]
+        }
+      }
+    );
+    const props = bar.encodeEntry(model);
 
+    it("should draw bar 2 bars from zero to field value when domain that excludes zero is specified", () => {
+      expect(props.x2).toEqual({scale: 'x', value: 0});
+    })
+  });
   describe('simple horizontal with point scale', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       data: {url: 'data/cars.json'},
@@ -648,7 +676,7 @@ describe('Mark: Bar', () => {
     const props = bar.encodeEntry(model);
 
     it('should end on axis and has no width', () => {
-      expect(props.x2).toEqual({value: 0});
+      expect(props.x2).toEqual({scale: 'x', value: 0});
       expect(props.width).toBeUndefined();
     });
   });
@@ -732,7 +760,7 @@ describe('Mark: Bar', () => {
 
     const props = bar.encodeEntry(model);
     it('should end on axis and have no width', () => {
-      expect(props.x2).toEqual({value: 0});
+      expect(props.x2).toEqual({scale: 'x', value: 0});
       expect(props.width).toBeUndefined();
     });
   });

--- a/test/compile/mark/encode/position-point.test.ts
+++ b/test/compile/mark/encode/position-point.test.ts
@@ -1,6 +1,8 @@
 import {X, Y} from '../../../../src/channel';
 import {pointPosition} from '../../../../src/compile/mark/encode';
+import {pointPositionDefaultRef} from '../../../../src/compile/mark/encode/position-point';
 import {parseUnitModelWithScaleAndLayoutSize} from '../../../util';
+
 
 describe('compile/mark/encode/position-point', () => {
   it('should return correctly for lat/lng', () => {
@@ -29,4 +31,36 @@ describe('compile/mark/encode/position-point', () => {
       expect(mixins[channel]['field']).toEqual(model.getName(channel));
     });
   });
+  it('should have scale for secondary channel', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize(
+      {
+        mark: {type: 'bar'},
+        encoding: {
+          x: {
+            field: 'x', type: 'quantitative',
+            scale: {
+              domain: [1, 4],
+              reverse: true,
+            },
+            stack: false
+          },
+          y: {field: 'y', type: 'nominal'}
+        },
+        data: {
+          values: [
+            {"x": 2, "y": "A"},
+            {"x": 3, "y": "B"}
+          ]
+        }
+      });
+    () => {
+      const channel1 = 'x';
+      const defaultPos = 'zeroOrMin';
+      const scaleName = model.scaleName(channel1);
+      const scale = model.getScaleComponent(channel1);
+      const channel = 'x2';
+      const mixins = pointPositionDefaultRef({model, defaultPos, channel, scaleName, scale});
+      expect(mixins[channel]['scale']).toEqual(scaleName);
+    };
+  })
 });


### PR DESCRIPTION
Written a test in bar.test.ts to test the case where the domain excludes 0 (might need more rigorous testing)
Written a test in position-point.test.ts to test pointPositionDefaultRef directly
Should check the area tests. They fail on some tests after modifying pointPositionDefaultRef

Please:

- [ ] Make the pull requests (PRs) atomic (fix one issue at a time). Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.
- [ ] Provide a concise title as a [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties") so we can easily copy it to the release note.
  - Use imperative mood and present tense.
- Mention relevant issues in the description (e.g., `Fixes #1` / `Fixes part of #1`).
- [ ] Lint and test (Run `yarn test`).
- [ ] If you send a pull request from a fork, make sure that GitHub actions run successfully. Make sure to add a [`GH_PAT` secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) for a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) with public repository permissions.
- [ ] Review your changes before sending the PR (to ensure code quality).
- For new features:
  - [ ] Add new unit tests.
  - [ ] Update the documentation under `site/docs/` + add examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
