### PR TITLE
fix: set binSuffix for defined channel

### DIFF
--- a/src/compile/mark/encode/defined.ts
+++ b/src/compile/mark/encode/defined.ts
@@ -30,7 +30,7 @@ function allFieldsInvalidPredicate(
     const scaleComponent = model.getScaleComponent(channel);
     if (scaleComponent) {
       const scaleType = scaleComponent.get('type');
-      const field = model.vgField(channel, {expr: 'datum'});
+      const field = model.vgField(channel, {expr: 'datum', binSuffix: model.stack?.impute ? 'mid' : undefined});
 
       // While discrete domain scales can handle invalid values, continuous scales can't.
       if (field && hasContinuousDomain(scaleType)) {

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -55,7 +55,7 @@ describe('Mark: Area', () => {
     });
 
     it('should use bin_mid for the defined check', () => {
-      expect(props.defined.signal.includes('bin_maxbins_10_IMDB_Rating_mid')).toBe(true);
+      expect(props.defined['signal']).toContain('bin_maxbins_10_IMDB_Rating_mid');
     });
   });
 

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -53,6 +53,10 @@ describe('Mark: Area', () => {
     it('should use bin_mid for x', () => {
       expect(props.x).toEqual({field: 'bin_maxbins_10_IMDB_Rating_mid', scale: 'x'});
     });
+
+    it('should use bin_mid for the defined check', () => {
+      expect(props.defined.signal.includes('bin_maxbins_10_IMDB_Rating_mid')).toBe(true);
+    });
   });
 
   describe('vertical area, with zero=false', () => {


### PR DESCRIPTION
This seems to be the change I want, but I'm not familiar with the code base. Should the `binSuffix` logic be consolidated? I saw it appears in at least one other place ([mark.ts](https://github.com/vega/vega-lite/blob/master/src/compile/mark/mark.ts#L297)).

Resolves #7930