### PR TITLE
Fix: check only run `config.numberFormat` on quantitative types

### DIFF
--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -160,7 +160,13 @@ export function labels(specifiedlabelsSpec: any, {fieldOrDatumDef, model, channe
       formatType,
       config
     });
-  } else if (format === undefined && formatType === undefined && config.customFormatTypes && config.numberFormatType) {
+  } else if (
+    fieldOrDatumDef.type === 'quantitative' &&
+    format === undefined &&
+    formatType === undefined &&
+    config.customFormatTypes &&
+    config.numberFormatType
+  ) {
     text = formatCustomType({
       fieldOrDatumDef,
       field: 'datum.value',

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -170,7 +170,7 @@ describe('compile/legend', () => {
   it('returns correct expression for custom format Type from config.numberFormatType', () => {
     const fieldDef: Encoding<string>['color'] = {
       field: 'a',
-      type: 'temporal'
+      type: 'quantitative'
     };
 
     const model = parseUnitModelWithScale({


### PR DESCRIPTION
Fixes a bug where the `numberFormat` function will run on non quantitative values.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.1--canary.8305.cda1c30.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.3.1--canary.8305.cda1c30.0
  # or 
  yarn add vega-lite@5.3.1--canary.8305.cda1c30.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
