### PR TITLE
feat: export `defaultTitleFormatter` as a top-level export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import pkg from '../package.json';
 export const version = pkg.version;
 
+export {defaultTitleFormatter} from './channeldef';
 export {compile} from './compile/compile';
 export type {Config} from './config';
 export {normalize} from './normalize';


### PR DESCRIPTION
Exports `defaultTitleFormatter` from the top-level of the `vega-lite` package. This makes it easier for people using the [`fieldTitle` option of `compile` ](https://vega.github.io/vega-lite/usage/compile.html#field-title) to write a custom implementation that uses the default definition as a starting point.

Does this seems like a reasonable change? Let me know if there are any other changes also needed here!