### PR TITLE
ci: split scripts and refine triggers

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -2,14 +2,10 @@ name: Check
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - stable
-      - next
+  pull_request:
     paths:
       - 'site/**'
       - 'scripts/**'
-  pull_request:
 
 jobs:
   toc:

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -5,11 +5,16 @@ on:
   push:
     branches-ignore:
       - stable
+      - next
+    paths:
+      - 'site/**'
+      - 'scripts/**'
   pull_request:
 
 jobs:
-  check:
-    name: Format, Schema, and Examples
+  toc:
+    name: TOC
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
 
     steps:
@@ -25,29 +30,27 @@ jobs:
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
 
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.x'
+
       - name: Setup data
         run: yarn data
 
-      - name: Install Parallel
+      - name: Build Jekyll
         run: |
-          # Faster than "sudo apt-get install parallel"
-          wget https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel
-          chmod +x parallel
-          cp parallel sem
-          sudo mv parallel sem /usr/local/bin
+          gem install bundler
+          pushd site
+          bundle install
+          bundle exec jekyll build -q
+          popd
 
-      - name: Format
-        if: github.ref != 'refs/heads/next'
-        run: yarn format
-
-      - name: Build Schema
-        run: yarn schema
-
-      - name: Check Schema
-        run: scripts/check-schema.sh
+      - name: Build TOC
+        run: scripts/generate-toc
 
       - name: Setup Git remote
         run: scripts/setup-git-ci.sh
 
       - name: Check and Commit
-        run: scripts/check-and-commit.sh
+        run: scripts/check-and-commit-toc.sh

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,6 @@ name: Check
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - stable
   pull_request:
 
 jobs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,7 +35,6 @@ jobs:
           sudo mv parallel sem /usr/local/bin
 
       - name: Format
-        if: github.ref != 'refs/heads/next'
         run: yarn format
 
       - name: Build Schema

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -1,7 +1,10 @@
 name: Auto-merge Dependabot PRs
+
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 * * * *'
+
 jobs:
   auto_merge:
     name: Auto-merge Dependabot PRs

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -7,6 +7,8 @@ on:
       - 'dependabot/**'
       # documentation site should not trigger releases
       - 'gh-pages'
+    paths-ignore:
+      - 'site/**'
 
 jobs:
   publish:

--- a/.github/workflows/release-docs-and-schema.yml
+++ b/.github/workflows/release-docs-and-schema.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn build
 
       - name: Setup Git remote
-        run: ./scripts/setup-git-ci.sh
+        run: scripts/setup-git-ci.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -40,7 +40,7 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
 
       - name: Check NPM deployment
-        run: ./scripts/check-npm.sh
+        run: scripts/check-npm.sh
 
       - uses: actions/setup-node@v3
         with:
@@ -56,4 +56,4 @@ jobs:
           site-directory: 'site/'
 
       - name: Publish schema
-        run: ./scripts/deploy-schema.sh
+        run: scripts/deploy-schema.sh

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,29 @@
+name: Test Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - stable
+    paths-ignore:
+      - 'src/**'
+  pull_request:
+
+jobs:
+  build-site:
+    name: Build Site
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+
+      - name: Install Node dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build:site

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,13 +1,12 @@
-name: Test Docs
+name: Test
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - stable
-    paths-ignore:
-      - 'src/**'
   pull_request:
+    paths:
+      - 'site/**'
+      - 'yarn.lock'
+      - '**prettier**'
 
 jobs:
   build-site:
@@ -24,6 +23,9 @@ jobs:
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile
+
+      - name: Lint
+        run: yarn prettierbase --check
 
       - name: Build
         run: yarn build:site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,12 @@ name: Test
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - stable
   pull_request:
+    paths-ignore:
+      - 'site/**'
 
 jobs:
-  test-matrix:
+  test:
     name: Node
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Test
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - next
+    branches-ignore:
+      - stable
   pull_request:
 
 jobs:
@@ -30,24 +31,6 @@ jobs:
 
       - name: Build
         run: yarn build
-
-  build-site:
-    name: Build Site
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          cache: 'yarn'
-
-      - name: Install Node dependencies
-        run: yarn --frozen-lockfile
-
-      - name: Build
-        run: yarn build:site
 
   runtime-lint-coverage:
     name: Runtime, Linting, and Coverage

--- a/scripts/check-and-commit-toc.sh
+++ b/scripts/check-and-commit-toc.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+
 # Only push on human pull request branches. Exclude release, prerelease, and bot branches.
 if [ "$GIT_BRANCH" != "stable" ] && [ "$GIT_BRANCH" != "next" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
   PUSH_BRANCH=true

--- a/scripts/check-and-commit-toc.sh
+++ b/scripts/check-and-commit-toc.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-git checkout $GIT_BRANCH
-
-echo "On branch $GIT_BRANCH."
-
 # Only push on human pull request branches. Exclude release, prerelease, and bot branches.
 if [ "$GIT_BRANCH" != "stable" ] && [ "$GIT_BRANCH" != "next" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
   PUSH_BRANCH=true

--- a/scripts/check-and-commit.sh
+++ b/scripts/check-and-commit.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+
 # Only push on human pull request branches. Exclude release, prerelease, and bot branches.
 if [ "$GIT_BRANCH" != "stable" ] && [ "$GIT_BRANCH" != "next" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
   PUSH_BRANCH=true

--- a/scripts/check-and-commit.sh
+++ b/scripts/check-and-commit.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-git checkout $GIT_BRANCH
-
-echo "On branch $GIT_BRANCH."
-
 # Only push on human pull request branches. Exclude release, prerelease, and bot branches.
 if [ "$GIT_BRANCH" != "stable" ] && [ "$GIT_BRANCH" != "next" ] && [[ "$GIT_BRANCH" != dependabot/* ]]; then
   PUSH_BRANCH=true


### PR DESCRIPTION
fixes #8326

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.1--canary.8356.5b3a942.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.4.1--canary.8356.5b3a942.0
  # or 
  yarn add vega-lite@5.4.1--canary.8356.5b3a942.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
