### PR TITLE
fix: preserve node order in swapWithParent

### DIFF
--- a/examples/compiled/facet_bullet.vg.json
+++ b/examples/compiled/facet_bullet.vg.json
@@ -80,7 +80,12 @@
       ]
     },
     {
-      "name": "data_1",
+      "name": "row_domain",
+      "source": "data_0",
+      "transform": [{"type": "aggregate", "groupby": ["title"]}]
+    },
+    {
+      "name": "data_2",
       "source": "data_0",
       "transform": [
         {
@@ -98,7 +103,7 @@
       ]
     },
     {
-      "name": "data_2",
+      "name": "data_3",
       "source": "data_0",
       "transform": [
         {
@@ -116,7 +121,7 @@
       ]
     },
     {
-      "name": "data_3",
+      "name": "data_4",
       "source": "data_0",
       "transform": [
         {
@@ -134,7 +139,7 @@
       ]
     },
     {
-      "name": "data_4",
+      "name": "data_5",
       "source": "data_0",
       "transform": [
         {
@@ -152,7 +157,7 @@
       ]
     },
     {
-      "name": "data_5",
+      "name": "data_6",
       "source": "data_0",
       "transform": [
         {
@@ -170,7 +175,7 @@
       ]
     },
     {
-      "name": "data_6",
+      "name": "data_7",
       "source": "data_0",
       "transform": [
         {
@@ -178,11 +183,6 @@
           "expr": "isValid(datum[\"markers.0\"]) && isFinite(+datum[\"markers.0\"])"
         }
       ]
-    },
-    {
-      "name": "row_domain",
-      "source": "data_0",
-      "transform": [{"type": "aggregate", "groupby": ["title"]}]
     }
   ],
   "signals": [

--- a/examples/compiled/interactive_multi_line_pivot_tooltip.vg.json
+++ b/examples/compiled/interactive_multi_line_pivot_tooltip.vg.json
@@ -17,6 +17,20 @@
       "source": "source_0",
       "transform": [
         {
+          "type": "filter",
+          "expr": "length(data(\"hover_store\")) && vlSelectionTest(\"hover_store\", datum)"
+        },
+        {
+          "type": "filter",
+          "expr": "(isDate(datum[\"date\"]) || (isValid(datum[\"date\"]) && isFinite(+datum[\"date\"]))) && isValid(datum[\"price\"]) && isFinite(+datum[\"price\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "source_0",
+      "transform": [
+        {
           "type": "pivot",
           "field": "symbol",
           "value": "price",
@@ -26,20 +40,6 @@
         {
           "type": "filter",
           "expr": "(isDate(datum[\"date\"]) || (isValid(datum[\"date\"]) && isFinite(+datum[\"date\"])))"
-        }
-      ]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "length(data(\"hover_store\")) && vlSelectionTest(\"hover_store\", datum)"
-        },
-        {
-          "type": "filter",
-          "expr": "(isDate(datum[\"date\"]) || (isValid(datum[\"date\"]) && isFinite(+datum[\"date\"]))) && isValid(datum[\"price\"]) && isFinite(+datum[\"price\"])"
         }
       ]
     }
@@ -147,7 +147,7 @@
       "type": "symbol",
       "style": ["point"],
       "interactive": false,
-      "from": {"data": "data_1"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -167,7 +167,7 @@
       "type": "rule",
       "style": ["rule"],
       "interactive": true,
-      "from": {"data": "data_0"},
+      "from": {"data": "data_1"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -223,8 +223,8 @@
       "domain": {
         "fields": [
           {"data": "source_0", "field": "date"},
-          {"data": "data_1", "field": "date"},
-          {"data": "data_0", "field": "date"}
+          {"data": "data_0", "field": "date"},
+          {"data": "data_1", "field": "date"}
         ]
       },
       "range": [0, {"signal": "width"}]
@@ -235,7 +235,7 @@
       "domain": {
         "fields": [
           {"data": "source_0", "field": "price"},
-          {"data": "data_1", "field": "price"}
+          {"data": "data_0", "field": "price"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -248,7 +248,7 @@
       "domain": {
         "fields": [
           {"data": "source_0", "field": "symbol"},
-          {"data": "data_1", "field": "symbol"}
+          {"data": "data_0", "field": "symbol"}
         ],
         "sort": true
       },

--- a/examples/compiled/interactive_seattle_weather.vg.json
+++ b/examples/compiled/interactive_seattle_weather.vg.json
@@ -17,6 +17,26 @@
       "source": "source_0",
       "transform": [
         {
+          "type": "filter",
+          "expr": "!length(data(\"click_store\")) || vlSelectionTest(\"click_store\", datum)"
+        },
+        {
+          "field": "date",
+          "type": "timeunit",
+          "units": ["month", "date"],
+          "as": ["monthdate_date", "monthdate_date_end"]
+        },
+        {
+          "type": "filter",
+          "expr": "(isDate(datum[\"monthdate_date\"]) || (isValid(datum[\"monthdate_date\"]) && isFinite(+datum[\"monthdate_date\"]))) && isValid(datum[\"temp_max\"]) && isFinite(+datum[\"temp_max\"]) && isValid(datum[\"precipitation\"]) && isFinite(+datum[\"precipitation\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "source_0",
+      "transform": [
+        {
           "field": "date",
           "type": "timeunit",
           "units": ["month", "date"],
@@ -32,26 +52,6 @@
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
-        }
-      ]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "!length(data(\"click_store\")) || vlSelectionTest(\"click_store\", datum)"
-        },
-        {
-          "field": "date",
-          "type": "timeunit",
-          "units": ["month", "date"],
-          "as": ["monthdate_date", "monthdate_date_end"]
-        },
-        {
-          "type": "filter",
-          "expr": "(isDate(datum[\"monthdate_date\"]) || (isValid(datum[\"monthdate_date\"]) && isFinite(+datum[\"monthdate_date\"]))) && isValid(datum[\"temp_max\"]) && isFinite(+datum[\"temp_max\"]) && isValid(datum[\"precipitation\"]) && isFinite(+datum[\"precipitation\"])"
         }
       ]
     }
@@ -304,7 +304,7 @@
           "type": "symbol",
           "style": ["point"],
           "interactive": true,
-          "from": {"data": "data_1"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "opacity": {"value": 0.7},
@@ -480,7 +480,7 @@
           "type": "rect",
           "style": ["bar"],
           "interactive": true,
-          "from": {"data": "data_0"},
+          "from": {"data": "data_1"},
           "encode": {
             "update": {
               "fill": [
@@ -555,7 +555,7 @@
     {
       "name": "concat_0_x",
       "type": "time",
-      "domain": {"data": "data_1", "field": "monthdate_date"},
+      "domain": {"data": "data_0", "field": "monthdate_date"},
       "range": [0, {"signal": "width"}]
     },
     {
@@ -568,7 +568,7 @@
     {
       "name": "concat_1_x",
       "type": "linear",
-      "domain": {"data": "data_0", "field": "__count"},
+      "domain": {"data": "data_1", "field": "__count"},
       "range": [0, {"signal": "width"}],
       "nice": true,
       "zero": true
@@ -576,7 +576,7 @@
     {
       "name": "concat_1_y",
       "type": "band",
-      "domain": {"data": "data_0", "field": "weather", "sort": true},
+      "domain": {"data": "data_1", "field": "weather", "sort": true},
       "range": {"step": {"signal": "concat_1_y_step"}},
       "paddingInner": 0.1,
       "paddingOuter": 0.05

--- a/src/compile/data/dataflow.ts
+++ b/src/compile/data/dataflow.ts
@@ -116,11 +116,14 @@ export abstract class DataFlowNode {
     // remove old links
     this._children = []; // equivalent to removing every child link one by one
     parent.removeChild(this);
-    parent.parent.removeChild(parent);
+    const loc = parent.parent.removeChild(parent);
 
     // swap two nodes
-    this.parent = newParent;
-    parent.parent = this;
+    this._parent = newParent;
+    newParent.addChild(this, loc);
+
+    parent._parent = this
+    this.addChild(parent, loc);
   }
 }
 

--- a/src/compile/data/dataflow.ts
+++ b/src/compile/data/dataflow.ts
@@ -122,7 +122,7 @@ export abstract class DataFlowNode {
     this._parent = newParent;
     newParent.addChild(this, loc);
 
-    parent._parent = this
+    parent._parent = this;
     this.addChild(parent, loc);
   }
 }

--- a/src/compile/data/dataflow.ts
+++ b/src/compile/data/dataflow.ts
@@ -118,7 +118,7 @@ export abstract class DataFlowNode {
     parent.removeChild(this);
     const loc = parent.parent.removeChild(parent);
 
-    // swap two nodes
+    // swap two nodes but maintain order in children
     this._parent = newParent;
     newParent.addChild(this, loc);
 

--- a/src/compile/data/dataflow.ts
+++ b/src/compile/data/dataflow.ts
@@ -122,8 +122,7 @@ export abstract class DataFlowNode {
     this._parent = newParent;
     newParent.addChild(this, loc);
 
-    parent._parent = this;
-    this.addChild(parent, loc);
+    parent.parent = this;
   }
 }
 


### PR DESCRIPTION
This PR closes #4680 and #5475.  It helps with part of #5261.

The root cause of the problem is within the [moveFacetDown map](https://github.com/vega/vega-lite/blob/ac00c92b01aa702be251d89d463f2df53e612e8b/src/compile/data/optimize.ts#L98). 

The problem occurs because the `swapWithParent` method does not preserve the order of branches in the tree, so the main [map](https://github.com/vega/vega-lite/blob/ac00c92b01aa702be251d89d463f2df53e612e8b/src/compile/data/optimize.ts#L98) iterates incorrectly.  It expects to be able to iterate over each branch in turn, but when the order changes, this fails.

I have used the following spec to find the bug.

<details>
<summary>Example buggy spec</summary>

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "data": {
    "values": [
      { "metric_1": 10, "metric_2": 1, "y_value": 0.2, "row_group": false },
      { "metric_1": 11, "metric_2": 1, "y_value": 0.3, "row_group": false },
      { "metric_1": 12, "metric_2": 2, "y_value": 0.1, "row_group": false },
      { "metric_1": 13, "metric_2": 2, "y_value": 0.8, "row_group": false },
      { "metric_1": 12, "metric_2": 2, "y_value": 0.7, "row_group": true },
      { "metric_1": 13, "metric_2": 3, "y_value": 0.2, "row_group": true },
      { "metric_1": 14, "metric_2": 3, "y_value": 0.4, "row_group": true },
      { "metric_1": 15, "metric_2": 4, "y_value": 0.9, "row_group": true } ]
  },
  "hconcat": [
    {
      "encoding": {
        "row": {
          "field": "row_group",
          "type": "nominal"
        },
        "x": {
          "field": "metric_2",
          "type": "quantitative"
        },
        "y": {
          "field": "y_value",
          "title": null,
          "type": "quantitative"
        }
      },
      "mark": "bar"
    },
    {
      "encoding": {
        "row": {
          "field": "row_group",
          "type": "nominal"
        },
        "x": {
          "field": "metric_1",
          "type": "quantitative"
        },
        "y": {
          "field": "y_value",
          "title": null,
          "type": "quantitative"
        }
      },
      "mark": "bar"
    }
  ]
}

```

</details>


To be more specific, with this example spec, in `optimize.ts` immediately prior to [the `moveFacetDown` map](https://github.com/vega/vega-lite/blob/ac00c92b01aa702be251d89d463f2df53e612e8b/src/compile/data/optimize.ts#L98), `data.sources` is a symmetrical tree like:

```
Source
├── OutputNode
│   └── FacetNode
│       └── FilterInvalidNode
│           └── OutputNode
└── OutputNode
    └── FacetNode
        └── FilterInvalidNode
            └── OutputNode
```

However, following the map, the data structure has become asymmetrical.  This is because `swapWithParent` does not preserve the order of the children.  But we're iterating recursively over these children, so the recursive map becomes asymetrical.  

The order fails to be preserved because when you remove a child and then re-add it [here](https://github.com/vega/vega-lite/blob/ac00c92b01aa702be251d89d463f2df53e612e8b/src/compile/data/dataflow.ts#L119), its position in the array is not preserved.

I have tested this against the following specs which are reported as broken in #4680, with the following outputs, which look correct to me.

Grateful for any feedback on the fix.   I've run tests locally, but I'm not sure I understand [this] about adding a `GH_PAT`.  Is that saying that, in my fork, I need to add a secret containing a personal access token that has only `public_repo` permissions?  I didn't want to do that without checking, because of potential security implications.


Specs:

<details>
<summary>My example used to bugfix</summary>

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "data": {
    "values": [
      { "metric_1": 10, "metric_2": 1, "y_value": 0.2, "row_group": false },
      { "metric_1": 11, "metric_2": 1, "y_value": 0.3, "row_group": false },
      { "metric_1": 12, "metric_2": 2, "y_value": 0.1, "row_group": false },
      { "metric_1": 13, "metric_2": 2, "y_value": 0.8, "row_group": false },
      { "metric_1": 12, "metric_2": 2, "y_value": 0.7, "row_group": true },
      { "metric_1": 13, "metric_2": 3, "y_value": 0.2, "row_group": true },
      { "metric_1": 14, "metric_2": 3, "y_value": 0.4, "row_group": true },
      { "metric_1": 15, "metric_2": 4, "y_value": 0.9, "row_group": true } ]
  },
  "hconcat": [
    {
      "encoding": {
        "row": {
          "field": "row_group",
          "type": "nominal"
        },
        "x": {
          "field": "metric_2",
          "type": "quantitative"
        },
        "y": {
          "field": "y_value",
          "title": null,
          "type": "quantitative"
        }
      },
      "mark": "bar"
    },
    {
      "encoding": {
        "row": {
          "field": "row_group",
          "type": "nominal"
        },
        "x": {
          "field": "metric_1",
          "type": "quantitative"
        },
        "y": {
          "field": "y_value",
          "title": null,
          "type": "quantitative"
        }
      },
      "mark": "bar"
    }
  ]
}
```

![robin_example](https://user-images.githubusercontent.com/2608005/128316086-32aaaffa-712d-4a28-b24f-fed7ee3ce13b.png)
</details>


<details>
<summary>cpennington example</summary>

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "data": {
    "values": [
      {
        "c1": "Argagarg",
        "c2": "Argagarg",
        "mu": "2-8",
        "win_chance": 0.2,
        "p": 0.005293199778439004,
        "type": "global",
        "cum_p": 0.49384000294641295
      },
      {
        "c1": "Argagarg",
        "c2": "BBB",
        "mu": "2.5-7.5",
        "win_chance": 0.25,
        "p": 0.006317783956548739,
        "type": "global",
        "cum_p": 0.4182141361083573
      },
      {
        "c1": "BBB",
        "c2": "Argagarg",
        "mu": "4-6",
        "win_chance": 0.39999999999999997,
        "p": 0.00599613286508726,
        "type": "global",
        "cum_p": 0.5810908430205882
      },
      {
        "c1": "BBB",
        "c2": "BBB",
        "mu": "2.5-7.5",
        "win_chance": 0.25,
        "p": 0.017437015257325033,
        "type": "global",
        "cum_p": 0.5011573865688447
      }
    ]
  },
  "transform": [
    {
      "joinaggregate": [
        {
          "op": "mean",
          "field": "cum_p",
          "as": "c1_avg_cum_p"
        }
      ],
      "groupby": [
        "c1"
      ]
    }
  ],
  "hconcat": [
    {
      "facet": {
        "row": {
          "field": "c1",
          "type": "ordinal"
        },
        "column": {
          "field": "c2",
          "type": "ordinal"
        }
      },
      "spec": {
        "mark": {
          "type": "bar"
        },
        "encoding": {
          "x": {
            "field": "mu",
            "type": "ordinal"
          },
          "y": {
            "field": "p",
            "type": "quantitative"
          },
          "color": {
            "field": "cum_p",
            "type": "quantitative"
          }
        }
      }
    },
    {
      "facet": {
        "row": {
          "field": "c1",
          "type": "ordinal"
        }
      },
      "spec": {
        "mark": {
          "type": "bar"
        },
        "encoding": {
          "x": {
            "field": "mu",
            "type": "ordinal"
          },
          "y": {
            "aggregate": "mean",
            "field": "p",
            "type": "quantitative"
          },
          "color": {
            "aggregate": "mean",
            "field": "c1_avg_cum_p",
            "type": "quantitative"
          }
        }
      }
    }
  ]
}
```

![cpennington_example](https://user-images.githubusercontent.com/2608005/128316070-5f4b800c-bc45-4647-8822-ac7f44f7c00e.png)


</details>



<details>
<summary>sh4pe example</summary>

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
  "data": {
    "values": [
      {
        "a": 0.1,
        "x": -5,
        "b": 0.1,
        "date": "2019-12-01T00:00:00"
      },
      {
        "a": 0.1,
        "x": 5,
        "b": 0.2,
        "date": "2019-12-01T00:00:00"
      },
      {
        "a": 0.1,
        "x": -55,
        "b": 0.1,
        "date": "2019-12-03T00:00:00"
      },
      {
        "a": 0,
        "x": -45,
        "b": 0.1,
        "date": "2019-12-03T00:00:00"
      }
    ]
  },
  "hconcat": [
    {
      "facet": {
        "column": {
          "field": "date",
          "type": "ordinal"
        }
      },
      "spec": {
        "encoding": {
          "x": {
            "field": "x",
            "type": "quantitative"
          },
          "y": {
            "field": "a",
            "type": "quantitative"
          }
        },
        "mark": "bar"
      }
    },
    {
      "facet": {
        "column": {
          "field": "date",
          "type": "ordinal"
        }
      },
      "spec": {
        "encoding": {
          "x": {
            "field": "x",
            "type": "quantitative"
          },
          "y": {
            "field": "b",
            "type": "quantitative"
          }
        },
        "mark": "bar"
      }
    }
  ]
}
```

![sh4pe_example](https://user-images.githubusercontent.com/2608005/128316107-a11132d8-da26-46ec-becd-5eadf633e58a.png)


</details>






<details>
<summary>Isue 5475 example</summary>

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
  "data": {"values": [{"a": "A", "b": 28}, {"a": "B", "b": 55}]},
  "vconcat": [
    {
      "title": "Title for first row",
      "facet": {"field": "a", "type": "ordinal"},
      "spec": {
        "mark": "bar",
        "encoding": {"y": {"field": "b", "type": "quantitative"}}
      }
    },
    {
      "title": "Title for second row",
      "facet": {"field": "a", "type": "ordinal"},
      "spec": {
        "mark": "bar",
        "encoding": {"y": {"field": "b", "type": "quantitative"}}
      }
    }
  ]
}
```

![5475_example](https://user-images.githubusercontent.com/2608005/128317722-95a475f6-3110-4741-8742-f59b7c82d904.png)



</details>




<details>
<summary>Isue 5261 example</summary>

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "data": {"url": "data/cars.json"},
  "vconcat": [
    {
      "facet": {"field": "Origin", "type": "nominal"},
      "spec": {
        "mark": "point",
        "encoding": {
          "x": {"field": "Horsepower", "type": "quantitative"},
          "y": {"field": "Miles_per_Gallon", "type": "quantitative"}
        }
      }
    },
    {
      "facet": {"field": "Origin", "type": "nominal"},
      "spec": {
        "mark": "tick",
        "encoding": {
          "x": {"field": "Horsepower", "type": "quantitative"}
        }
      }
    }
  ]
}
```

![5261_example](https://user-images.githubusercontent.com/2608005/128317746-40650829-a279-435c-aa66-3a28044fa2c8.png)



</details>
