### PR TITLE
ci: cache node dependencies, only check one node version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT || github.token }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
 
@@ -54,6 +59,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_PAT || github.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.4.1
+        with:
+          cache: 'yarn'
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,14 @@ jobs:
   test-matrix:
     name: Node
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [12, 14, 16]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node ${{ matrix.node }}
+      - name: Setup Node
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: ${{ matrix.node }}
+          cache: 'yarn'
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
@@ -41,6 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup Node
+        uses: actions/setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
 
@@ -56,6 +58,11 @@ jobs:
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.4.1
+        with:
+          cache: 'yarn'
 
       - name: Install extra dependencies for Puppeteer
         run: sudo apt-get install libgbm1
@@ -90,6 +97,11 @@ jobs:
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.4.1
+        with:
+          cache: 'yarn'
 
       - name: Build
         run: yarn build:only


### PR DESCRIPTION
I don't remember when we ever had an issue with a particular node version. Since we run mostly in the browser, I think we can reduce the test complexity. I also added yarn caching for faster tests. 

This reduces test times. For example, the node tests are 15s faster. 