### PR TITLE
ci: set up node before running yarn and use caching everywhere

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-          cache: 'yarn'
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/release-docs-and-schema.yml
+++ b/.github/workflows/release-docs-and-schema.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,13 +56,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Node dependencies
-        run: yarn --frozen-lockfile
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           cache: 'yarn'
+
+      - name: Install Node dependencies
+        run: yarn --frozen-lockfile
 
       - name: Install extra dependencies for Puppeteer
         run: sudo apt-get install libgbm1
@@ -95,13 +95,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Node dependencies
-        run: yarn --frozen-lockfile
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           cache: 'yarn'
+
+      - name: Install Node dependencies
+        run: yarn --frozen-lockfile
 
       - name: Build
         run: yarn build:only


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.1--canary.8328.0f7bd89.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.4.1--canary.8328.0f7bd89.0
  # or 
  yarn add vega-lite@5.4.1--canary.8328.0f7bd89.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
