### PR TITLE
feat: enable default tooltip for boxplot outliers

### DIFF
--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -289,7 +289,7 @@ export function normalizeBoxPlot(
 
   const outlierLayersMixins = partLayerMixins<BoxPlotPartsMixins>(markDef, 'outliers', config.boxplot, {
     transform: [{filter: `(${fieldExpr} < ${lowerWhiskerExpr}) || (${fieldExpr} > ${upperWhiskerExpr})`}],
-    mark: 'point',
+    mark: {"type": "point", "tooltip": {"content": "data"}},
     encoding: {
       [continuousAxis]: {
         field: continuousAxisChannelDef.field,


### PR DESCRIPTION
This is a bit of a issue/discussion, but I wanted to show which change I think will work so I made a PR right away. I think it is quite useful to see hover info on boxplot outliers to get more into about these points. Having this enable by default facilitates getting this info right away without adding a tooltip encoding and is in line with the default tooltip added for the box and whiskers. One drawback could be that the tooltip gets cluttered if there are a lot of columns in the dataframe, and that it might not be possible to turn it off completely (but this is also the case for the box and it is easy to set it to a single field).

Please:

- [ ] Make the pull requests (PRs) atomic (fix one issue at a time). Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.
- [ ] Provide a concise title as a [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties") so we can easily copy it to the release note.
  - Use imperative mood and present tense.
- Mention relevant issues in the description (e.g., `Fixes #1` / `Fixes part of #1`).
- [ ] Lint and test (Run `yarn test`).
- [ ] If you send a pull request from a fork, make sure that GitHub actions run successfully. Make sure to add a [`GH_PAT` secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) for a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) with public repository permissions.
- [ ] Review your changes before sending the PR (to ensure code quality).
- For new features:
  - [ ] Add new unit tests.
  - [ ] Update the documentation under `site/docs/` + add examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
