### PR TITLE
ci: monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,14 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
-      day: sunday
-      time: '23:00'
-      timezone: PST8PDT
-    open-pull-requests-limit: 10
+      interval: monthly
     ignore:
       - dependency-name: 'vega'
   - package-ecosystem: bundler
     directory: '/site'
     schedule:
-      interval: weekly
-      day: sunday
-      time: '23:00'
-      timezone: PST8PDT
-    open-pull-requests-limit: 10
+      interval: monthly
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
-      day: sunday
-      time: '23:00'
-      timezone: PST8PDT
-    open-pull-requests-limit: 10
+      interval: monthly


### PR DESCRIPTION
Reduce update cadence.

To reduce even further, we can use [groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) but this is the first step.