### PR TITLE
feat: simplify rollup script and update to more modern js

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,7 +11,7 @@ import pkg from './package.json' assert {type: 'json'};
 export function disallowedImports() {
   return {
     resolveId: module => {
-      if (module === 'vega' || module === 'util' || module === 'd3') {
+      if (['vega', 'util', 'd3'].includes(module)) {
         throw new Error('Cannot import from Vega, Node Util, or D3 in Vega-Lite.');
       }
       return null;
@@ -76,7 +76,7 @@ const outputs = [
           [
             '@babel/env',
             {
-              targets: 'defaults and not IE 11'
+              targets: 'defaults'
             }
           ],
           '@babel/typescript'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
+    "target": "ES2020",
+    "module": "ES2020",
     "moduleResolution": "Node",
 
     "esModuleInterop": true,


### PR DESCRIPTION
The defaults browserlists already doesn't include IE anymore. Also switching to es2020