### PR TITLE
docs: remove stars from some libraries on ecosystem page

### DIFF
--- a/site/_includes/docs_toc.md
+++ b/site/_includes/docs_toc.md
@@ -96,7 +96,6 @@
         - [Window Transform Definition]({{site.baseurl}}/docs/window.html#window-transform-definition)
         - [Window Only Operation Reference]({{site.baseurl}}/docs/window.html#ops)
         - [Examples]({{site.baseurl}}/docs/window.html#examples)
-        - [Additional Examples]({{site.baseurl}}/docs/window.html#additional-examples)
 - [Mark]({{site.baseurl}}/docs/mark.html)
     - [Documentation Overview]({{site.baseurl}}/docs/mark.html#documentation-overview)
     - [Mark Types]({{site.baseurl}}/docs/mark.html#types)

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -45,7 +45,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 
 - <span class="octicon octicon-star"></span> [Altair](https://altair-viz.github.io) exposes a Python API for building statistical visualizations that follows Vega-Lite syntax.
 - <span class="octicon octicon-star"></span> [Vega-Lite API](https://github.com/vega/vega-lite-api) is a JavaScript API for creating Vega-Lite JSON specifications.
-- <span class="octicon octicon-star"></span> [Elm-Vega](https://package.elm-lang.org/packages/gicentre/elm-vega/latest) generates Vega-Lite specifications in the pure functional language [Elm](https://elm-lang.org).
+- <span class="octicon octicon-star"></span> [elm-vegaLite](https://package.elm-lang.org/packages/gicentre/elm-vegalite/latest) generates Vega-Lite specifications in the pure functional language [Elm](https://elm-lang.org).
 - [Altair wrapper in R](https://vegawidget.github.io/altair/)
 - [ipyvega](https://github.com/vega/ipyvega) supports Vega and Vega-Lite charts in Jupyter Notebooks.
 - [VegaLite (Elixir bindings)](https://github.com/elixir-nx/vega_lite).

--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -16,9 +16,9 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 
 - <span class="octicon octicon-star"></span> [Vega-Editor](https://vega.github.io/editor/), the online editor for Vega and Vega-Lite. You can also get an output Vega spec from a given Vega-Lite spec as well.
 - <span class="octicon octicon-star"></span> [Vega Viewer](https://github.com/RandomFractals/vscode-vega-viewer), a VSCode extension for interactive preview of Vega and Vega-Lite maps and graphs.
-- <span class="octicon octicon-star"></span> [vega-desktop](https://github.com/kristw/vega-desktop), a desktop app that lets you open `.vg.json` and `.vl.json` to see visualizations just like you open image files with an image viewer. This is useful for [creating visualizations with Vega/Vega-Lite locally](https://medium.com/@kristw/create-visualizations-with-vega-on-your-machine-using-your-preferred-editor-529e1be875c0).
+- [vega-desktop](https://github.com/kristw/vega-desktop), a desktop app that lets you open `.vg.json` and `.vl.json` to see visualizations just like you open image files with an image viewer. This is useful for [creating visualizations with Vega/Vega-Lite locally](https://medium.com/@kristw/create-visualizations-with-vega-on-your-machine-using-your-preferred-editor-529e1be875c0).
 - <span class="octicon octicon-star"></span> [Voyager (2)](https://github.com/vega/voyager), visualization tool for exploratory data analysis that blends a Tableau-style specification interface (formerly [Polestar](https://github.com/vega/polestar)) with chart recommendations (formerly the Voyager visualization browser) and generates Vega-Lite visualizations.
-- <span class="octicon octicon-star"></span>[Bayes](https://bayes.com) - A creative data exploration and storytelling tool. Easily create and publish Vega-Lite visualizations.
+- [Bayes](https://bayes.com) - A creative data exploration and storytelling tool. Easily create and publish Vega-Lite visualizations.
 - [data.world Chart Builder](https://data.world/integrations/chart-builder), a chart builder that imports data from queries in data.world. The generated specs can be saved locally or uploaded back to data.world. Project is [open source](https://github.com/datadotworld/chart-builder).
 - [ColorBrewer-Lite](https://github.com/vis-au/colorbrewer), a fork of the ColorBrewer project that allows importing Vega-Lite specifications into the ColorBrewer interface to pick effective color schemes "in situ" for any color encoding.
 - [Emacs Vega View](https://github.com/applied-science/emacs-vega-view), a tool that allows one to view Vega visualizations directly within emacs, currently supporting specs written in JSON, elisp or clojure.
@@ -39,7 +39,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 ## Plug-ins for Vega-Lite
 
 - <span class="octicon octicon-star"></span> [Tooltips for Vega and Vega-Lite](https://github.com/vega/vega-lite-tooltip)
-- <span class="octicon octicon-star"></span> [Leaflet Tile Map integration for Vega and Vega-Lite](https://github.com/nyurik/leaflet-vega)
+- [Leaflet Tile Map integration for Vega and Vega-Lite](https://github.com/nyurik/leaflet-vega)
 
 ## Bindings for Programming Languages
 
@@ -108,7 +108,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 ## Tools for Embedding Vega-Lite Visualizations
 
 - <span class="octicon octicon-star"></span> [Vega-Embed](https://github.com/vega/vega-embed), a convenience wrapper for Vega and Vega-Lite.
-- <span class="octicon octicon-star"></span>[Flourish](https://flourish.studio/2018/05/29/vega-lite-in-flourish/) - Visualization and Storytelling Platform
+- <span class="octicon octicon-star"></span> [Flourish](https://flourish.studio/2018/05/29/vega-lite-in-flourish/) - Visualization and Storytelling Platform
 - [Visdown](http://visdown.com), a web app to create Vega-Lite visualizations in Markdown. Specs are written in [YAML](http://www.yaml.org/) (not JSON) within `code` blocks.
 - [vega-element](https://www.webcomponents.org/element/PolymerVis/vega-element) is a Polymer web component to embed Vega or Vega-Lite visualization using custom HTML tags.
 - [marked-vega](https://www.webcomponents.org/element/PolymerVis/marked-vega) is a Polymer web component to parse image/code markdowns into Vega and Vega-Lite charts.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -193,11 +193,11 @@ const {row: _r, column: _c, facet: _f, ...SINGLE_DEF_UNIT_CHANNEL_INDEX} = SINGL
 
 export const SINGLE_DEF_CHANNELS = keys(SINGLE_DEF_CHANNEL_INDEX);
 
-export type SingleDefChannel = typeof SINGLE_DEF_CHANNELS[number];
+export type SingleDefChannel = (typeof SINGLE_DEF_CHANNELS)[number];
 
 export const SINGLE_DEF_UNIT_CHANNELS = keys(SINGLE_DEF_UNIT_CHANNEL_INDEX);
 
-export type SingleDefUnitChannel = typeof SINGLE_DEF_UNIT_CHANNELS[number];
+export type SingleDefUnitChannel = (typeof SINGLE_DEF_UNIT_CHANNELS)[number];
 
 export function isSingleDefUnitChannel(str: string): str is SingleDefUnitChannel {
   return !!SINGLE_DEF_UNIT_CHANNEL_INDEX[str];
@@ -389,7 +389,7 @@ const {
 } = UNIT_CHANNEL_INDEX;
 
 export const NONPOSITION_CHANNELS = keys(NONPOSITION_CHANNEL_INDEX);
-export type NonPositionChannel = typeof NONPOSITION_CHANNELS[number];
+export type NonPositionChannel = (typeof NONPOSITION_CHANNELS)[number];
 
 const POSITION_SCALE_CHANNEL_INDEX = {
   x: 1,
@@ -418,7 +418,7 @@ const OFFSET_SCALE_CHANNEL_INDEX: {xOffset: 1; yOffset: 1} = {xOffset: 1, yOffse
 
 export const OFFSET_SCALE_CHANNELS = keys(OFFSET_SCALE_CHANNEL_INDEX);
 
-export type OffsetScaleChannel = typeof OFFSET_SCALE_CHANNELS[0];
+export type OffsetScaleChannel = (typeof OFFSET_SCALE_CHANNELS)[0];
 
 export function isXorYOffset(channel: Channel): channel is OffsetScaleChannel {
   return channel in OFFSET_SCALE_CHANNEL_INDEX;
@@ -441,7 +441,7 @@ const {
   ...NONPOSITION_SCALE_CHANNEL_INDEX
 } = NONPOSITION_CHANNEL_INDEX;
 export const NONPOSITION_SCALE_CHANNELS = keys(NONPOSITION_SCALE_CHANNEL_INDEX);
-export type NonPositionScaleChannel = typeof NONPOSITION_SCALE_CHANNELS[number];
+export type NonPositionScaleChannel = (typeof NONPOSITION_SCALE_CHANNELS)[number];
 
 export function isNonPositionScaleChannel(channel: Channel): channel is NonPositionScaleChannel {
   return !!NONPOSITION_CHANNEL_INDEX[channel];
@@ -478,7 +478,7 @@ const SCALE_CHANNEL_INDEX = {
 
 /** List of channels with scales */
 export const SCALE_CHANNELS = keys(SCALE_CHANNEL_INDEX);
-export type ScaleChannel = typeof SCALE_CHANNELS[number];
+export type ScaleChannel = (typeof SCALE_CHANNELS)[number];
 
 export function isScaleChannel(channel: Channel): channel is ScaleChannel {
   return !!SCALE_CHANNEL_INDEX[channel];

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -27,7 +27,7 @@ export type BoxPlot = typeof BOXPLOT;
 
 export const BOXPLOT_PARTS = ['box', 'median', 'outliers', 'rule', 'ticks'] as const;
 
-type BoxPlotPart = typeof BOXPLOT_PARTS[number];
+type BoxPlotPart = (typeof BOXPLOT_PARTS)[number];
 
 export type BoxPlotPartsMixins = PartsMixins<BoxPlotPart>;
 

--- a/src/compositemark/errorband.ts
+++ b/src/compositemark/errorband.ts
@@ -18,7 +18,7 @@ export type ErrorBand = typeof ERRORBAND;
 
 export const ERRORBAND_PARTS = ['band', 'borders'] as const;
 
-type ErrorBandPart = typeof ERRORBAND_PARTS[number];
+type ErrorBandPart = (typeof ERRORBAND_PARTS)[number];
 
 export type ErrorBandPartsMixins = PartsMixins<ErrorBandPart>;
 

--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -44,7 +44,7 @@ export type ErrorInputType = 'raw' | 'aggregated-upper-lower' | 'aggregated-erro
 
 export const ERRORBAR_PARTS = ['ticks', 'rule'] as const;
 
-export type ErrorBarPart = typeof ERRORBAR_PARTS[number];
+export type ErrorBarPart = (typeof ERRORBAR_PARTS)[number];
 
 export interface ErrorExtraEncoding<F extends Field> {
   /**


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.1--canary.8641.fe3f2dd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vega-lite@5.6.1--canary.8641.fe3f2dd.0
  # or 
  yarn add vega-lite@5.6.1--canary.8641.fe3f2dd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
