### PR TITLE
ci: Use Pull Request Head Ref

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ Publishing is handled by a 2-branch [pre-release process](https://intuit.github.
 - PRs made into the default branch are auto-deployed to the `next` pre-release tag on NPM. The result can be installed with `npm install vega-lite/@next`.
   - When merging into `next`, please use the `squash and merge` strategy.
 - To release a new stable version, open a PR from `next` into `stable` using this [compare link](https://github.com/vega/vega-lite/compare/stable...next).
-  - When merging from `next` into `stable`, please use the `create a merge commit` strategy. 
+  - When merging from `next` into `stable`, please use the `create a merge commit` strategy.
   - After the release note is generated (from commits), please take a look to clean up so the log is readable to the community.
 
 ## Suggested Programming Environment.


### PR DESCRIPTION
This PR is in relation to #8356. PRs on forked repos fail.
I believe this is related to: https://github.com/actions/checkout/issues/551.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.1--canary.8363.08df068.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.4.1--canary.8363.08df068.0
  # or 
  yarn add vega-lite@5.4.1--canary.8363.08df068.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
