### PR TITLE
Clarify that we need to turn on `customFormatTypes` to use custom format types 

### DIFF
--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -58,7 +58,9 @@ These two config properties define the default number and time formats for text 
 
 ### Providing Custom Formatters
 
-To customize how Vega-Lite formats numbers or text, you can register a new formatter by (1) registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property and (2) setting the `customFormatTypes` config to `true`. For example, to register `customFormatA`, you run need to register the function:
+To customize how Vega-Lite formats numbers or text, you can register a custom formatter by 
+
+(1) registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property.  For example, to register `customFormatA`, you run need to register the function:
 
 ```js
 vega.expressionFunction('customFormatA', function(datum, params) {
@@ -67,9 +69,19 @@ vega.expressionFunction('customFormatA', function(datum, params) {
 });
 ```
 
-You can then use this custom format function with `format` and `formatType` properties in text encodings and guides (axis/legend/header).
+2) setting the `customFormatTypes` config to `true`. 
 
-```json
+```js
+{
+  ...,
+  "config": {"customFormatTypes": true}
+}
+```
+
+
+3) You can then use this custom format function with `format` and `formatType` properties in text encodings and guides (axis/legend/header).
+
+```js
 {
   "format": <params>,
   "formatType": "customFormatA"

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -60,7 +60,7 @@ These two config properties define the default number and time formats for text 
 
 To customize how Vega-Lite formats numbers or text, you can register a custom formatter by
 
-(1) Registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property. For example, to register `customFormatA`, you run need to register the function:
+(1) Registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property. For example, to register `customFormatA`, you need to register the function:
 
 ```js
 vega.expressionFunction('customFormatA', function(datum, params) {

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -58,9 +58,9 @@ These two config properties define the default number and time formats for text 
 
 ### Providing Custom Formatters
 
-To customize how Vega-Lite formats numbers or text, you can register a custom formatter by 
+To customize how Vega-Lite formats numbers or text, you can register a custom formatter by
 
-(1) Registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property.  For example, to register `customFormatA`, you run need to register the function:
+(1) Registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property. For example, to register `customFormatA`, you run need to register the function:
 
 ```js
 vega.expressionFunction('customFormatA', function(datum, params) {
@@ -69,7 +69,7 @@ vega.expressionFunction('customFormatA', function(datum, params) {
 });
 ```
 
-2) Setting the `customFormatTypes` config to `true`. 
+2. Setting the `customFormatTypes` config to `true`.
 
 ```js
 {
@@ -78,8 +78,7 @@ vega.expressionFunction('customFormatA', function(datum, params) {
 }
 ```
 
-
-3) You can then use this custom format function with `format` and `formatType` properties in text encodings and guides (axis/legend/header).
+3. You can then use this custom format function with `format` and `formatType` properties in text encodings and guides (axis/legend/header).
 
 ```js
 {

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -60,7 +60,7 @@ These two config properties define the default number and time formats for text 
 
 To customize how Vega-Lite formats numbers or text, you can register a custom formatter by 
 
-(1) registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property.  For example, to register `customFormatA`, you run need to register the function:
+(1) Registering [an expression function](https://vega.github.io/vega/docs/api/extensibility/#expressions) that takes a data point and an optional format property.  For example, to register `customFormatA`, you run need to register the function:
 
 ```js
 vega.expressionFunction('customFormatA', function(datum, params) {
@@ -69,7 +69,7 @@ vega.expressionFunction('customFormatA', function(datum, params) {
 });
 ```
 
-2) setting the `customFormatTypes` config to `true`. 
+2) Setting the `customFormatTypes` config to `true`. 
 
 ```js
 {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8212.924ee60.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8212.924ee60.0
  # or 
  yarn add vega-lite@5.2.1--canary.8212.924ee60.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
