### PR TITLE
ci: simplify setup and use caching

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -5,8 +5,6 @@ on:
     branches-ignore:
       # No canary deploys for branches opened by dependabot
       - 'dependabot/**'
-      # documentation site should not trigger releases
-      - 'gh-pages'
 
 jobs:
   publish:
@@ -14,21 +12,29 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
 
     name: Make a release and publish to NPM
-
     steps:
       - uses: actions/checkout@v3
-
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
 
-      - run: npm run release
+      - name: Build
+        run: yarn build
+
+      - name: Check NPM deployment
+        run: ./scripts/check-npm.sh
+
+      - name: Create release
+        run: npx auto shipit
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -5,6 +5,8 @@ on:
     branches-ignore:
       # No canary deploys for branches opened by dependabot
       - 'dependabot/**'
+      # documentation site should not trigger releases
+      - 'gh-pages'
 
 jobs:
   publish:

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,7 +24,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
@@ -38,5 +38,5 @@ jobs:
       - name: Create release
         run: npm run shipit
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -39,4 +39,5 @@ jobs:
         run: npm run shipit
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./scripts/check-npm.sh
 
       - name: Create release
-        run: npx auto shipit
+        run: npm run shipit
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,7 +24,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
@@ -38,5 +38,5 @@ jobs:
       - name: Create release
         run: npm run shipit
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release-docs-and-schema.yml
+++ b/.github/workflows/release-docs-and-schema.yml
@@ -39,13 +39,6 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
 
-      - name: Check NPM deployment
-        run: ./scripts/check-npm.sh
-
-      - uses: actions/setup-node@v3
-        with:
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Prebuild website
         run: yarn predeploy:site
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test-matrix:
+  test:
     name: Node
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "watch:site": "yarn build:site -w",
     "watch:test": "yarn jest --watch test/",
     "watch:test:runtime": "NODE_OPTIONS=--experimental-vm-modules TZ=America/Los_Angeles npx jest --watch test-runtime/ --config test-runtime/jest-config.json",
-    "release": "yarn run prebuild && yarn build && auto shipit"
+    "release": "yarn run prebuild && yarn build && yarn shipit",
+    "shipit": "auto shipit"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.1--canary.8355.8713057.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.4.1--canary.8355.8713057.0
  # or 
  yarn add vega-lite@5.4.1--canary.8355.8713057.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
