### PR TITLE
ci: only run updates to schema and TOC on human feature request branches

### DIFF
--- a/scripts/check-and-commit-toc.sh
+++ b/scripts/check-and-commit-toc.sh
@@ -7,7 +7,8 @@ git checkout $GIT_BRANCH
 
 echo "On branch $GIT_BRANCH."
 
-if [ "$GIT_BRANCH" != "stable" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
+# Only push on human pull request branches. Exclude release, prerelease, and bot branches.
+if [ "$GIT_BRANCH" != "stable" ] && [ "$GIT_BRANCH" != "next" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
   PUSH_BRANCH=true
   echo "Will try to push changes."
 else

--- a/scripts/check-and-commit.sh
+++ b/scripts/check-and-commit.sh
@@ -7,7 +7,8 @@ git checkout $GIT_BRANCH
 
 echo "On branch $GIT_BRANCH."
 
-if [ "$GIT_BRANCH" != "stable" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
+# Only push on human pull request branches. Exclude release, prerelease, and bot branches.
+if [ "$GIT_BRANCH" != "stable" ] && [ "$GIT_BRANCH" != "next" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
   PUSH_BRANCH=true
   echo "Will try to push changes."
 else
@@ -21,7 +22,6 @@ echo ""
 
 # Commit the schema if outdated
 if ! git diff --exit-code ./build/vega-lite-schema.json; then
-  ## Only do this for stable
   if [ "$PUSH_BRANCH" = true ]; then
     git add ./build/vega-lite-schema.json
     git commit -m "chore: update schema [ci skip]"


### PR DESCRIPTION
## Motivation

- Avoid making direct commits to the prerelease branch.
- See https://github.com/vega/vega-lite/commit/ae13aff7b480cf9c994031eca08a6b1720e01ab3#r67485453

## Changes

- Updated autocommit logic + comments as a follow-up to #7984 