### PR TITLE
chore(release): bump package.json version to v5.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "author": "Dominik Moritz, Kanit \"Ham\" Wongsuphasawat, Arvind Satyanarayan, Jeffrey Heer",
-  "version": "5.2.0",
+  "version": "5.6.0",
   "collaborators": [
     "Kanit Wongsuphasawat (http://kanitw.yellowpigz.com)",
     "Dominik Moritz (https://www.domoritz.de)",


### PR DESCRIPTION
## Motivation

- Manual workaround for bug reported in https://github.com/vega/vega-lite/issues/8370#issuecomment-1223318989

## Changes

- Manually increments package.json to the version that auto _would_ bump to when #8368 is merged

## Testing

- No runtime impact

## Notes

- Make sure not to merge this until we are able to merge #8368 immediately after. 