### PR TITLE
chore: remove generating and tracking versions.yml from version control

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
 
   toc:
     name: TOC
-    if: "!contains(github.event.head_commit.message, '[CI]')"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -20,8 +20,7 @@ set -x
 
 yarn version --new-version $1 --no-git-tag-version
 
-yarn build:versions
-git add site/_data/versions.yml package.json
+git add package.json
 
 git commit -m "chore: release v$1"
 git tag -m "Release v$1." "v$1"

--- a/scripts/check-and-commit-toc.sh
+++ b/scripts/check-and-commit-toc.sh
@@ -24,7 +24,7 @@ if ! git diff --exit-code ./site/_includes/docs_toc.md
 then
   if [ "$PUSH_BRANCH" = true ]; then
     git add site/_includes/docs_toc.md site/Gemfile.lock
-    git commit -m "chore: update TOC [CI]"
+    git commit -m "chore: update TOC [ci skip]"
 
     # Push all the TOC changes
     git pull --rebase

--- a/scripts/check-and-commit.sh
+++ b/scripts/check-and-commit.sh
@@ -24,7 +24,7 @@ if ! git diff --exit-code ./build/vega-lite-schema.json; then
   ## Only do this for master
   if [ "$PUSH_BRANCH" = true ]; then
     git add ./build/vega-lite-schema.json
-    git commit -m "chore: update schema [CI]"
+    git commit -m "chore: update schema [ci skip]"
   else
     echo "Outdated schema."
     exit 1
@@ -49,7 +49,7 @@ git add examples
 
 if [ "$PUSH_BRANCH" = true ]; then
   if ! git diff --cached --word-diff=color --exit-code examples; then
-    git commit -m "chore: update examples [CI]"
+    git commit -m "chore: update examples [ci skip]"
   fi
 else
   # Don't diff SVG as floating point calculation is not always consistent
@@ -66,7 +66,7 @@ echo ""
 if [ "$PUSH_BRANCH" = true ]; then
   if ! git diff --exit-code site src test test-runtime; then
     git add --all
-    git commit -m "style: auto-formatting [CI]"
+    git commit -m "style: auto-formatting [ci skip]"
   fi
 
   # should be empty

--- a/scripts/deploy-schema.sh
+++ b/scripts/deploy-schema.sh
@@ -24,7 +24,7 @@ done
 if [ -n "$(git status --porcelain)" ]; then
     # Note: git commands need single quotes for all the files and directories with wildcards
     git add '*.json'
-    git commit -m"Add Vega-Lite $version"
+    git commit -m"Add Vega-Lite $version [ci skip]"
     git push
 else
   echo "Nothing has changed"

--- a/site/_data/versions.yml
+++ b/site/_data/versions.yml
@@ -1,4 +1,0 @@
-vega: 5.21.0
-vega-lite: 5.2.0
-vega-embed: 6.20.5
-vega-tooltip: 0.27.0


### PR DESCRIPTION
## Motivation

Paving the way for #7972 by reducing the amount of git commit related work that the release bot needs to do.

## Changes

- Introduces the "skip ci" suffix for all the scripts that make commits in the `scripts/` folder. An exception was made for `bump.sh` since that is run locally. This is important to prevent the risk of infinite loops (if the auto job also creates commits, it can trigger itself if we're not careful).
- Removes `versions.yml` from git. It appears to me that it's already pushed into the `_site` folder by the release.yml file because

### Details (Tracking the chain of indirection)

Documenting the call chain:

1. The docs site gets built by this Workflow step
https://github.com/vega/vega-lite/blob/4f349e3dd7227364852a7b69af6c15824b910fff/.github/workflows/release.yml#L47-L48 

2. Redirects

https://github.com/vega/vega-lite/blob/4f349e3dd7227364852a7b69af6c15824b910fff/package.json#L52

3. Redirects

https://github.com/vega/vega-lite/blob/4f349e3dd7227364852a7b69af6c15824b910fff/package.json#L57

4. Runs

https://github.com/vega/vega-lite/blob/4f349e3dd7227364852a7b69af6c15824b910fff/package.json#L49

5. This _should_ regenerate `versions.yml` from scratch, independently of whatever was checked into the repo before. 

https://github.com/vega/vega-lite/blob/4f349e3dd7227364852a7b69af6c15824b910fff/scripts/update-version.sh#L5-L10

According to the docs for the [publish step](https://github.com/alex-page/blazing-fast-gh-pages-deploy/blob/0430b71bc1750aa1d6f306fa14498c957ab40fa2/index.js#L11-L12):

> Calling this function will create a temporary clone of the current repository, create a gh-pages branch if one doesn't already exist, copy over all files from the base path, or only those that match patterns from the optional src configuration, commit all changes, and push to the origin remote.

I believe this means that `site/data/versions.yml`does not need to be committed to Git, and it's OK for us to just populate it on the fly as part of the github actions workflow step.