### PR TITLE
chore: fix selection types in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Build
         run: yarn build:only
 
+      - name: Typechecks
+        run: yarn tsc
+
       - name: Lint
         run: yarn lint
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -287,13 +287,13 @@ describe('Selection', () => {
       const component = parseUnitSelection(model, [
         {
           name: 'one',
-          select: {type: 'interval', fields: ['Horsepower', 'Miles_per_Gallon'], encodings: ['x', 'y']}
+          select: {type: 'point', fields: ['Horsepower', 'Miles_per_Gallon'], encodings: ['x', 'y']}
         }
       ]);
 
       expect(component['one'].project.items).toEqual([
-        {field: 'Horsepower', channel: 'x', type: 'R', signals: {data: 'one_Horsepower', visual: 'one_x'}},
-        {field: 'Miles_per_Gallon', channel: 'y', type: 'R', signals: {data: 'one_Miles_per_Gallon', visual: 'one_y'}}
+        {field: 'Horsepower', channel: 'x', type: 'E', signals: {data: 'one_Horsepower', visual: 'one_x'}},
+        {field: 'Miles_per_Gallon', channel: 'y', type: 'E', signals: {data: 'one_Miles_per_Gallon', visual: 'one_y'}}
       ]);
     });
   });

--- a/test/compile/selection/scales.test.ts
+++ b/test/compile/selection/scales.test.ts
@@ -5,7 +5,6 @@ import {assembleScalesForModel} from '../../../src/compile/scale/assemble';
 import {assembleTopLevelSignals, assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
 import {UnitModel} from '../../../src/compile/unit';
 import * as log from '../../../src/log';
-import {Domain} from '../../../src/scale';
 import {parseConcatModel, parseModel, parseUnitModelWithScaleAndSelection} from '../../util';
 
 describe('Selection + Scales', () => {
@@ -26,7 +25,7 @@ describe('Selection + Scales', () => {
             }
           },
           {
-            params: [{name: 'brush3', select: {type: 'interval', fields: ['symbol']}}],
+            params: [{name: 'brush3', select: {type: 'point', fields: ['symbol']}}],
             mark: 'area',
             encoding: {
               x: {
@@ -42,12 +41,12 @@ describe('Selection + Scales', () => {
               color: {
                 field: 'symbol',
                 type: 'nominal',
-                scale: {domain: {param: 'brush3'} as Domain}
+                scale: {domain: {param: 'brush3'}}
               },
               opacity: {
                 field: 'symbol',
                 type: 'ordinal',
-                scale: {domain: {param: 'var'} as Domain}
+                scale: {domain: {param: 'var'}}
               }
             }
           }


### PR DESCRIPTION
Without these changes, `yarn tsc` fails. It also makes sense since only points selections have `fields`. I added a check to the CI to prevent this issue in the future. 