### PR TITLE
chore: fix link to Vega slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Question
     url: https://stackoverflow.com/tags/vega-lite
-    about: Please ask questions on Stack Overflow (https://stackoverflow.com/tags/vega-lite), on Slack (https://bit.ly/join-vega-slack-2020), or on [the mailing list](https://bit.ly/vega-discuss).
+    about: Please ask questions on Stack Overflow (https://stackoverflow.com/tags/vega-lite), on Slack (https://bit.ly/join-vega-slack-2022), or on [the mailing list](https://bit.ly/vega-discuss).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,1 +1,1 @@
-You can ask questions on [Stack Overflow](https://stackoverflow.com/tags/vega-lite), [the mailing list](https://bit.ly/vega-discuss) or on [Slack](https://bit.ly/join-vega-slack-2020).
+You can ask questions on [Stack Overflow](https://stackoverflow.com/tags/vega-lite), [the mailing list](https://bit.ly/vega-discuss) or on [Slack](https://bit.ly/join-vega-slack-2022).

--- a/site/index.md
+++ b/site/index.md
@@ -83,7 +83,7 @@ For more information, read our [introduction article to Vega-Lite v2 on Medium](
 - Award winning [research paper](https://idl.cs.washington.edu/papers/vega-lite) and [video of our OpenVis Conf talk](https://www.youtube.com/watch?v=9uaHRWj04D4) on the design of Vega-Lite
 - Listen to a Data Stories episode about [Declarative Visualization with Vega-Lite and Altair](http://datastori.es/121-declarative-visualization-with-vega-lite-and-altair-with-dominik-moritz-jacob-vanderplas-kanit-ham-wongsuphasawat/)
 - [JSON schema](http://json-schema.org/) specification for [Vega-Lite](https://github.com/vega/schema) ([latest](https://vega.github.io/schema/vega-lite/v5.json))
-- Ask questions about Vega-Lite on [Stack Overflow](https://stackoverflow.com/tags/vega-lite) or [Slack](https://bit.ly/join-vega-slack-2020)
+- Ask questions about Vega-Lite on [Stack Overflow](https://stackoverflow.com/tags/vega-lite) or [Slack](https://bit.ly/join-vega-slack-2022)
 - Fork our [Vega-Lite Block](https://bl.ocks.org/domoritz/455e1c7872c4b38a58b90df0c3d7b1b9), or [Observable Notebook](https://beta.observablehq.com/@domoritz/vega-lite-demo).
 
 ## Users


### PR DESCRIPTION
fixes #8171

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8174.602fa71.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8174.602fa71.0
  # or 
  yarn add vega-lite@5.2.1--canary.8174.602fa71.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
