### PR TITLE
feat: remove flatmap polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
   },
   "dependencies": {
     "@types/clone": "~2.1.1",
-    "array-flat-polyfill": "^1.0.1",
     "clone": "~2.1.2",
     "fast-deep-equal": "~3.1.3",
     "fast-json-stable-stringify": "~2.1.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,3 @@
-import 'array-flat-polyfill';
 import {default as clone_} from 'clone';
 import deepEqual_ from 'fast-deep-equal';
 import stableStringify from 'fast-json-stable-stringify';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,11 +2396,6 @@ array-back@^4.0.1, array-back@^4.0.2:
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
   integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
-array-flat-polyfill@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz#1e3a4255be619dfbffbfd1d635c1cf357cd034e7"
-  integrity sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==
-
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"


### PR DESCRIPTION
Supported since node 11
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.0--canary.8434.91e1716.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.6.0--canary.8434.91e1716.0
  # or 
  yarn add vega-lite@5.6.0--canary.8434.91e1716.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
