### PR TITLE
fix: handle falsy legend values in selections

### DIFF
--- a/src/compile/selection/legends.ts
+++ b/src/compile/selection/legends.ts
@@ -72,7 +72,7 @@ const legendBindings: SelectionCompiler<'point'> = {
           ...(!selCmpt.init ? {value: null} : {}),
           on: [
             // Legend entries do not store values, so we need to walk the scenegraph to the symbol datum.
-            {events, update: 'datum.value || item().items[0].items[0].datum.value', force: true},
+            {events, update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value', force: true},
             {events: stream.merge, update: `!event.item || !datum ? null : ${sgName}`, force: true}
           ]
         });

--- a/src/compile/selection/legends.ts
+++ b/src/compile/selection/legends.ts
@@ -72,7 +72,7 @@ const legendBindings: SelectionCompiler<'point'> = {
           ...(!selCmpt.init ? {value: null} : {}),
           on: [
             // Legend entries do not store values, so we need to walk the scenegraph to the symbol datum.
-            {events, update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value', force: true},
+            {events, update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value', force: true},
             {events: stream.merge, update: `!event.item || !datum ? null : ${sgName}`, force: true}
           ]
         });

--- a/test/compile/selection/legends.test.ts
+++ b/test/compile/selection/legends.test.ts
@@ -139,7 +139,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
+              update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -186,7 +186,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
+              update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -227,7 +227,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
+              update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -264,7 +264,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
+              update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -301,7 +301,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
+              update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -431,7 +431,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
+              update: 'datum.value != null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {

--- a/test/compile/selection/legends.test.ts
+++ b/test/compile/selection/legends.test.ts
@@ -139,7 +139,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -186,7 +186,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -227,7 +227,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -264,7 +264,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -301,7 +301,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -431,7 +431,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'datum.value !== null? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {


### PR DESCRIPTION
Proposed fix for https://github.com/vega/vega-lite/issues/8143.

The problem this PR addresses is that when a boolean column is present in the legend, and a selection is bound to the legend, clicking on the `false` entry does nothing.

The problem is this expression:
```
datum.value || item().items[0].items[0].datum.value
```
When `datum.value` is falsy, it's value is never used. Instead, I think this expression should be

```
datum.value != null? datum.value: item().items[0].items[0].datum.value
```
so that the datum's value is used as long as it's not null or undefined.

---
Here is the result of this change for the repro in #8143

[Open the Chart in the Vega Editor](https://vega.github.io/editor/#/url/vega/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykSArJQBWENgDsQAGhBMkUANZkATmwbiAJmhAB3GHTjSQOJBo01xZNAJnwaZLGgDMABhcyImAJ4AbQ+ig4Hx8jDSRMFFQAbVBxJAR-EAgguChMNmUXACYsgH1PDMMAXylY+MSxBmVA3JcjKpD0LFx8IigNcREIDSCaYmVKcThMAnEcBF4KAFowiOTMCAABYgBGSiyATkoXAln+OWU-Ly6JIwAzDORMNFBvHETRU5KQTGUkcQgL5QQ0GJeve7aL4IBg+FAyOAADxwym0swYCEoxCQyhowy8AF4MQByADiYKYqnE2KMSAg2iYIBKtwBiTONB8mDgsIh0Nh6BoEAAakgfDQNAAKeEIKIAHRAXjRPg04oAugBKAAEADJlYrOQAxCwGAUAamFYolUplIAVVNlRVlHnscR85OiZQS2kh+SZOCMyJ8DH8WRc1JAcSd6B0-Po9Rws0Sck0EBMgSFbGQFgF2Mh2PllD8lnoUkVK1zLkoAiVACpFS7PHB3f7A4l1HQPbzvTdnqcHSA4KRxAttAg1Mk+6Rw5HtJyACoMHB+AUqNQ4AXypUAfkVs8nC8VqEV9eulpr5W0yT8aQy2TyTFyfjIcE0ja9-nEoJ8Mjbf07N577cq1USxDROiMO5EigPlFCMZBlAUWsKUvcgbw0fIvAQJg2DtKlSiSNQf20P84AAmQgO0ECaDAmQIKgg90AvK94MvJAmCCcl-W-QIcP-QDaSI0CFHAlEKKDWRYOvTRcg-VE4CYq0QEnEd0GFJEmzgRUAEIMUVR9ghXeTPW9LcDAQBdWCZBAICiFxZSMxBTPMyhtMU84MlY1BXm9f1327e0-hY392IIziAm480ZBk8JEmU9zMEshBFQAHxilThUVFcNJ8TdFSPVJ0kyHJcmouDbxkL4nJcuA9ww6D0Ayk9sqyYdQpwnwAGUUjSdhxAAJQk1DSAFcUqqys9XUKcVc3FesJBGxUStzEr5XQx0KhagacswSc-DqplDyW08cry4SNBUrF1KfJLFWAekgg0fB0u2mrclWqc4FyC7pQgXMdIkrcon6nbzyE+CLTSlL5oDSikluwaHr8Z7jXJGQPt+GlAXQABRc5jQpc19wEn67vSMgyHW+H7NQM5eWSF9JHbCL7VABJlGvRHMKqJyQFw-D-mRkBiLAsrpIjer0AiygIH0M5MAAaTgLwsfKsHccGvtzDOGXKaZmmbiSG1eS249lryKHimCgXNvQJWaBV3rwb136huUOBJoVla2AJvxTpStKnYNta4FzL37pdwmlOSk6t2mm6bbxwO3ZXf3DaBp85r3KTyM8hbez4uHOYqJCUJCDxvHW6JjDYCxriksvmXkTA+n8aaQDOVQflQUA9kPLCajqZ4bygNgek1kLTdANg4zoGX2yZTxtGUrMyHoIVwiQK3-YKe3xUXWL4uIJqlrascJMwZeIZy1eHekRVhTm4n7zQFZ-QR1BCyyS1CoZRpQAfl43g+Ex7e7dCkivDYAofwoBoC8mAqhDI6NLo4RRGibwAD4FIHaqhOAAARCSUBUQ4Brm2D+JMS5lwAT0aAOC8FUzAdrRoIBxReDgCiLc4pFS6kVAKTkPI+SCgNHQhhyg5TLgvuEBEhp6EojlGlcU4p9TCJFLw8RpolSsPFAAbkVJKS6TCQAsLYcCcIC9VpyKNJdOUo1aEgA3sokAajkTiW8FonR7DuS8n5AYkR4pbEIK8AI06PC2bwPRBIrR0i-GeMCYonRqjFRMAcawpxnDXF+KYD4rSsjDTJNNJI8xMjDHpIEQAyEmtwFFxAIU1+sD0BiNhM8ceYCoAQO0KrBuGNKkY2eKLJAyM6kNMqjATphhynSkxkUEZL8kj1L8GnUGAkynZ20DgUu-8ZAaETEgCwms26VQ7k9OogytCVL4UYMQyhrjOWUK5GQ39GYt0AVWIp1DnSujuSMmQJgzAWCsI-Is2NEhNMIugPkQwUShFWesm5mzmY-lqDAoZrTYHPCuf4LyDymhwHsI4Eo5kZDiBInXc5vsQAAC9mRsDQCVH5REoEsjmegDI5hbQgqTJQkAELvLQr2XAuxTTjmnPJZc941zuahTIBkGWFLen9I4lzOlFgdbLNBcy1l2z2XNIqbII5GReX4oRQKnOyFUJBRAEgSEEkmbFN+UYDIaJ-4ArgOLIwKh+SNQmYkWZjr9n1xrooAAwmoG1VCyAMoCGinwAo7AOBGAAFhcEneVTK0BkztASgkjEE3kwJcgtNSayLGpRpCJkNr3AgAQBYPNBbTlFq9Qoe0iaKZEosD0Qpj9mIuudJa8SNrZBsGwImB1qJ9m1oJTXTAJSqlGBTT4AAgnyQN2hUQRvHfRIIk7LBFyyAAdiLROgAQmSXoQxez8g0ETetmgoRoD9Bhc1jT23WtOSAPw9qZDuqzXW4do6MYyAnQAeVIIcTpZL8UERIgoX16hTkBqDdzENYa0URoING2Np7G0XrGTRGMZqgEgMpT4aBHhc6oTHP5bmNBqgnvfb+AJiCITiF7v3G5EACNoRuYPUBzTgia0-q8d4sYUQfgASPeQY9OMkzvqM5ifSuYdMBPh-VPgiNcygKRkCAyXh0BKZSGjdG2MTtptMqM-0RK6aMJXN4rUhxnO9MbWSw9R6IIngfbQAoZ43jnjAAxS8+rHzyKfdeSo4psK9nkzJqp1RnshGwM4AogvigyVaIRhiFL3iVAAPjUjGq+-ib6oDvhhB+hYnACD3O0pjemKqCXQwhRjcms6merrXQDVn+Y2fY+-LLzZ0DcZ-nx-+rY7Pjz+JPe9znZ7zz2EfSOg1fMWP8-FaL3nguyhVGqBtUJIvzcmzkRbuY7LJcVGlxUGW7wddywQ7LBWisWm7t2cSZWwZ7VomJNEtXuxV3M3iprrHNb0g4zcrj39eN-13OJi0QA)