### PR TITLE
fix: repair docs site examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ts-jest": "^29.0.5",
     "ts-json-schema-generator": "^1.2.0",
     "typescript": "~4.9.5",
-    "vega-cli": "^5.22.1",
+    "vega-cli": "^5.24.0",
     "vega-datasets": "~2.7.0",
     "vega-embed": "^6.21.3",
     "vega-tooltip": "^0.31.0",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
     "vega-util": "~1.17.0",
     "yargs": "~17.7.0"
   },
+  "resolutions": {
+    "vega-scale": "7.3.0"
+  },
   "peerDependencies": {
     "vega": "^5.24.0"
   },


### PR DESCRIPTION
## Motivation

- Quick fix for #8841

## Changes

- Ran `yarn why vega-scale` to find that both vega-scale `7.2.0` and `7.3.0` were present, when only was expecting
- Pining repo to `7.3.0` would prevent different libraries from accessing different versions.

## Testing

- Build site locally, confirm that the currently broken examples render correctly
- I'm not able to update the lockfile locally - something about python or C dependencies erroring out. Maybe this is something that can be regenerated and exported from CI, or by a maintainer with a working local environment.

## Notes

- Longer term fix -> try to adjust dependencies (possibly upstream) so that only one version of vega-scale is needed
- TODO: look into visual regression testing to detect this type of issue programmatically in the future
