### PR TITLE
fix: prevent warning when autosize type and width/height type are compatible

### DIFF
--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -163,17 +163,22 @@ function getTopLevelProperties(
       log.warn(log.message.droppingFit());
       autosize.type = 'pad';
     } else if (width === 'step' || height === 'step') {
-      // effectively XOR, because else if
 
       // get step dimension
       const sizeType = width === 'step' ? 'width' : 'height';
-      // log that we're dropping fit for respective channel
-      log.warn(log.message.droppingFit(getPositionScaleChannel(sizeType)));
 
-      // setting type to inverse fit (so if we dropped fit-x, type is now fit-y)
+      // get inverse fit (so if we had fit-x, type is now fit-y)
       const inverseSizeType = sizeType === 'width' ? 'height' : 'width';
-      autosize.type = getFitType(inverseSizeType);
+      const inverseFitType = getFitType(inverseSizeType)
+
+      // check if we need to update the fit type
+      if (autosize.type !== inverseFitType) {
+        // log that we're dropping fit for respective channel
+        log.warn(log.message.droppingFit(getPositionScaleChannel(sizeType)));
+        // setting type to the inverse fit
+        autosize.type = inverseFitType;
     }
+      }
   }
 
   return {

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -171,6 +171,48 @@ describe('compile/compile', () => {
     })
   );
 
+  it(
+    'should NOT drop fit-x in top-level properties for fit-x chart with specified width',
+    log.wrap(localLogger => {
+      const {spec} = compile({
+        data: {
+          values: [{x: 'foo', y: 1}]
+        },
+        width: 400,
+        autosize: 'fit-x',
+        mark: 'point',
+        encoding: {
+          x: {field: 'x', type: 'nominal'},
+          y: {field: 'y', type: 'quantitative'}
+        }
+      });
+
+      expect(localLogger.warns).toHaveLength(0);
+      expect(spec.autosize).toBe('fit-x');
+    })
+  );
+
+  it(
+    'should NOT drop fit-y in top-level properties for fit-y chart with specified height',
+    log.wrap(localLogger => {
+      const {spec} = compile({
+        data: {
+          values: [{x: 'foo', y: 1}]
+        },
+        height: 400,
+        autosize: 'fit-y',
+        mark: 'point',
+        encoding: {
+          x: {field: 'x', type: 'nominal'},
+          y: {field: 'y', type: 'quantitative'}
+        }
+      });
+
+      expect(localLogger.warns).toHaveLength(0);
+      expect(spec.autosize).toBe('fit-y');
+    })
+  );
+
   it('should use size signal for bar chart width', () => {
     const {spec} = compile({
       data: {values: [{a: 'A', b: 28}]},


### PR DESCRIPTION
Currently a "Dropping fit-y" warning is generated even if `autosize` is set to `fit-x`. 
This fix checks the fit type before generating the warning.

Screenshot of the issue:
<img width="970" alt="Screen Shot 2022-11-30 at 2 17 10 PM" src="https://user-images.githubusercontent.com/42784736/204888521-bc9fe260-eec5-4073-97b3-d414dcf36991.png">

