### PR TITLE
docs: correct link to docs instead of editor

### DIFF
--- a/site/_data/examples.json
+++ b/site/_data/examples.json
@@ -23,12 +23,12 @@
       {
         "name": "bar_grouped",
         "title": "Grouped Bar Chart",
-        "description": "Read [here](https://vega.github.io/editor/#/examples/vega-lite/size.html#offset-step) for more details about how to set step size for grouped bar. "
+        "description": "Read [here](https://vega.github.io/vega-lite/docs/size.html#offset-step) for more details about how to set step size for grouped bar. "
       },
       {
         "name": "bar_grouped_repeated",
         "title": "Grouped Bar Chart (Multiple Measure with Repeat)",
-        "description": "Read [here](https://vega.github.io/editor/#/examples/vega-lite/size.html#offset-step) for more details about how to set step size for grouped bar. "
+        "description": "Read [here](https://vega.github.io/vega-lite/docs/size.html#offset-step) for more details about how to set step size for grouped bar. "
       },
       {
         "name": "stacked_bar_weather",

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -601,10 +601,8 @@ export interface RelativeBandSize {
 }
 
 // Point/Line OverlayMixins are only for area, line, and trail but we don't want to declare multiple types of MarkDef
-export interface MarkDef<
-  M extends string | Mark = Mark,
-  ES extends ExprRef | SignalRef = ExprRef | SignalRef
-> extends GenericMarkDef<M>,
+export interface MarkDef<M extends string | Mark = Mark, ES extends ExprRef | SignalRef = ExprRef | SignalRef>
+  extends GenericMarkDef<M>,
     Omit<
       MarkConfig<ES> &
         AreaConfig<ES> &


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.1--canary.8592.fcbd150.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.6.1--canary.8592.fcbd150.0
  # or 
  yarn add vega-lite@5.6.1--canary.8592.fcbd150.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
