### PR TITLE
docs: add heat lane example

### DIFF
--- a/examples/specs/bar_heatlane.vl.json
+++ b/examples/specs/bar_heatlane.vl.json
@@ -41,7 +41,6 @@
         "type": "bar",
         "xOffset": 2,
         "x2Offset": -2,
-        "color": "black",
         "cornerRadius": 3
       },
       "encoding": {

--- a/examples/specs/bar_heatlane.vl.json
+++ b/examples/specs/bar_heatlane.vl.json
@@ -12,7 +12,7 @@
       "as": ["bin_Horsepower_start", "bin_Horsepower_end"]
     },
     {
-      "aggregate": [{"op": "count"}],
+      "aggregate": [{"op": "count", "as": "count"}],
       "groupby": ["bin_Horsepower_start", "bin_Horsepower_end"]
     },
     {"bin": true, "field": "count", "as": ["bin_count_start", "bin_count_end"]},

--- a/examples/specs/bar_heatlane.vl.json
+++ b/examples/specs/bar_heatlane.vl.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "Heat lane chart based on https://www.smashingmagazine.com/2022/07/accessibility-first-approach-chart-visual-design/",
+  "data": {"url": "data/cars.json"},
+  "height": 150,
+  "width": 400,
+  "title": "Heat Lane of Horsepower",
+  "transform": [
+    {
+      "bin": true,
+      "field": "Horsepower",
+      "as": ["bin_Horsepower_start", "bin_Horsepower_end"]
+    },
+    {
+      "aggregate": [{"op": "count"}],
+      "groupby": ["bin_Horsepower_start", "bin_Horsepower_end"]
+    },
+    {"bin": true, "field": "count", "as": ["bin_count_start", "bin_count_end"]},
+    {"calculate": "-datum.bin_count_end/2", "as": "y2"},
+    {"calculate": "datum.bin_count_end/2", "as": "y"},
+    {
+      "joinaggregate": [
+        {"field": "bin_count_end", "op": "max", "as": "max_bin_count_end"}
+      ]
+    }
+  ],
+  "encoding": {
+    "x": {
+      "field": "bin_Horsepower_start",
+      "type": "quantitative",
+      "title": "Horsepower",
+      "axis": {"grid": false}
+    },
+    "x2": {"field": "bin_Horsepower_end"},
+    "y": {"field": "y", "axis": null},
+    "y2": {"field": "y2"}
+  },
+  "layer": [
+    {
+      "mark": {
+        "type": "bar",
+        "xOffset": 2,
+        "x2Offset": -2,
+        "color": "black",
+        "cornerRadius": 3
+      },
+      "encoding": {
+        "color": {
+          "field": "max_bin_count_end",
+          "type": "ordinal",
+          "title": "count",
+          "scale": {"scheme": "lighttealblue"}
+        }
+      }
+    },
+    {
+      "mark": {
+        "type": "bar",
+        "xOffset": 2,
+        "x2Offset": -2,
+        "yOffset": -3,
+        "y2Offset": 3
+      },
+      "encoding": {
+        "color": {"field": "bin_count_end", "type": "ordinal", "title": "count"}
+      }
+    }
+  ]
+}

--- a/site/_data/examples.json
+++ b/site/_data/examples.json
@@ -95,6 +95,10 @@
       {
         "name": "bar_axis_space_saving",
         "title": "Bar Chart with a Spacing-Saving Y-Axis"
+      },
+      {
+        "name": "bar_heatlane",
+        "title": "Heat Lane Chart"
       }
     ],
     "Histograms, Density Plots, and Dot Plots": [


### PR DESCRIPTION
As discussed on twitter (https://twitter.com/domoritz/status/1546869138370355201), this PR adds a new gallery example for the heat lane visualization type described in https://www.smashingmagazine.com/2022/07/accessibility-first-approach-chart-visual-design/.

![visualization](https://user-images.githubusercontent.com/15064365/179423250-718e07a2-c328-4041-ab61-4ffc4e9cefab.png)


Thanks!
