### PR TITLE
feat: smaller bundles by making vega libraries external

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
+    "@rollup/plugin-alias": "^3.1.8",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
+import alias from '@rollup/plugin-alias';
 import bundleSize from 'rollup-plugin-bundle-size';
 import {terser} from 'rollup-plugin-terser';
 import pkg from './package.json';
@@ -31,9 +32,6 @@ export function debugImports() {
 const extensions = ['.js', '.ts'];
 
 const globals = {
-  'vega-event-selector': 'vega',
-  'vega-expression': 'vega',
-  'vega-util': 'vega',
   vega: 'vega'
 };
 
@@ -60,6 +58,13 @@ const outputs = [
     plugins: [
       disallowedImports(),
       debugImports(),
+      alias({
+        entries: {
+          'vega-event-selector': 'vega',
+          'vega-expression': 'vega',
+          'vega-util': 'vega'
+        }
+      }),
       resolve({browser: true, extensions}),
       commonjs(),
       json(),
@@ -78,7 +83,7 @@ const outputs = [
       }),
       bundleSize()
     ],
-    external: ['vega', 'vega-util']
+    external: ['vega']
   }
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,6 +1196,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@rollup/plugin-alias@^3.1.8":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.8.tgz#645fd84659e08d3d1b059408fcdf69c1dd435a6b"
+  integrity sha512-tf7HeSs/06wO2LPqKNY3Ckbvy0JRe7Jyn98bXnt/gfrxbe+AJucoNJlsEVi9sdgbQtXemjbakCpO/76JVgnHpA==
+  dependencies:
+    slash "^3.0.0"
+
 "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"


### PR DESCRIPTION
This makes all the Vega libraries external by renaming their imports to `Vega`. This works because Vega exports all the library functions at the top-level as well (done in https://github.com/vega/vega/pull/3154).

This pull request also fixes an issue where imports for external dependencies (namely Vega-util) were not renamed to Vega.

This patch is needed to support importing Vega-Lite as a stand alone bundle. See https://github.com/altair-viz/altair/pull/2517.  