### PR TITLE
docs: add Graphpad to Vega-Lite ecosystem

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -27,6 +27,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [Deneb](https://deneb-viz.github.io), a Power BI custom visual with an editor for Vega-Lite or Vega specifications.
 - [VizLinter](https://vizlinter.idvxlab.com/), an online editor that detects and fixes encoding issues based on vega-lite-linter.
 - [Datapane](https://github.com/datapane/datapane), a Python framework for building interactive reports from open-source visualization formats such as Vega-Lite.
+- [Graphpad](https://www.figma.com/community/widget/1027276088284051809), an editor for creating Vega-Lite visualizations in the Figjam collaborative whiteboarding tool.
 
 ## Tools for Scaling Vega-Lite Visualizations
 


### PR DESCRIPTION
## Motivation

- Improve discoverability of a tool I contributed to the Figjam ecosystem for improving collaboration between product designers and data analysts

## Changes

- Added entry to `ecosystem.md`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8050.b5e6c82.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8050.b5e6c82.0
  # or 
  yarn add vega-lite@5.2.1--canary.8050.b5e6c82.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
