### PR TITLE
chore: align input sliders with numbers

### DIFF
--- a/site/static/main.css
+++ b/site/static/main.css
@@ -583,6 +583,11 @@ footer .edit-page {
   max-width: 180px;
 }
 
+.example .vega-bind input {
+  vertical-align: text-bottom;
+  margin-right: 3px;
+}
+
 .example .vega-bind-name {
   display: inline-block;
   min-width: 150px;


### PR DESCRIPTION
I am trying to make the change shown for `0` in this screenshot, so that the text is not far below the sliders. I am not 100% sure this is the right css syntax so please double check

![image](https://user-images.githubusercontent.com/4560057/205109821-d5405b06-4da4-4e10-9eb8-99f730466d7b.png)
