### PR TITLE
docs(ecosystem): add Datapane library to ecosystem

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -26,7 +26,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [Ivy](http://ivy-vis.netlify.app/), an Integrated Visualization Editing environment that wraps Vega-Lite (among other declarative visualization grammars) as templates to facilitate reuse, exploration, and opportunistic creation. Includes an in-app reproduction of [Polestar](https://github.com/vega/polestar).
 - [Deneb](https://deneb-viz.github.io), a Power BI custom visual with an editor for Vega-Lite or Vega specifications.
 - [VizLinter](https://vizlinter.idvxlab.com/), an online editor that detects and fixes encoding issues based on vega-lite-linter.
-- [Datapane](https://github.com/datapane/datapane), a Python framework for building interactive reports from open-source visualization formats such as vega-lite
+- [Datapane](https://github.com/datapane/datapane), a Python framework for building interactive reports from open-source visualization formats such as Vega-Lite.
 
 ## Plug-ins for Vega-Lite
 

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -26,6 +26,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [Ivy](http://ivy-vis.netlify.app/), an Integrated Visualization Editing environment that wraps Vega-Lite (among other declarative visualization grammars) as templates to facilitate reuse, exploration, and opportunistic creation. Includes an in-app reproduction of [Polestar](https://github.com/vega/polestar).
 - [Deneb](https://deneb-viz.github.io), a Power BI custom visual with an editor for Vega-Lite or Vega specifications.
 - [VizLinter](https://vizlinter.idvxlab.com/), an online editor that detects and fixes encoding issues based on vega-lite-linter.
+- [Datapane](https://github.com/datapane/datapane), a Python framework for building interactive reports from open-source visualization formats such as vega-lite
 
 ## Plug-ins for Vega-Lite
 


### PR DESCRIPTION
This adds Datapane's GitHub repo to the ecosystem. I put it in "Tools for Authoring Vega-Lite Visualizations" section, based on the other similar libraries there, but let me know if this is not the appropriate category.

Thanks!
