### PR TITLE
docs: add Scalene and CSrankings

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -105,7 +105,6 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [Scalene](https://github.com/plasma-umass/scalene): A CPU+GPU+memory profiler for Python.
 - [CSrankings](https://csrankings.org): a metrics-based ranking of top computer science institutions around the world.
 
-
 ## Tools for Embedding Vega-Lite Visualizations
 
 - <span class="octicon octicon-star"></span> [Vega-Embed](https://github.com/vega/vega-embed), a convenience wrapper for Vega and Vega-Lite.

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -102,6 +102,9 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [Datablocks](https://datablocks.pro), a node-based editor for exploring, analyzing and transforming data without code.
 - [Rath](https://github.com/Kanaries/Rath) An augmented analysis tool including auto-EDA, pattern discovery, multi-dimensional visualization recommendation, and interactive dashboards generation.
 - [MarkText](https://github.com/marktext/marktext): An open-source markdown editor that supports Vega-Lite.
+- [Scalene](https://github.com/plasma-umass/scalene): A CPU+GPU+memory profiler for Python.
+- [CSrankings](https://csrankings.org): a metrics-based ranking of top computer science institutions around the world.
+
 
 ## Tools for Embedding Vega-Lite Visualizations
 


### PR DESCRIPTION
* Scalene uses Vega-Lite for its visualizations in its (standard) web interface
* CSrankings uses Vega-Lite for bar charts / pie chart visualizations of faculty publication charts by area.
