### PR TITLE
fix: handle falsy legend values in selections (take 2)

### DIFF
--- a/src/compile/selection/legends.ts
+++ b/src/compile/selection/legends.ts
@@ -72,7 +72,7 @@ const legendBindings: SelectionCompiler<'point'> = {
           ...(!selCmpt.init ? {value: null} : {}),
           on: [
             // Legend entries do not store values, so we need to walk the scenegraph to the symbol datum.
-            {events, update: 'datum.value || item().items[0].items[0].datum.value', force: true},
+            {events, update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value', force: true},
             {events: stream.merge, update: `!event.item || !datum ? null : ${sgName}`, force: true}
           ]
         });

--- a/src/compile/selection/legends.ts
+++ b/src/compile/selection/legends.ts
@@ -72,7 +72,7 @@ const legendBindings: SelectionCompiler<'point'> = {
           ...(!selCmpt.init ? {value: null} : {}),
           on: [
             // Legend entries do not store values, so we need to walk the scenegraph to the symbol datum.
-            {events, update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value', force: true},
+            {events, update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value', force: true},
             {events: stream.merge, update: `!event.item || !datum ? null : ${sgName}`, force: true}
           ]
         });

--- a/test/compile/selection/legends.test.ts
+++ b/test/compile/selection/legends.test.ts
@@ -139,7 +139,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -186,7 +186,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -227,7 +227,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -264,7 +264,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -301,7 +301,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -431,7 +431,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'datum.value || item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
               force: true
             },
             {

--- a/test/compile/selection/legends.test.ts
+++ b/test/compile/selection/legends.test.ts
@@ -139,7 +139,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -186,7 +186,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -227,7 +227,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -264,7 +264,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -301,7 +301,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value',
               force: true
             },
             {
@@ -431,7 +431,7 @@ describe('Interactive Legends', () => {
                   markname: 'Origin_legend_entries'
                 }
               ],
-              update: 'isDefined(datum.value)? datum.value: item().items[0].items[0].datum.value',
+              update: 'isDefined(datum.value) ? datum.value : item().items[0].items[0].datum.value',
               force: true
             },
             {


### PR DESCRIPTION
Replacement for https://github.com/vega/vega-lite/pull/8800, which was reverted.  Fixes https://github.com/vega/vega-lite/issues/8143.

This implementation also handles `null` legend values by using the `isDefined` expression function.