### PR TITLE
Add support for tiles to geoshape mark

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -144,6 +144,9 @@
         },
         {
           "$ref": "#/definitions/TickConfig"
+        },
+        {
+          "$ref": "#/definitions/GeoshapeConfig"
         }
       ]
     },
@@ -7625,7 +7628,7 @@
           "type": "string"
         },
         "geoshape": {
-          "$ref": "#/definitions/MarkConfig",
+          "$ref": "#/definitions/GeoshapeConfig",
           "description": "Geoshape-Specific Config"
         },
         "header": {
@@ -11426,6 +11429,820 @@
         "geometries",
         "type"
       ],
+      "type": "object"
+    },
+    "GeoshapeConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Align"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The horizontal alignment of the text or ranged marks (area, bar, image, rect, rule). One of `\"left\"`, `\"right\"`, `\"center\"`.\n\n__Note:__ Expression reference is *not* supported for range marks."
+        },
+        "angle": {
+          "anyOf": [
+            {
+              "description": "The rotation angle of the text, in degrees.",
+              "maximum": 360,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "aria": {
+          "anyOf": [
+            {
+              "description": "A boolean flag indicating if [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) should be included (SVG output only). If `false`, the \"aria-hidden\" attribute will be set on the output SVG element, removing the mark item from the ARIA accessibility tree.",
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "ariaRole": {
+          "anyOf": [
+            {
+              "description": "Sets the type of user interface element of the mark item for [ARIA accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) (SVG output only). If specified, this property determines the \"role\" attribute. Warning: this property is experimental and may be changed in the future.",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "ariaRoleDescription": {
+          "anyOf": [
+            {
+              "description": "A human-readable, author-localized description for the role of the mark item for [ARIA accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) (SVG output only). If specified, this property determines the \"aria-roledescription\" attribute. Warning: this property is experimental and may be changed in the future.",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "aspect": {
+          "anyOf": [
+            {
+              "description": "Whether to keep aspect ratio of image marks.",
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "baseline": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextBaseline"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "For text marks, the vertical text baseline. One of `\"alphabetic\"` (default), `\"top\"`, `\"middle\"`, `\"bottom\"`, `\"line-top\"`, `\"line-bottom\"`, or an expression reference that provides one of the valid values. The `\"line-top\"` and `\"line-bottom\"` values operate similarly to `\"top\"` and `\"bottom\"`, but are calculated relative to the `lineHeight` rather than `fontSize` alone.\n\nFor range marks, the vertical alignment of the marks. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Note:__ Expression reference is *not* supported for range marks."
+        },
+        "blend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Blend",
+              "description": "The color blend mode for drawing an item on its current background. Any valid [CSS mix-blend-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) value can be used.\n\n__Default value: `\"source-over\"`"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/Gradient"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Default color.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__\n- This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).\n- The `fill` and `stroke` properties have higher precedence than `color` and will override `color`."
+        },
+        "cornerRadius": {
+          "anyOf": [
+            {
+              "description": "The radius in pixels of rounded rectangles or arcs' corners.\n\n__Default value:__ `0`",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "cornerRadiusBottomLeft": {
+          "anyOf": [
+            {
+              "description": "The radius in pixels of rounded rectangles' bottom left corner.\n\n__Default value:__ `0`",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "cornerRadiusBottomRight": {
+          "anyOf": [
+            {
+              "description": "The radius in pixels of rounded rectangles' bottom right corner.\n\n__Default value:__ `0`",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "cornerRadiusTopLeft": {
+          "anyOf": [
+            {
+              "description": "The radius in pixels of rounded rectangles' top right corner.\n\n__Default value:__ `0`",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "cornerRadiusTopRight": {
+          "anyOf": [
+            {
+              "description": "The radius in pixels of rounded rectangles' top left corner.\n\n__Default value:__ `0`",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "cursor": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Cursor",
+              "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "description": {
+          "anyOf": [
+            {
+              "description": "A text description of the mark item for [ARIA accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) (SVG output only). If specified, this property determines the [\"aria-label\" attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute).",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "dir": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextDirection",
+              "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "dx": {
+          "anyOf": [
+            {
+              "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "dy": {
+          "anyOf": [
+            {
+              "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "ellipsis": {
+          "anyOf": [
+            {
+              "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "endAngle": {
+          "anyOf": [
+            {
+              "description": "The end angle in radians for arc marks. A value of `0` indicates up (north), increasing values proceed clockwise.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/Gradient"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Default fill color. This property has higher precedence than `config.color`. Set to `null` to remove fill.\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "anyOf": [
+            {
+              "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `false` for all `point`, `line`, and `rule` marks as well as `geoshape` marks for [`graticule`](https://vega.github.io/vega-lite/docs/data.html#graticule) data sources; otherwise, `true`.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "anyOf": [
+            {
+              "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "fontSize": {
+          "anyOf": [
+            {
+              "description": "The font size, in pixels.\n\n__Default value:__ `11`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "fontStyle": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontStyle",
+              "description": "The font style (e.g., `\"italic\"`)."
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "fontWeight": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight",
+              "description": "The font weight. This can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "height": {
+          "anyOf": [
+            {
+              "description": "Height of the marks.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "href": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/URI",
+              "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink."
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "innerRadius": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.\n\n__Default value:__ `0`",
+          "minimum": 0
+        },
+        "interpolate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Interpolate",
+              "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0` -- indicating no limit",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "lineBreak": {
+          "anyOf": [
+            {
+              "description": "A delimiter, such as a newline character, upon which to break text strings into multiple lines. This property is ignored if the text is array-valued.",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "lineHeight": {
+          "anyOf": [
+            {
+              "description": "The line height in pixels (the spacing between subsequent lines of text) for multi-line text marks.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0
+        },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "orient": {
+          "$ref": "#/definitions/Orientation",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts. The value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick should be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line if `config.sortLineBy` is not specified. For stacked charts, this is always determined by the orientation of the stack; therefore explicitly specified value will be ignored."
+        },
+        "outerRadius": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.\n\n__Default value:__ `0`",
+          "minimum": 0
+        },
+        "padAngle": {
+          "anyOf": [
+            {
+              "description": "The angular padding applied to sides of the arc, in radians.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "radius": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.\n\n__Default value:__ `min(plot_width, plot_height)/2`",
+          "minimum": 0
+        },
+        "radius2": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The secondary (inner) radius in pixels of arc marks.\n\n__Default value:__ `0`",
+          "minimum": 0
+        },
+        "shape": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SymbolShape"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Shape of the point marks. Supported values include:\n- plotting shapes: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n- the line symbol `\"stroke\"`\n- centered directional shapes `\"arrow\"`, `\"wedge\"`, or `\"triangle\"`\n- a custom [SVG path string](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) (For correct sizing, custom shape paths should be defined within a square bounding box with coordinates ranging from -1 to 1 along both the x and y dimensions.)\n\n__Default value:__ `\"circle\"`"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. Note that this value sets the area of the symbol; the side lengths will increase with the square root of this value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__\n- `30` for point, circle, square marks; width/height's `step`\n- `2` for bar marks with discrete dimensions;\n- `5` for bar marks with continuous dimensions;\n- `11` for text marks.",
+          "minimum": 0
+        },
+        "smooth": {
+          "anyOf": [
+            {
+              "description": "A boolean flag (default true) indicating if the image should be smoothed when resized. If false, individual pixels should be scaled directly rather than interpolated with smoothing. For SVG rendering, this option may not work in some browsers due to lack of standardization.",
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "startAngle": {
+          "anyOf": [
+            {
+              "description": "The start angle in radians for arc marks. A value of `0` indicates up (north), increasing values proceed clockwise.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/Gradient"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Default stroke color. This property has higher precedence than `config.color`. Set to `null` to remove stroke.\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StrokeCap",
+              "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"butt\"`"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeDash": {
+          "anyOf": [
+            {
+              "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeDashOffset": {
+          "anyOf": [
+            {
+              "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeJoin": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StrokeJoin",
+              "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeMiterLimit": {
+          "anyOf": [
+            {
+              "description": "The miter limit at which to bevel a line join.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeOffset": {
+          "anyOf": [
+            {
+              "description": "The offset in pixels at which to draw the group stroke and fill. If unspecified, the default behavior is to dynamically offset stroked groups such that 1 pixel stroke widths align with the pixel grid.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeOpacity": {
+          "anyOf": [
+            {
+              "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "strokeWidth": {
+          "anyOf": [
+            {
+              "description": "The stroke width, in pixels.",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "tension": {
+          "anyOf": [
+            {
+              "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Text",
+              "description": "Placeholder text if the `text` channel is not specified"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "theta": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "- For arc marks, the arc length in radians if theta2 is not specified, otherwise the start arc angle. (A value of 0 indicates up or “north”, increasing values proceed clockwise.)\n\n- For text marks, polar coordinate angle in radians.",
+          "maximum": 360,
+          "minimum": 0
+        },
+        "theta2": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The end angle of arc marks in radians. A value of 0 indicates up or “north”, increasing values proceed clockwise."
+        },
+        "tile": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            }
+          ],
+          "description": "A flag for overlaying tiles on top of geoshape marks, or an object defining the properties of the overlayed tiles.\n\n- If this property is an empty object (`{}`) or `true`, tiles with default properties will be used.\n\n- If this property is `false`, no tiles would be automatically added to geoshape marks.\n\n__Default value:__ `false`."
+        },
+        "timeUnitBandPosition": {
+          "description": "Default relative band position for a time unit. If set to `0`, the marks will be positioned at the beginning of the time unit band step. If set to `0.5`, the marks will be positioned in the middle of the time unit band step.",
+          "type": "number"
+        },
+        "timeUnitBandSize": {
+          "description": "Default relative band size for a time unit. If set to `1`, the bandwidth of the marks will be equal to the time unit band step. If set to `0.5`, bandwidth of the marks will be half of the time unit band step.",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `true` or `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used.\n- If set to `null` or `false`, then no tooltip will be used.\n\nSee the [`tooltip`](https://vega.github.io/vega-lite/docs/tooltip.html) documentation for a detailed discussion about tooltip  in Vega-Lite.\n\n__Default value:__ `null`"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/URI",
+              "description": "The URL of the image file for image marks."
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "width": {
+          "anyOf": [
+            {
+              "description": "Width of the marks.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ]
+        },
+        "x": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "const": "width",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"` without specified `x2` or `width`.\n\nThe `value` of this channel can be a number or a string `\"width\"` for the width of the plot."
+        },
+        "x2": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "const": "width",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"` for the width of the plot."
+        },
+        "y": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "const": "height",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"` without specified `y2` or `height`.\n\nThe `value` of this channel can be a number or a string `\"height\"` for the height of the plot."
+        },
+        "y2": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "const": "height",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"` for the height of the plot."
+        }
+      },
       "type": "object"
     },
     "Gradient": {
@@ -17285,6 +18102,17 @@
           "description": "Thickness of the tick mark.\n\n__Default value:__  `1`",
           "minimum": 0,
           "type": "number"
+        },
+        "tile": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            }
+          ],
+          "description": "A flag for overlaying tiles on top of geoshape marks, or an object defining the properties of the overlayed tiles.\n\n- If this property is an empty object (`{}`) or `true`, tiles with default properties will be used.\n\n- If this property is `false`, no tiles would be automatically added to geoshape marks.\n\n__Default value:__ `false`."
         },
         "timeUnitBandPosition": {
           "description": "Default relative band position for a time unit. If set to `0`, the marks will be positioned at the beginning of the time unit band step. If set to `0.5`, the marks will be positioned in the middle of the time unit band step.",
@@ -27281,7 +28109,7 @@
           "description": "Circle-Specific Config"
         },
         "geoshape": {
-          "$ref": "#/definitions/MarkConfig",
+          "$ref": "#/definitions/GeoshapeConfig",
           "description": "Geoshape-Specific Config"
         },
         "group-subtitle": {

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -340,6 +340,7 @@ export const VL_ONLY_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX: {
   bar: ['binSpacing', 'continuousBandSize', 'discreteBandSize'],
   rect: ['binSpacing', 'continuousBandSize', 'discreteBandSize'],
   line: ['point'],
+  geoshape: ['tile'],
   tick: ['bandSize', 'thickness']
 };
 
@@ -356,7 +357,8 @@ export type AnyMarkConfig<ES extends ExprRef | SignalRef> =
   | BarConfig<ES>
   | RectConfig<ES>
   | LineConfig<ES>
-  | TickConfig<ES>;
+  | TickConfig<ES>
+  | GeoshapeConfig<ES>;
 
 export interface MarkConfigMixins<ES extends ExprRef | SignalRef> {
   /** Mark Config */
@@ -404,7 +406,7 @@ export interface MarkConfigMixins<ES extends ExprRef | SignalRef> {
   trail?: LineConfig<ES>;
 
   /** Geoshape-Specific Config */
-  geoshape?: MarkConfig<ES>;
+  geoshape?: GeoshapeConfig<ES>;
 }
 
 const MARK_CONFIG_INDEX: Flag<keyof MarkConfigMixins<any>> = {
@@ -495,7 +497,22 @@ export interface PointOverlayMixins<ES extends ExprRef | SignalRef> {
   point?: boolean | OverlayMarkDef<ES> | 'transparent';
 }
 
+export interface TileOverlayMixins<ES extends ExprRef | SignalRef> {
+  /**
+   * A flag for overlaying tiles on top of geoshape marks, or an object defining the properties of the overlayed tiles.
+   *
+   * - If this property is an empty object (`{}`) or `true`, tiles with default properties will be used.
+   *
+   * - If this property is `false`, no tiles would be automatically added to geoshape marks.
+   *
+   * __Default value:__ `false`.
+   */
+  tile?: boolean | OverlayMarkDef<ES>;
+}
+
 export interface LineConfig<ES extends ExprRef | SignalRef> extends MarkConfig<ES>, PointOverlayMixins<ES> {}
+
+export interface GeoshapeConfig<ES extends ExprRef | SignalRef> extends MarkConfig<ES>, TileOverlayMixins<ES> {}
 
 export interface LineOverlayMixins<ES extends ExprRef | SignalRef> {
   /**
@@ -608,6 +625,7 @@ export interface MarkDef<M extends string | Mark = Mark, ES extends ExprRef | Si
         AreaConfig<ES> &
         BarConfig<ES> & // always extends RectConfig
         LineConfig<ES> &
+        GeoshapeConfig<ES> &
         TickConfig<ES>,
       'startAngle' | 'endAngle' | 'width' | 'height'
     >,

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -208,6 +208,9 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
 
     let outerParams = {};
     if (tileOverlay) {
+      // Right now, we assume that the following properties are present in projections.
+      // Should be fixed with some graceful failure or fallback values
+      const prScale = projection.scale;
       layer.push({
         mark: {
           type: 'image',
@@ -233,8 +236,9 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
           {calculate: 'sequence(0, 4)', as: 'b'},
           {flatten: ['b']},
           {
+            // Using 'round' below as else sometimes it uses values like 1.9999999999999998 instead of 2
             calculate:
-              "base_tile_url + zoom_ceil + '/' + (datum.a + dii_floor + tiles_count) % tiles_count + '/' + ((datum.b + djj_floor)) + '.png'",
+              "base_tile_url + zoom_ceil + '/' + round((datum.a + dii_floor + tiles_count) % tiles_count) + '/' + ((datum.b + djj_floor)) + '.png'",
             as: 'url'
           },
           {
@@ -266,20 +270,16 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
             value: 'height / 2'
           },
           {
+            name: 'prScale',
+            expr: prScale
+          },
+          {
             name: 'zoom_level',
-            value: 2.75
+            expr: 'log((2 * PI * prScale) / base_tile_size) / log(2)'
           },
           {
             name: 'zoom_ceil',
             expr: 'ceil(zoom_level)'
-          },
-          {
-            name: 'rotate_longitude',
-            value: 5.9025
-          },
-          {
-            name: 'center_latitude',
-            value: 52.56
           },
           {
             name: 'tiles_count',

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -140,6 +140,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
       {
         name,
         ...(params ? {params} : {}),
+        ...(markDef.type === 'geoshape' && tileOverlay && isObject(projection) ? {projection} : {}),
         mark: dropLineAndPointAndTile({
           // TODO: extract this 0.7 to be shared with default opacity for point/tick/...
           ...(markDef.type === 'area' && markDef.opacity === undefined && markDef.fillOpacity === undefined
@@ -200,7 +201,6 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
     }
     if (tileOverlay) {
       layer.push({
-        ...(projection ? {projection} : {}),
         mark: {
           type: 'image',
           clip: true,

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -211,7 +211,9 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
       // Right now, we assume that the following properties are present in projections.
       // Should be fixed with some graceful failure or fallback values
       const prScale = projection.scale;
-      layer.push({
+      // Use unshift to insert layer at the beginning of the array so that
+      // the geoshape layer will be plotted on top of the tiles.
+      layer.unshift({
         mark: {
           type: 'image',
           clip: true,
@@ -236,17 +238,16 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
           {calculate: 'sequence(0, 4)', as: 'b'},
           {flatten: ['b']},
           {
-            // Using 'round' below as else sometimes it uses values like 1.9999999999999998 instead of 2
             calculate:
-              "base_tile_url + zoom_ceil + '/' + round((datum.a + dii_floor + tiles_count) % tiles_count) + '/' + ((datum.b + djj_floor)) + '.png'",
+              "base_tile_url + zoom_ceil + '/' + (datum.a + dii_floor + tiles_count) % tiles_count + '/' + ((datum.b + djj_floor)) + '.png'",
             as: 'url'
           },
           {
-            calculate: '(datum.a * tile_size + dx) + tile_size / 2',
+            calculate: 'datum.a * tile_size + dx + tile_size / 2',
             as: 'x'
           },
           {
-            calculate: '(datum.b * tile_size + dy) + tile_size / 2',
+            calculate: 'datum.b * tile_size + dy + tile_size / 2',
             as: 'y'
           }
         ]
@@ -262,14 +263,6 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
             value: 'https://tile.openstreetmap.org/'
           },
           {
-            name: 'tx',
-            value: 'width / 2'
-          },
-          {
-            name: 'ty',
-            value: 'height / 2'
-          },
-          {
             name: 'prScale',
             expr: prScale
           },
@@ -283,7 +276,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
           },
           {
             name: 'tiles_count',
-            expr: 'pow(2, zoom_level)'
+            expr: 'pow(2, zoom_ceil)'
           },
           {
             name: 'tile_size',

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -136,11 +136,15 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
     const lineOverlay = markDef.type === 'area' && getLineOverlay(markDef, config[markDef.type]);
     const tileOverlay = getTileOverlay(markDef, config[markDef.type]);
 
+    const pushDownData: boolean = markDef.type === 'geoshape' && tileOverlay && isObject(outerSpec.data);
     const layer: NormalizedUnitSpec[] = [
       {
         name,
         ...(params ? {params} : {}),
         ...(markDef.type === 'geoshape' && tileOverlay && isObject(projection) ? {projection} : {}),
+        // Data is pushed down into this first layer so that we can use a different dataset for the tile
+        // layer. The data is removed from outerSpec further below.
+        ...(pushDownData ? {data: outerSpec.data} : {}),
         mark: dropLineAndPointAndTile({
           // TODO: extract this 0.7 to be shared with default opacity for point/tick/...
           ...(markDef.type === 'area' && markDef.opacity === undefined && markDef.fillOpacity === undefined
@@ -243,7 +247,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
 
     return normalize(
       {
-        ...outerSpec,
+        ...(pushDownData ? omit(outerSpec, ['data']) : outerSpec),
         layer,
         ...(tileOverlay
           ? {

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -308,7 +308,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
           },
           {
             name: 'dy',
-            expr: 'round(djj_floor - djj) * tile_size'
+            expr: 'round((djj_floor - djj) * tile_size)'
           }
         ]
       };

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -264,7 +264,9 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
           },
           {
             name: 'prScale',
-            expr: prScale
+            // Using expr in case it is an expression and not just a number.
+            // Convert to String in case it is just a number.
+            expr: String(prScale)
           },
           {
             name: 'zoom_level',


### PR DESCRIPTION
This PR is far from being ready to be merged as many corner cases need to be handled, tests and documentation written, etc. But I have a few questions on how to proceed which are probably easier to answer if you can see the code. The goal is to add a `tile` property to the `geoshape` mark which adds tiles from arbitrary tile XYZ tile servers as `image` marks. See #8767 for more context and all the credits for the calculations goes to @mattijn who provided the initial specs!

## Current status
I already got the layering to work so that the following spec (notice the `"tile": true` in `"mark"`):

```json
{
  "data": {
    "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/world-110m.json",
    "format": {"feature": "countries", "type": "topojson"}
  },
  "mark": {
    "type": "geoshape",
    "fillOpacity": 0.1,
    "stroke": "orange",
    "strokeWidth": 2,
    "tile": true
  },
  "width": 400,
  "height": 400,
  "projection": {
    "type": "mercator",
    "scale": 300,
    "center": [0, 40],
    "rotate": [-10, 0, 0]
  }
}
```

produces an extended VL spec in the Vega Editor which is very close to what @mattijn originally came up with. The main change is that I rewrote the calculations so that they do not depend on an input zoom level but instead the zoom level is determined based on `scale` in `projection`:

```json
{
  "width": 400,
  "height": 400,
  "layer": [
    {
      "mark": {
        "type": "image",
        "clip": true,
        "height": {"expr": "tile_size"},
        "width": {"expr": "tile_size"}
      },
      "encoding": {
        "url": {"field": "url", "type": "nominal"},
        "x": {"field": "x", "scale": null, "type": "quantitative"},
        "y": {"field": "y", "scale": null, "type": "quantitative"}
      },
      "data": {
        "sequence": {"start": 0, "stop": 4, "as": "a"},
        "name": "tile_list"
      },
      "transform": [
        {"calculate": "sequence(0, 4)", "as": "b"},
        {"flatten": ["b"]},
        {
          "calculate": "base_tile_url + zoom_ceil + '/' + (datum.a + dii_floor + tiles_count) % tiles_count + '/' + ((datum.b + djj_floor)) + '.png'",
          "as": "url"
        },
        {"calculate": "datum.a * tile_size + dx + tile_size / 2", "as": "x"},
        {"calculate": "datum.b * tile_size + dy + tile_size / 2", "as": "y"}
      ]
    },
    {
      "projection": {
        "type": "mercator",
        "scale": 300,
        "center": [0, 40],
        "rotate": [-10, 0, 0]
      },
      "data": {
        "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/world-110m.json",
        "format": {"feature": "countries", "type": "topojson"}
      },
      "mark": {
        "type": "geoshape",
        "fillOpacity": 0.1,
        "stroke": "orange",
        "strokeWidth": 2
      },
      "encoding": {}
    }
  ],
  "params": [
    {"name": "base_tile_size", "value": 256},
    {"name": "base_tile_url", "value": "https://tile.openstreetmap.org/"},
    {"name": "prScale", "expr": "300"},
    {
      "name": "zoom_level",
      "expr": "log((2 * PI * prScale) / base_tile_size) / log(2)"
    },
    {"name": "zoom_ceil", "expr": "ceil(zoom_level)"},
    {"name": "tiles_count", "expr": "pow(2, zoom_ceil)"},
    {
      "name": "tile_size",
      "expr": "base_tile_size * pow(2, zoom_level - zoom_ceil)"
    },
    {"name": "base_point", "expr": "invert('projection', [0, 0])"},
    {"name": "dii", "expr": "(base_point[0] + 180) / 360 * tiles_count"},
    {"name": "dii_floor", "expr": "floor(dii)"},
    {"name": "dx", "expr": "(dii_floor - dii) * tile_size"},
    {
      "name": "djj",
      "expr": "(1 - log(tan(base_point[1] * PI / 180) + 1 / cos(base_point[1] * PI / 180)) / PI) / 2 * tiles_count"
    },
    {"name": "djj_floor", "expr": "floor(djj)"},
    {"name": "dy", "expr": "round((djj_floor - djj) * tile_size)"}
  ]
}
```

This VL spec renders fine:

<img width="472" alt="image" src="https://user-images.githubusercontent.com/23366411/236631803-5f6f331d-1c75-4094-9992-6c083fbffa91.png">

## Questions
There are two related issues around the parameters in the above spec where I'd be very grateful for guidance from @domoritz or any VL maintainer.

* The current approach relies on value parameters which in my understanding need to be at the top-level of a specification, i.e. I cannot have them in a `LayerSpec`. I managed to push them to the top-level of the processed view as in the example above, but this does not work if the above spec is wrapped into an `hconcat` chart. Any ideas (existing mechanisms?) how I could push these parameters to the top of any spec, independent of how deeply nested the chart spec is which has `"tile": true`?
* The parameters do show up in the extended Vega-Lite specs in the Vega Editor. However, this is not the spec which is passed to `vega.parse`. The spec which is eventually passed lost the parameters section. I think this happens here https://github.com/vega/vega-lite/blob/main/src/compile/compile.ts#L122. `spec` has the parameters, `vgSpec` does not. You can see the behavior I described in this screen recording:

https://user-images.githubusercontent.com/23366411/236632406-5842518a-4c11-4884-b01d-34a52a8539d5.mov

If it's not possible to do what I want with the parameters, I could maybe rewrite the generated spec so that all expressions are inlined but that would lead to a lot of duplicated calculations and makes the resulting VL and Vega specs less readable in my opinion.

Any help is greatly appreciated! Thanks.

Linked issue: Closes #8767. 