### PR TITLE
chore: publish script is not just for prereleases and canaries

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM (canaries and prereleases)
+name: Publish to NPM
 
 on:
   push:


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.8242.8790c53.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.2.1--canary.8242.8790c53.0
  # or 
  yarn add vega-lite@5.2.1--canary.8242.8790c53.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
