### PR TITLE
fix: log correct property name

### DIFF
--- a/src/scale.ts
+++ b/src/scale.ts
@@ -811,7 +811,7 @@ export function channelScalePropertyIncompatability(channel: Channel, propName: 
     case 'scheme':
     case 'domainMid':
       if (!isColorChannel(channel)) {
-        return log.message.cannotUseScalePropertyWithNonColor(channel);
+        return log.message.cannotUseScalePropertyWithNonColor(propName);
       }
       return undefined;
     case 'align':


### PR DESCRIPTION
fixes #8137

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8140.8f29ddb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8140.8f29ddb.0
  # or 
  yarn add vega-lite@5.2.1--canary.8140.8f29ddb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
