### PR TITLE
docs: fix types page title

### DIFF
--- a/site/docs/types.md
+++ b/site/docs/types.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 menu: docs
-title: Parameter Types
+title: Property Types
 permalink: /docs/types.html
 ---
 


### PR DESCRIPTION
Seems like the title of this page should be "Property Types", not "Parameter Types". When I stumbled upon it, I initially confused it for a list of available (Vega Lite parameters)[https://vega.github.io/vega-lite/docs/parameter.html]. FWIW: A nearly [identical page in Vega's docs](https://vega.github.io/vega/docs/types/) is also currently titled "Parameter Types".
