### PR TITLE
docs: `titleFormat` -> `fieldTitle` in compile docs

### DIFF
--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -60,7 +60,7 @@ To customize how Vega-Lite generates axis or legend titles for a [field definiti
 
 ```js
 const vgSpec = vegaLite.compile(vlSpec, {
-  titleFormat: function (fieldDef, config) {
+  fieldTitle: function (fieldDef, config) {
     const fn = fieldDef.aggregate || fieldDef.timeUnit || (fieldDef.bin && 'bin');
     if (fn) {
       return `${fn.toUpperCase()}(${fieldDef.field})`;

--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -56,7 +56,7 @@ interface LoggerInterface {
 
 ### Customized Field Title Formatter
 
-To customize how Vega-Lite generates axis or legend titles for a [field definition](encoding.html#field-def), you can provide a `titleFormat` function as a property of the `compile` function's `options` argument.
+To customize how Vega-Lite generates axis or legend titles for a [field definition](encoding.html#field-def), you can provide a `fieldTitle` function as a property of the `compile` function's `options` argument.
 
 ```js
 const vgSpec = vegaLite.compile(vlSpec, {


### PR DESCRIPTION
Just fixing a small typo in the examples in the docs on `compile`, I think this was just a typo originally that never got caught.
