### PR TITLE
Proposal to make the vega lite examples page polyglot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test/log
 test/log/difflist.json
 yarn-debug.log*
 yarn-error.log*
+*.edn

--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -46,4 +46,4 @@ ls examples/compiled/*.svg | parallel --no-notice --plus --halt 1 "[ -f examples
 ls examples/compiled/*.png | parallel --no-notice --plus --halt 1 "[ -f examples/specs/{/..}.vl.json ] || rm -f examples/compiled/{/..}.png"
 
 #generate edn files
-ls examples/specs/*.vl.json | parallel "cat {} | jet --from json --to edn --keywordize > {.}.edn"
+ls examples/specs/*.vl.json | parallel "cat {} | jet --from json --to edn --keywordize | puget --opts '{:map-delimiter \"\" :print-color false}' > {.}.edn"

--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -45,4 +45,5 @@ ls examples/compiled/*.svg | parallel --no-notice --plus --halt 1 "[ -f examples
 
 ls examples/compiled/*.png | parallel --no-notice --plus --halt 1 "[ -f examples/specs/{/..}.vl.json ] || rm -f examples/compiled/{/..}.png"
 
-
+#generate edn files
+ls examples/specs/*.vl.json | parallel "cat {} | jet --from json --to edn --keywordize > {.}.edn"

--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -2,12 +2,78 @@
 
 <div id="{{ id }}"></div>
 
+<style>
+/* Style the list */
+ul.tab {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    border: 1px solid #ccc;
+    background-color: #f1f1f1;
+}
+
+/* Float the list items side by side */
+ul.tab li {float: left;}
+
+/* Style the links inside the list items */
+ul.tab li a {
+    display: inline-block;
+    color: black;
+    text-align: center;
+    padding: 14px 16px;
+    text-decoration: none;
+    transition: 0.3s;
+    font-size: 17px;
+}
+
+/* Change background color of links on hover */
+ul.tab li a:hover {background-color: #ddd;}
+
+/* Create an active/current tablink class */
+ul.tab li a:focus, .active {background-color: #ccc;}
+
+/* Style the tab content */
+.tabcontent {
+    display: none;
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    border-top: none;
+}
+</style>
+
+
 <script>
     window.onload = function() {
       const spec = {% include_relative {{ include.spec }}.vl.json %};
 
-      embedExample('#{{id}}', spec, false);
+        embedExample('#{{id}}', spec, false);
+        document.getElementById('Json-button').click()  
   }
+</script>
+
+<script>
+function openLanguage(evt, languageName) {
+    // Declare all variables
+    var i, tabcontent, tablinks;
+
+    // Get all elements with class="tabcontent" and hide them
+    tabcontent = document.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
+
+    // Get all elements with class="tablinks" and remove the class "active"
+    tablinks = document.getElementsByClassName("tablinks");
+    for (i = 0; i < tabcontent.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
+    }
+
+    // Show the current tab, and add an "active" class to the link that opened the tab
+    document.getElementById(languageName).style.display = "block";
+    evt.currentTarget.className += " active";
+}
+
 </script>
 
 <a href="https://vega.github.io/editor/#/examples/vega-lite/{{ include.spec }}">
@@ -16,7 +82,23 @@
 
 <h3 id="spec">Vega-Lite JSON Specification</h3>
 
+
 {: .example-spec}
 ```json
-{% include_relative {{ include.spec }}.vl.json %}
+ {% include_relative {{ include.spec }}.vl.json %}
 ```
+
+
+<ul class="tab">
+  <li><a id="Json-button" href="#" class="tablinks" onclick="openLanguage(event, 'Json')">JSON</a></li>
+  <li><a href="#" class="tablinks" onclick="openLanguage(event, 'EDN')">EDN</a></li>
+</ul>
+
+<pre id="Json" class="tabcontent">
+
+{% include_relative {{ include.spec }}.vl.json %}
+  </pre>
+
+<pre id="EDN" class="tabcontent">
+{% include_relative {{ include.spec }}.vl.edn %}
+</pre>


### PR DESCRIPTION
This is a very early draft proposal to make the vega lite examples page polyglot.
(see discussion here: https://github.com/vega/vega-lite/issues/7758)
The PR contains:

- change to site/_includes/example.html to show the examples in different languages in a tabbed view
- all vega lite spec files in EDN format (mostly used in Clojure)  They are autogenerated from all current examples json specs
   (the auto generation process has been started from file site/_data/examples.json
- empty files for ".R" ".python" ".hanami"