### PR TITLE
docs: fix position-offset permalink in encoding.md

### DIFF
--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -213,7 +213,7 @@ In addition to the general [field definition properties](#field-def), field defi
 
 **Note:** `x2` and `y2` do not have their own definitions for `scale`, `axis`, `sort`, and `stack` since they share the same scales and axes with `x` and `y` respectively.
 
-{:#positon-offset}
+{:#position-offset}
 
 ## Position Offset Channels
 


### PR DESCRIPTION
Current docs have a typo in the [Position Offset permalink](https://vega.github.io/vega-lite/docs/encoding.html#positon-offset). Fixing this to "position-offset" so the [reference here](https://github.com/vega/vega-lite/blob/309af9ac314b5c83ecf89afbda6069a63fd7a53e/site/docs/encoding.md?plain=1#L84) resolves properly.