### PR TITLE
fix: make es2020 bundle es5

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -68,10 +68,7 @@ const outputs = [
         babelHelpers: 'bundled',
         presets: [
           [
-            '@babel/env',
-            {
-              targets: 'defaults and not IE 11'
-            }
+            '@babel/preset-env',
           ],
           '@babel/typescript'
         ]


### PR DESCRIPTION
closes #7759

This will help solve issues with importing `vega-lite` from `node_modules`. It will avoid the need to add special build configuration to your environment (eg NextJS, Create React App, Webpack or Rollup) to transpile the lib from `node_modules`. For example, it will help with https://github.com/vega/react-vega/issues/367
