### PR TITLE
refactor: rectBinPosition(), rectPosition()

### DIFF
--- a/src/compile/mark/arc.ts
+++ b/src/compile/mark/arc.ts
@@ -18,8 +18,8 @@ export const arc: MarkCompiler = {
       ...encode.pointPosition('y', model, {defaultPos: 'mid'}),
 
       // arcs are rectangles in polar coordinates
-      ...encode.rectPosition(model, 'radius', 'arc'),
-      ...encode.rectPosition(model, 'theta', 'arc')
+      ...encode.rectPosition(model, 'radius'),
+      ...encode.rectPosition(model, 'theta')
     };
   }
 };

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -14,8 +14,8 @@ export const bar: MarkCompiler = {
         size: 'ignore',
         theta: 'ignore'
       }),
-      ...encode.rectPosition(model, 'x', 'bar'),
-      ...encode.rectPosition(model, 'y', 'bar')
+      ...encode.rectPosition(model, 'x'),
+      ...encode.rectPosition(model, 'y')
     };
   }
 };

--- a/src/compile/mark/encode/index.ts
+++ b/src/compile/mark/encode/index.ts
@@ -1,3 +1,4 @@
+export {aria} from './aria';
 export {baseEncodeEntry} from './base';
 export {color} from './color';
 export {wrapCondition} from './conditional';
@@ -5,7 +6,7 @@ export {defined, valueIfDefined} from './defined';
 export {nonPosition} from './nonposition';
 export {pointPosition} from './position-point';
 export {pointOrRangePosition, rangePosition} from './position-range';
-export {rectBinPosition, rectPosition} from './position-rect';
+export {rectPosition} from './position-rect';
 export {text} from './text';
 export {tooltip, tooltipRefForEncoding} from './tooltip';
-export {aria} from './aria';
+

--- a/src/compile/mark/encode/index.ts
+++ b/src/compile/mark/encode/index.ts
@@ -9,4 +9,3 @@ export {pointOrRangePosition, rangePosition} from './position-range';
 export {rectPosition} from './position-rect';
 export {text} from './text';
 export {tooltip, tooltipRefForEncoding} from './tooltip';
-

--- a/src/compile/mark/encode/position-rect.ts
+++ b/src/compile/mark/encode/position-rect.ts
@@ -27,10 +27,7 @@ import {pointPositionDefaultRef} from './position-point';
 import {rangePosition} from './position-range';
 import * as ref from './valueref';
 
-export function rectPosition(
-  model: UnitModel,
-  channel: 'x' | 'y' | 'theta' | 'radius'
-): VgEncodeEntry {
+export function rectPosition(model: UnitModel, channel: 'x' | 'y' | 'theta' | 'radius'): VgEncodeEntry {
   const {config, encoding, markDef} = model;
   const mark = markDef.type;
 
@@ -55,7 +52,6 @@ export function rectPosition(
     !(hasSizeDef && !isRelativeBandSize(hasSizeDef)) &&
     !hasDiscreteDomain(scaleType)
   ) {
-
     return rectBinPosition({
       fieldDef: channelDef,
       fieldDef2: channelDef2,
@@ -173,10 +169,10 @@ function positionAndSize(
     bandPosition: center
       ? 0.5
       : isSignalRef(bandSize)
-        ? {signal: `(1-${bandSize})/2`}
-        : isRelativeBandSize(bandSize)
-          ? (1 - bandSize.band) / 2
-          : 0
+      ? {signal: `(1-${bandSize})/2`}
+      : isRelativeBandSize(bandSize)
+      ? (1 - bandSize.band) / 2
+      : 0
   });
 
   if (vgSizeChannel) {
@@ -194,9 +190,9 @@ function positionAndSize(
       [vgChannel2]: isArray(posRef)
         ? [posRef[0], {...posRef[1], offset: sizeOffset}]
         : {
-          ...posRef,
-          offset: sizeOffset
-        }
+            ...posRef,
+            offset: sizeOffset
+          }
     };
   }
 }
@@ -255,7 +251,7 @@ function rectBinPosition({
   const axis = model.component.axes[channel]?.[0];
   const axisTranslate = axis?.get('translate') ?? 0.5; // vega default is 0.5
 
-  const spacing = isXorY(channel) ? (getMarkPropOrConfig('binSpacing', markDef, config) ?? 0) : 0;
+  const spacing = isXorY(channel) ? getMarkPropOrConfig('binSpacing', markDef, config) ?? 0 : 0;
 
   const channel2 = getSecondaryRangeChannel(channel);
   const vgChannel = getVgPositionChannel(channel);
@@ -266,8 +262,8 @@ function rectBinPosition({
   const bandPosition = isSignalRef(bandSize)
     ? {signal: `(1-${bandSize.signal})/2`}
     : isRelativeBandSize(bandSize)
-      ? (1 - bandSize.band) / 2
-      : 0.5;
+    ? (1 - bandSize.band) / 2
+    : 0.5;
 
   if (isBinning(fieldDef.bin) || fieldDef.timeUnit) {
     return {

--- a/src/compile/mark/image.ts
+++ b/src/compile/mark/image.ts
@@ -14,8 +14,8 @@ export const image: MarkCompiler = {
         size: 'ignore',
         theta: 'ignore'
       }),
-      ...encode.rectPosition(model, 'x', 'image'),
-      ...encode.rectPosition(model, 'y', 'image'),
+      ...encode.rectPosition(model, 'x'),
+      ...encode.rectPosition(model, 'y'),
       ...encode.text(model, 'url')
     };
   }

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -14,8 +14,8 @@ export const rect: MarkCompiler = {
         size: 'ignore',
         theta: 'ignore'
       }),
-      ...encode.rectPosition(model, 'x', 'rect'),
-      ...encode.rectPosition(model, 'y', 'rect')
+      ...encode.rectPosition(model, 'x'),
+      ...encode.rectPosition(model, 'y')
     };
   }
 };

--- a/test/compile/mark/encode/position-rect.test.ts
+++ b/test/compile/mark/encode/position-rect.test.ts
@@ -1,24 +1,25 @@
-import {TypedFieldDef} from '../../../../src/channeldef';
-import {rectBinPosition} from '../../../../src/compile/mark/encode';
-import {defaultConfig} from '../../../../src/config';
+import {rectPosition} from '../../../../src/compile/mark/encode/position-rect';
 import * as log from '../../../../src/log';
+import {parseUnitModelWithScaleAndLayoutSize} from '../../../util';
 
 describe('compile/mark/encode/position-rect', () => {
-  const config = defaultConfig;
-  describe('rectBinPosition', () => {
+  describe('rectPosition', () => {
     it('produces correct x-mixins for signal reverse', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: true, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'x',
-        bandSize: 1,
-        scaleName: undefined,
-        reverse: {signal: 'r'},
-        axisTranslate: 0.5, // Vega default
-        spacing: 1,
-        markDef: {type: 'bar'},
-        config
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: 'bar',
+        encoding: {
+          x: {
+            bin: true,
+            field: 'x',
+            type: 'quantitative',
+            scale: {reverse: {signal: 'r'}}
+          }
+        }
       });
+
+      const props = rectPosition(model, 'x');
+      expect(props.x[0]).toEqual({test: "!isValid(datum[\"bin_maxbins_10_x\"]) || !isFinite(+datum[\"bin_maxbins_10_x\"])", value: 0});
       expect(props.x[1].offset).toEqual({
         signal: '0.5 + (r ? -1 : 1) * -0.5'
       });
@@ -28,18 +29,21 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct x-mixins for binned data with step and start field, without end field', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: {binned: true, step: 2}, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'x',
-        bandSize: 1,
-        scaleName: 'x',
-        reverse: false,
-        axisTranslate: 0.5, // Vega default
-        spacing: 1,
-        markDef: {type: 'bar'},
-        config
+
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: 'bar',
+        encoding: {
+          x: {
+            bin: {binned: true, step: 2},
+            field: 'x',
+            type: 'quantitative'
+          }
+        }
       });
+
+      const props = rectPosition(model, 'x');
+
       expect(props.x).toEqual({
         signal: 'scale("x", datum["x"] + 2)',
         offset: 0
@@ -47,18 +51,20 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct y-mixins for signal reverse', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: true, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'y',
-        bandSize: 1,
-        scaleName: undefined,
-        axisTranslate: 0.5, // Vega default
-        reverse: {signal: 'r'},
-        spacing: 1,
-        markDef: {type: 'bar'},
-        config
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: 'bar',
+        encoding: {
+          y: {
+            bin: true,
+            field: 'x',
+            type: 'quantitative',
+            scale: {reverse: {signal: 'r'}}
+          }
+        }
       });
+
+      const props = rectPosition(model, 'y');
       expect(props.y2[1].offset).toEqual({
         signal: '0.5 + (r ? -1 : 1) * -0.5'
       });
@@ -67,19 +73,22 @@ describe('compile/mark/encode/position-rect', () => {
       });
     });
 
-    it('produces correct x-mixins for signal reverse (different values)', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: true, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'x',
-        bandSize: 1,
-        scaleName: undefined,
-        axisTranslate: 0.5, // Vega default
-        reverse: {signal: 'r'},
-        spacing: 2,
-        markDef: {type: 'bar'},
-        config
+    it('produces correct x-mixins for signal reverse with custom spacing', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: {type: 'bar', binSpacing: 2},
+        encoding: {
+          x: {
+            bin: true,
+            field: 'x',
+            type: 'quantitative',
+            scale: {reverse: {signal: 'r'}}
+          }
+        }
       });
+
+      const props = rectPosition(model, 'x');
+
       expect(props.x[1].offset).toEqual({
         signal: '0.5 + (r ? -1 : 1) * -1'
       });
@@ -89,18 +98,21 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct y-mixins for signal reverse with different spacing', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: true, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'y',
-        bandSize: 1,
-        scaleName: undefined,
-        axisTranslate: 0.5, // Vega default
-        reverse: {signal: 'r'},
-        spacing: 2,
-        markDef: {type: 'bar'},
-        config
+
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: {type: 'bar', binSpacing: 2},
+        encoding: {
+          y: {
+            bin: true,
+            field: 'x',
+            type: 'quantitative',
+            scale: {reverse: {signal: 'r'}}
+          }
+        }
       });
+
+      const props = rectPosition(model, 'y');
       expect(props.y2[1].offset).toEqual({
         signal: '0.5 + (r ? -1 : 1) * -1'
       });
@@ -112,17 +124,21 @@ describe('compile/mark/encode/position-rect', () => {
     it(
       'generates warning for invalid binned spec without x2',
       log.wrap(logger => {
-        const fieldDef: TypedFieldDef<string> = {field: 'bin_start', bin: 'binned', type: 'quantitative'};
-        const props = rectBinPosition({
-          fieldDef,
-          channel: 'x',
-          bandSize: 1,
-          scaleName: undefined,
-          axisTranslate: 0.5, // Vega default
-          reverse: false,
-          markDef: {type: 'bar'},
-          config
+
+        const model = parseUnitModelWithScaleAndLayoutSize({
+          data: {values: []},
+          mark: {type: 'bar', binSpacing: 2},
+          encoding: {
+            x: {
+              bin: 'binned',
+              field: 'x',
+              type: 'quantitative',
+              scale: {reverse: {signal: 'r'}}
+            }
+          }
         });
+
+        const props = rectPosition(model, 'x');
         expect(props).not.toBeDefined();
         expect(logger.warns[0]).toEqual(log.message.channelRequiredForBinned('x2'));
       })
@@ -131,35 +147,41 @@ describe('compile/mark/encode/position-rect', () => {
     it(
       'generates warning for invalid binned spec without y2',
       log.wrap(logger => {
-        const fieldDef: TypedFieldDef<string> = {field: 'bin_start', bin: 'binned', type: 'quantitative'};
-        const props = rectBinPosition({
-          fieldDef,
-          channel: 'y',
-          bandSize: 1,
-          scaleName: undefined,
-          axisTranslate: 0.5, // Vega default
-          reverse: false,
-          markDef: {type: 'bar'},
-          config
+        const model = parseUnitModelWithScaleAndLayoutSize({
+          data: {values: []},
+          mark: {type: 'bar', binSpacing: 2},
+          encoding: {
+            y: {
+              bin: 'binned',
+              field: 'y',
+              type: 'quantitative',
+              scale: {reverse: {signal: 'r'}}
+            }
+          }
         });
+
+        const props = rectPosition(model, 'y');
         expect(props).not.toBeDefined();
         expect(logger.warns[0]).toEqual(log.message.channelRequiredForBinned('y2'));
       })
     );
 
     it('produces correct x-mixins for signal translate', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: true, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'x',
-        bandSize: 1,
-        scaleName: undefined,
-        axisTranslate: {signal: 't'}, // Vega default
-        reverse: false,
-        spacing: 1,
-        markDef: {type: 'bar'},
-        config
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: 'bar',
+        encoding: {
+          x: {
+            bin: true,
+            field: 'x',
+            type: 'quantitative',
+            axis: {translate: {signal: 't'}}
+          }
+        }
       });
+      model.parseAxesAndHeaders();
+
+      const props = rectPosition(model, 'x');
       expect(props.x[1].offset).toEqual({
         signal: 't + -0.5'
       });
@@ -169,18 +191,23 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct x-mixins for signal translate, signal reverse, signal offset', () => {
-      const fieldDef: TypedFieldDef<string> = {field: 'x', bin: true, type: 'quantitative'};
-      const props = rectBinPosition({
-        fieldDef,
-        channel: 'x',
-        bandSize: 1,
-        scaleName: undefined,
-        axisTranslate: {signal: 't'}, // Vega default
-        reverse: {signal: 'r'},
-        spacing: 1,
-        markDef: {type: 'bar', xOffset: {signal: 'o'}},
-        config
+
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {values: []},
+        mark: {type: 'bar', xOffset: {signal: 'o'}},
+        encoding: {
+          x: {
+            bin: true,
+            field: 'x',
+            type: 'quantitative',
+            scale: {reverse: {signal: 'r'}},
+            axis: {translate: {signal: 't'}}
+          }
+        }
       });
+      model.parseAxesAndHeaders();
+
+      const props = rectPosition(model, 'x');
       expect(props.x[1].offset).toEqual({
         signal: 't + (r ? -1 : 1) * (o + -0.5)'
       });

--- a/test/compile/mark/encode/position-rect.test.ts
+++ b/test/compile/mark/encode/position-rect.test.ts
@@ -19,7 +19,10 @@ describe('compile/mark/encode/position-rect', () => {
       });
 
       const props = rectPosition(model, 'x');
-      expect(props.x[0]).toEqual({test: "!isValid(datum[\"bin_maxbins_10_x\"]) || !isFinite(+datum[\"bin_maxbins_10_x\"])", value: 0});
+      expect(props.x[0]).toEqual({
+        test: '!isValid(datum["bin_maxbins_10_x"]) || !isFinite(+datum["bin_maxbins_10_x"])',
+        value: 0
+      });
       expect(props.x[1].offset).toEqual({
         signal: '0.5 + (r ? -1 : 1) * -0.5'
       });
@@ -29,7 +32,6 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct x-mixins for binned data with step and start field, without end field', () => {
-
       const model = parseUnitModelWithScaleAndLayoutSize({
         data: {values: []},
         mark: 'bar',
@@ -98,7 +100,6 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct y-mixins for signal reverse with different spacing', () => {
-
       const model = parseUnitModelWithScaleAndLayoutSize({
         data: {values: []},
         mark: {type: 'bar', binSpacing: 2},
@@ -124,7 +125,6 @@ describe('compile/mark/encode/position-rect', () => {
     it(
       'generates warning for invalid binned spec without x2',
       log.wrap(logger => {
-
         const model = parseUnitModelWithScaleAndLayoutSize({
           data: {values: []},
           mark: {type: 'bar', binSpacing: 2},
@@ -191,7 +191,6 @@ describe('compile/mark/encode/position-rect', () => {
     });
 
     it('produces correct x-mixins for signal translate, signal reverse, signal offset', () => {
-
       const model = parseUnitModelWithScaleAndLayoutSize({
         data: {values: []},
         mark: {type: 'bar', xOffset: {signal: 'o'}},


### PR DESCRIPTION
This PR makes:
- rectBinPosition private and only requires a few parameters.
  - also re-write related tests by calling the broader `rectPosition` -- the tests should be now much more understandable 
- remove unnecessary `mark` param from `rectPosition`. 


