### PR TITLE
ci: update contribution information

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@ Please:
   - Use imperative mood and present tense.
 - Mention relevant issues in the description (e.g., `Fixes #1` / `Fixes part of #1`).
 - [ ] Lint and test (Run `yarn test`).
-- [ ] If you send a pull request from a fork, make sure that GitHub actions run successfully. Make sure to add a [`GH_PAT` secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) for a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) with public repository permissions.
 - [ ] Review your changes before sending the PR (to ensure code quality).
 - For new features:
   - [ ] Add new unit tests.

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -1,6 +1,7 @@
 name: Check
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'site/**'

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github..ref }}
+          ref: ${{ github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -1,8 +1,7 @@
 name: Check
 
 on:
-  workflow_dispatch:
-  pull_request:
+  push:
     paths:
       - 'site/**'
       - 'scripts/**'
@@ -17,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github..ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: Check
 
 on:
+  workflow_dispatch:
   push:
 
 jobs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,7 @@
 name: Check
 
 on:
-  workflow_dispatch:
-  pull_request:
+  push:
 
 jobs:
   check:
@@ -13,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,10 @@
+name: 'First Interaction'
+
+on:
+  pull_request:
+
+steps:
+  - uses: actions/first-interaction@v1
+    with:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}
+      pr-message: 'Welcome to Vega. Since this is your first contribution, please make sure to read the [contributing guide](https://github.com/vega/vega-lite/blob/next/CONTRIBUTING.md).'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Welcome to the Vega community. Everyone is welcome to contribute. We value all forms of contributions including code reviews, patches, examples, community participation, tutorial, and blog posts. In this document, we outline the guidelines for contributing to the various aspects of the project.
 
+**IMPORTANT:**: If you send a pull request from a fork, make sure that GitHub actions run successfully. Make sure to add a [`GH_PAT` secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) for a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) with public repository permissions.
+
 If you find a bug in the code or a mistake in the [documentation](https://vega.github.io/vega-lite/docs/) or want a new feature, you can help us by creating an issue to [our repository](https://github.com/vega/vega-lite), or even submit a pull request (PR).
 
 - For small fixes, please feel free to submit a pull request. Don't worry about creating an issue first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to the Vega community. Everyone is welcome to contribute. We value all forms of contributions including code reviews, patches, examples, community participation, tutorial, and blog posts. In this document, we outline the guidelines for contributing to the various aspects of the project.
 
-**IMPORTANT:**: If you send a pull request from a fork, make sure that GitHub actions run successfully. Make sure to add a [`GH_PAT` secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) for a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) with public repository permissions.
+If you send a pull request from a fork, make sure that GitHub actions run successfully. Make sure to add a [`GH_PAT` secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets) for a [personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) with public repository permissions.
 
 If you find a bug in the code or a mistake in the [documentation](https://vega.github.io/vega-lite/docs/) or want a new feature, you can help us by creating an issue to [our repository](https://github.com/vega/vega-lite), or even submit a pull request (PR).
 


### PR DESCRIPTION
Okay, after trying out #8363, #8365, and #8366, along with some ideas on my personal fork, I've come to the conclusion that switching the `Format, Schema, and Examples` CI to be on `push` rather than on `pull_request` is the best solution. The reason for this decision is the complexity between running the CI and committing changes on a target repository versus committing the changes to the PR branch. This would involve complex resolutions such as possibly `pull_request_target`, which has [security implications](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

Therefore, this PR changes the contribution workflow so `check` will occur within the fork repository rather than on PR. We can add another CI to validate that the action ran successfully as well.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.5.1--canary.8367.dd8fa44.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.5.1--canary.8367.dd8fa44.0
  # or 
  yarn add vega-lite@5.5.1--canary.8367.dd8fa44.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
