### PR TITLE
ci: don't skip the ci when we have automatic commits

### DIFF
--- a/scripts/check-and-commit-toc.sh
+++ b/scripts/check-and-commit-toc.sh
@@ -25,7 +25,7 @@ if ! git diff --exit-code ./site/_includes/docs_toc.md
 then
   if [ "$PUSH_BRANCH" = true ]; then
     git add site/_includes/docs_toc.md site/Gemfile.lock
-    git commit -m "chore: update TOC [ci skip]"
+    git commit -m "chore: update TOC [CI]"
 
     # Push all the TOC changes
     git pull --rebase

--- a/scripts/check-and-commit.sh
+++ b/scripts/check-and-commit.sh
@@ -24,7 +24,7 @@ echo ""
 if ! git diff --exit-code ./build/vega-lite-schema.json; then
   if [ "$PUSH_BRANCH" = true ]; then
     git add ./build/vega-lite-schema.json
-    git commit -m "chore: update schema [ci skip]"
+    git commit -m "chore: update schema [CI]"
   else
     echo "Outdated schema."
     exit 1
@@ -49,7 +49,7 @@ git add examples
 
 if [ "$PUSH_BRANCH" = true ]; then
   if ! git diff --cached --word-diff=color --exit-code examples; then
-    git commit -m "chore: update examples [ci skip]"
+    git commit -m "chore: update examples [CI]"
   fi
 else
   # Don't diff SVG as floating point calculation is not always consistent
@@ -66,7 +66,7 @@ echo ""
 if [ "$PUSH_BRANCH" = true ]; then
   if ! git diff --exit-code site src test test-runtime; then
     git add --all
-    git commit -m "style: auto-formatting [ci skip]"
+    git commit -m "style: auto-formatting [CI]"
   fi
 
   # should be empty

--- a/scripts/deploy-schema.sh
+++ b/scripts/deploy-schema.sh
@@ -26,7 +26,7 @@ done
 if [ -n "$(git status --porcelain)" ]; then
     # Note: git commands need single quotes for all the files and directories with wildcards
     git add '*.json'
-    git commit -m"Add Vega-Lite $version [ci skip]"
+    git commit -m"Add Vega-Lite $version [CI]"
     git push
 else
   echo "Nothing has changed"


### PR DESCRIPTION
Otherwise we skip CI for commits coming from the CI: https://github.com/vega/vega-lite/pull/8088.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8089.0345f00.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8089.0345f00.0
  # or 
  yarn add vega-lite@5.2.1--canary.8089.0345f00.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
