### PR TITLE
fix: Allow width and height in LayerRepeatSpec

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -12467,6 +12467,9 @@
               "$ref": "#/definitions/LayerSpec"
             },
             {
+              "$ref": "#/definitions/UnitSpecWithFrame"
+            },
+            {
               "$ref": "#/definitions/UnitSpec"
             }
           ],
@@ -29221,6 +29224,9 @@
               "anyOf": [
                 {
                   "$ref": "#/definitions/LayerSpec"
+                },
+                {
+                  "$ref": "#/definitions/UnitSpecWithFrame"
                 },
                 {
                   "$ref": "#/definitions/UnitSpec"

--- a/src/spec/repeat.ts
+++ b/src/spec/repeat.ts
@@ -2,7 +2,7 @@ import {isArray} from 'vega-util';
 import {LayerSpec, NonNormalizedSpec} from '.';
 import {Field} from '../channeldef';
 import {BaseSpec, GenericCompositionLayoutWithColumns, ResolveMixins} from './base';
-import {UnitSpec} from './unit';
+import {UnitSpec, UnitSpecWithFrame} from './unit';
 
 export interface RepeatMapping {
   /**
@@ -53,7 +53,7 @@ export interface LayerRepeatSpec extends BaseSpec, GenericCompositionLayoutWithC
   /**
    * A specification of the view that gets repeated.
    */
-  spec: LayerSpec<Field> | UnitSpec<Field>;
+  spec: LayerSpec<Field> | UnitSpecWithFrame<Field> | UnitSpec<Field>;
 }
 
 export function isRepeatSpec(spec: BaseSpec): spec is RepeatSpec {


### PR DESCRIPTION
This is an attempt to fix the issue raised in #8523 by allowing the `spec` parameter to be a `UnitSpecWithFrame`, in addition to the current options of `LayerSpec` and `UnitSpec`.

Here is an example of a spec that raises warnings currently but does not raise a warning in this PR.  (I deleted the `$schema` parameter from Mattijn's original spec.)  [Open the Chart in the Vega Editor](https://vega.github.io/editor/#/url/vega-lite/N4IgTgpgDhCGAuIBcoA2sCeEzINogFUBlAfQHEwB7AZ2pABoQB1SsVAEwHcBLdicqrRABdRgGNKqAK4BbAHZ4QASQCyAEQBCJAEoJucgOYMQ2yvHgQ5JACqUZCShGo69hkQF9G1GGOSge7PAAFsgATAAM4YxBENwGQYhIAIwAzFEg7AiwfiBSbMggCfBQ1EgA9GVi7HIAdABW1Hyo3ABuYDVyEPBlclAyZS0QBrAAtJnwsNRd1AACLUk1oQCcNeFl47BlMpQt3E711JQKniD2YADWBc2dxpYS7PpGKCASqKw547I5kDAIV5jYEDuE4ADxyACN9Mh4GApBBGAAzPYcb7QOCJF6SWTHE4YHKwAwGSDDCwFGRwBSI5HsVG-DHoLA4E7wbjwVAQAoqCkAAkoCO5xG5sDk7G5LDYXF4EG5FBodGBwKAA)

Thanks for looking and for any feedback!