### PR TITLE
chore: update master to next in CI scripts and docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,7 +35,7 @@ jobs:
           sudo mv parallel sem /usr/local/bin
 
       - name: Format
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/next'
         run: yarn format
 
       - name: Build Schema

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - next
   pull_request:
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ You can find [tasks with the "Good first issue" label in the issue tracker :pray
 
 The website is under `site/` and the documentation is under `site/docs/`. We use GitHub Pages to publish our documentation when we release a new version. To contribute changes to the documentation or website, simply submit a pull request that changes the corresponding markdown files in `site/`.
 
-Since we only publish the GitHub Pages when we release a new version, it might be slightly outdated compared to `master`. For development, once you have [setup the repository](#repository-setup), you can run `yarn site` to serve the GitHub page locally at [http://localhost:4000/vega-lite/](http://localhost:4000/vega-lite/).
+Since we only publish the GitHub Pages when we release a new version, it might be slightly outdated compared to `next`. For development, once you have [setup the repository](#repository-setup), you can run `yarn site` to serve the GitHub page locally at [http://localhost:4000/vega-lite/](http://localhost:4000/vega-lite/).
 
 Note that when you checkout different branches, the compiled JavaScript for the website might be reset. You might have to run `yarn build:site` to recompile the JavaScript so that interactive examples work.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Vega-Lite <a href="https://vega.github.io/vega-lite/"><img align="right" src="https://github.com/vega/logos/blob/master/assets/VL_Color@64.png?raw=true" height="38"></img></a>
+# Vega-Lite <a href="https://vega.github.io/vega-lite/"><img align="right" src="https://github.com/vega/logos/blob/next/assets/VL_Color@64.png?raw=true" height="38"></img></a>
 
-[![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) [![Build Status](https://github.com/vega/vega-lite/workflows/Test/badge.svg)](https://github.com/vega/vega-lite/actions) [![codecov](https://codecov.io/gh/vega/vega-lite/branch/master/graph/badge.svg)](https://codecov.io/gh/vega/vega-lite) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=rounded)](https://github.com/prettier/prettier) [![JSDevlivr](https://data.jsdelivr.com/v1/package/npm/vega-lite/badge?style=rounded)](https://www.jsdelivr.com/package/npm/vega-lite)
+[![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) [![Build Status](https://github.com/vega/vega-lite/workflows/Test/badge.svg)](https://github.com/vega/vega-lite/actions) [![codecov](https://codecov.io/gh/vega/vega-lite/branch/next/graph/badge.svg)](https://codecov.io/gh/vega/vega-lite) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=rounded)](https://github.com/prettier/prettier) [![JSDevlivr](https://data.jsdelivr.com/v1/package/npm/vega-lite/badge?style=rounded)](https://www.jsdelivr.com/package/npm/vega-lite)
 
 ![Teaser](site/static/teaser.png)
 

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -172,6 +172,6 @@ base: /docs/
 ---
 
 <span class="edit-page">
-  <a href="https://github.com/vega/vega-lite/edit/master/site/{{page.path}}">Edit this page</a>
+  <a href="https://github.com/vega/vega-lite/edit/next/site/{{page.path}}">Edit this page</a>
 </span>
 {{ content }}

--- a/site/_layouts/plain.html
+++ b/site/_layouts/plain.html
@@ -36,7 +36,7 @@ layout: base
 <footer>
   <div class="page-centered">
    <span class="edit-page">
-      <a href="https://github.com/vega/vega-lite/edit/master/site/{% if page.edit_path %}{{ page.edit_path }}{% else %}{{ page.path }}{% endif %}">Edit this page</a> and submit a pull request!
+      <a href="https://github.com/vega/vega-lite/edit/next/site/{% if page.edit_path %}{{ page.edit_path }}{% else %}{{ page.path }}{% endif %}">Edit this page</a> and submit a pull request!
     </span>
 
     <a href="http://idl.cs.washington.edu" title="UW Interactive Data Lab" class="idl-logo"><img src="{{ site.baseurl }}/static/idl-logo.png"/></a>

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -6,7 +6,7 @@ permalink: /ecosystem.html
 redirect_from: /applications.html
 ---
 
-This is an incomplete list of integrations, applications, and extensions of the Vega-Lite language and compiler. If you want to add a tool or library, [edit this file and send us a pull request](https://github.com/vega/vega-lite/blob/master/site/ecosystem.md).
+This is an incomplete list of integrations, applications, and extensions of the Vega-Lite language and compiler. If you want to add a tool or library, [edit this file and send us a pull request](https://github.com/vega/vega-lite/blob/next/site/ecosystem.md).
 
 We mark featured plugins and tools with a <span class="octicon octicon-star"></span>.
 

--- a/site/static/post.ts
+++ b/site/static/post.ts
@@ -1,4 +1,4 @@
-// copied from https://github.com/vega/vega-embed/blob/master/src/post.ts
+// copied from https://github.com/vega/vega-embed/blob/next/src/post.ts
 
 import {Renderers} from 'vega';
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8031.0044b51.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8031.0044b51.0
  # or 
  yarn add vega-lite@5.2.1--canary.8031.0044b51.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
