### PR TITLE
docs: add ecosysem section for tools that scale Vega-Lite

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -28,6 +28,12 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [VizLinter](https://vizlinter.idvxlab.com/), an online editor that detects and fixes encoding issues based on vega-lite-linter.
 - [Datapane](https://github.com/datapane/datapane), a Python framework for building interactive reports from open-source visualization formats such as Vega-Lite.
 
+## Tools for Scaling Vega-Lite Visualizations
+
+- [altair-transform](https://github.com/altair-viz/altair-transform), a Python library for pre-evaluating Altair/Vega-Lite transforms with Pandas.
+- [ibis-vega-transform](https://github.com/Quansight/ibis-vega-transform), a Python library and JupyterLab extension for evaluating Altair/Vega-Lite transforms with external databases using [Ibis](https://ibis-project.org/).
+- <span class="octicon octicon-star"></span> [VegaFusion](https://vegafusion.io/), a Rust library and Python API that provides server-side acceleration for interactive Altair/Vega-Lite visualizations using [Apache Arrow](https://arrow.apache.org/) and [DataFusion](https://arrow.apache.org/datafusion/).
+
 ## Plug-ins for Vega-Lite
 
 - <span class="octicon octicon-star"></span> [Tooltips for Vega and Vega-Lite](https://github.com/vega/vega-lite-tooltip)

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -33,6 +33,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [altair-transform](https://github.com/altair-viz/altair-transform), a Python library for pre-evaluating Altair/Vega-Lite transforms with Pandas.
 - [ibis-vega-transform](https://github.com/Quansight/ibis-vega-transform), a Python library and JupyterLab extension for evaluating Altair/Vega-Lite transforms with external databases using [Ibis](https://ibis-project.org/).
 - <span class="octicon octicon-star"></span> [VegaFusion](https://vegafusion.io/), a Rust library and Python API that provides server-side acceleration for interactive Altair/Vega-Lite visualizations using [Apache Arrow](https://arrow.apache.org/) and [DataFusion](https://arrow.apache.org/datafusion/).
+- [Scalable Vega](https://github.com/vega/scalable-vega), a demo of how to scale Vega to large datasets by implementing a custom transform that accepts SQL queries and requests data from an external database.
 
 ## Plug-ins for Vega-Lite
 


### PR DESCRIPTION
I would like to add my new project [VegaFusion](https://vegafusion.io/) to the ecosystem page.

I noticed that a few related projects that focus on scaling Vega-Lite/Altair visualizations to larger datasets were not already present, so added a new section named "Tools for Scaling Vega-Lite Visualizations" with descriptions of `altair-transform` (cc @jakevdp) and `ibis-vega-transform` (cc @saulshanabrook) and VegaFusion.

Happy to add something on [Scalable Vega](https://github.com/vega/scalable-vega) if that makes sense, and to reorganize/reword as you see fit.  Thanks!
