### PR TITLE
feat: support isolatedModules

### DIFF
--- a/src/compositemark/index.ts
+++ b/src/compositemark/index.ts
@@ -25,9 +25,9 @@ import {
   normalizeErrorBar
 } from './errorbar';
 
-export {BoxPlotConfig} from './boxplot';
-export {ErrorBandConfigMixins} from './errorband';
-export {ErrorBarConfigMixins} from './errorbar';
+export type {BoxPlotConfig} from './boxplot';
+export type {ErrorBandConfigMixins} from './errorband';
+export type {ErrorBarConfigMixins} from './errorbar';
 
 export type CompositeMarkNormalizerRun = (
   spec: GenericUnitSpec<any, any>,

--- a/src/spec/base.ts
+++ b/src/spec/base.ts
@@ -12,7 +12,7 @@ import {LayoutAlign, RowCol} from '../vega.schema';
 import {isConcatSpec, isVConcatSpec} from './concat';
 import {isFacetMapping, isFacetSpec} from './facet';
 
-export {TopLevel} from './toplevel';
+export type {TopLevel} from './toplevel';
 
 /**
  * Common properties for all types of specification

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -14,20 +14,26 @@ import {RepeatSpec} from './repeat';
 import {TopLevel} from './toplevel';
 import {FacetedUnitSpec, GenericUnitSpec, NormalizedUnitSpec, TopLevelUnitSpec, UnitSpecWithFrame} from './unit';
 
-export {BaseSpec, LayoutSizeMixins} from './base';
-export {
+export type {BaseSpec, LayoutSizeMixins} from './base';
+export type {
   GenericHConcatSpec,
   GenericVConcatSpec,
+  NormalizedConcatSpec
+} from './concat';
+export {
   isAnyConcatSpec,
   isHConcatSpec,
   isVConcatSpec,
-  NormalizedConcatSpec
 } from './concat';
-export {GenericFacetSpec, isFacetSpec, NormalizedFacetSpec} from './facet';
-export {GenericLayerSpec, isLayerSpec, LayerSpec, NormalizedLayerSpec} from './layer';
-export {isRepeatSpec, RepeatSpec} from './repeat';
-export {TopLevel} from './toplevel';
-export {FacetedUnitSpec, GenericUnitSpec, isUnitSpec, NormalizedUnitSpec, UnitSpec} from './unit';
+export type {GenericFacetSpec, NormalizedFacetSpec} from './facet';
+export {isFacetSpec} from './facet';
+export type {GenericLayerSpec, LayerSpec, NormalizedLayerSpec} from './layer';
+export {isLayerSpec} from './layer';
+export type {RepeatSpec} from './repeat';
+export {isRepeatSpec} from './repeat';
+export type {TopLevel} from './toplevel';
+export type {FacetedUnitSpec, GenericUnitSpec, NormalizedUnitSpec, UnitSpec} from './unit';
+export {isUnitSpec} from './unit';
 
 /**
  * Any specification in Vega-Lite.

--- a/test/jest.overrides.ts
+++ b/test/jest.overrides.ts
@@ -11,3 +11,5 @@ console.warn = function (msg: string, msg2: string) {
   warn.apply(console, arguments);
   throw new Error(`${msg}: ${msg2} -- Please remove unnecessary errors or use log.wrap to consume reasonable errors`);
 };
+
+export {};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,8 @@
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "isolatedModules": true
   },
   "include": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "preserveConstEnums": true,
     "resolveJsonModule": true,
     "suppressImplicitAnyIndexErrors": true,
+    "isolatedModules": true,
     "lib": ["ESNext.Array", "DOM", "DOM.Iterable"],
     "noEmit": true
   },


### PR DESCRIPTION
Fixes #7869 

This makes it easier to use vega-lite in NextJS TypeScript projects, since NextJS uses SWC/Babel which require isolatedModules