### PR TITLE
fix: Set package.json version to 5.5.0 (re-sync with stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "author": "Dominik Moritz, Kanit \"Ham\" Wongsuphasawat, Arvind Satyanarayan, Jeffrey Heer",
-  "version": "5.6.0",
+  "version": "5.5.0",
   "collaborators": [
     "Kanit Wongsuphasawat (http://kanitw.yellowpigz.com)",
     "Dominik Moritz (https://www.domoritz.de)",


### PR DESCRIPTION
## Motivation

- https://github.com/vega/vega-lite/pull/8378 bumped us 1 patch version too high. 
- There may be a longer term fix, but at minimum we should clean up `next` so that this versioning issue doesn't block the release of core graphing features.

## Changes

- Learned from https://github.com/vega/vega-lite/pull/8380 that we can't fix things by merging stable back into next since that creates a merge conflict. It seems that stable must lead in front of next, the reverse isn't possible.

## Testing

- After this merges, the 5.6.0 release PR (https://github.com/vega/vega-lite/pull/8368 ) should no longer have a merge conflict.
