### PR TITLE
fix: correctly handle merging of domains with more than one sort object

### DIFF
--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -589,7 +589,13 @@ export function mergeDomains(domains: VgNonUnionDomain[]): VgDomain {
       let sort = sorts[0];
       if (sorts.length > 1) {
         log.warn(log.message.MORE_THAN_ONE_SORT);
-        sort = true;
+        // Get sorts with non-default ops
+        const filteredSorts = sorts.filter(s => isObject(s) && 'op' in s && s.op !== 'min');
+        if (sorts.every(s => isObject(s) && 'op' in s) && filteredSorts.length === 1) {
+          sort = filteredSorts[0];
+        } else {
+          sort = true;
+        }
       } else {
         // Simplify domain sort by removing field and op when the field is the same as the domain field.
         if (isObject(sort) && 'field' in sort) {

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -1085,6 +1085,38 @@ describe('compile/scale', () => {
     );
 
     it(
+      'should warn if sorts conflict even if one sort object is not default',
+      log.wrap(localLogger => {
+        const domain = mergeDomains([
+          {
+            data: 'foo',
+            field: 'a',
+            sort: {
+              op: 'min'
+            }
+          },
+          {
+            data: 'foo',
+            field: 'a',
+            sort: {
+              op: 'sum'
+            }
+          }
+        ]);
+
+        expect(domain).toEqual({
+          data: 'foo',
+          field: 'a',
+          sort: {
+            op: 'sum'
+          }
+        });
+
+        expect(localLogger.warns[0]).toEqual(log.message.MORE_THAN_ONE_SORT);
+      })
+    );
+
+    it(
       'should warn if sorts conflict even if we do not union',
       log.wrap(localLogger => {
         const domain = mergeDomains([

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -1085,7 +1085,7 @@ describe('compile/scale', () => {
     );
 
     it(
-      'should warn if sorts conflict even if one sort object is not default',
+      'should use non-min aggregation when sort ops conflict',
       log.wrap(localLogger => {
         const domain = mergeDomains([
           {


### PR DESCRIPTION
Partially addresses https://github.com/vega/vega-lite/issues/5013