### PR TITLE
ci: pull_request -> pull_request_target

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -2,7 +2,7 @@ name: Check
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     paths:
       - 'site/**'
       - 'scripts/**'

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -2,7 +2,8 @@ name: Check
 
 on:
   workflow_dispatch:
-  pull_request_target:
+    workflows: ['Test']
+  pull_request:
     paths:
       - 'site/**'
       - 'scripts/**'

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -2,7 +2,7 @@ name: Check
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths:
       - 'site/**'
       - 'scripts/**'

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -2,7 +2,6 @@ name: Check
 
 on:
   workflow_dispatch:
-    workflows: ['Test']
   pull_request:
     paths:
       - 'site/**'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: Check
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,8 @@ name: Check
 
 on:
   workflow_dispatch:
-  pull_request_target:
+    workflows: ['Test']
+  pull_request:
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: Check
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,6 @@ name: Check
 
 on:
   workflow_dispatch:
-    workflows: ['Test']
   pull_request:
 
 jobs:


### PR DESCRIPTION
More explorations to get the CI working à la #8363
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.5.1--canary.8366.69684a7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.5.1--canary.8366.69684a7.0
  # or 
  yarn add vega-lite@5.5.1--canary.8366.69684a7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
