### PR TITLE
fix: prevent duplicate spec names in top-level selection view paths

### DIFF
--- a/src/normalize/toplevelselection.ts
+++ b/src/normalize/toplevelselection.ts
@@ -31,7 +31,7 @@ export class TopLevelSelectionsNormalizer extends SpecMapper<NormalizerParams, N
     }
 
     normParams.selections = selections;
-    return super.map(spec, addSpecNameToParams(spec, normParams));
+    return super.map(spec, normParams);
   }
 
   public mapUnit(spec: UnitSpec<Field>, normParams: NormalizerParams): NormalizedUnitSpec | NormalizedLayerSpec {


### PR DESCRIPTION
Address one bug from #8348. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.1--canary.8486.d7be769.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.6.1--canary.8486.d7be769.0
  # or 
  yarn add vega-lite@5.6.1--canary.8486.d7be769.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
