### PR TITLE
docs: remove the duplicate 'Expr' on the sidebar

### DIFF
--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -146,9 +146,6 @@ sidebar:
     sub-sidebar:
       - text: Value
         url: value
-      - text: Expr
-        url: parameter
-        anchor: '#expr'
       - text: Bind
         url: bind
       - text: Select


### PR DESCRIPTION
I find "Expr" on the sidebar of doc is duplicate with its parent 'Parameter' link.

No evidence was found that this was done intentionally. So I just remove it.

![image](https://user-images.githubusercontent.com/54462/216085264-a517a0ae-2ed7-483e-9e9d-2135f033622c.png)

![image](https://user-images.githubusercontent.com/54462/216086857-1a380108-dcca-425a-8f90-5330ec40694d.png)
