### PR TITLE
chore: update contributors in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Read about future plans in [our roadmap](https://github.com/vega/roadmap/project
 
 The development of Vega-Lite is led by the alumni and members of the [University of Washington Interactive Data Lab](https://idl.cs.washington.edu) (UW IDL), including [Kanit "Ham" Wongsuphasawat](https://twitter.com/kanitw) (now at Databricks), [Dominik Moritz](https://twitter.com/domoritz) (now at CMU and Apple), [Arvind Satyanarayan](https://twitter.com/arvindsatya1) (now at MIT), and [Jeffrey Heer](https://twitter.com/jeffrey_heer) (UW IDL).
 
-Vega-Lite gets significant contributions from its community--in particular [Will Strimling](https://willium.com), [Yuhan (Zoe) Lu](https://github.com/YuhanLu), [Souvik Sen](https://github.com/invokesus), [Chanwut Kittivorawong](https://github.com/chanwutk), [Matthew Chun](https://github.com/mattwchun), [Akshat Shrivastava](https://github.com/AkshatSh), [Saba Noorassa](https://github.com/Saba9), [Sira Horradarn](https://github.com/sirahd), [Donghao Ren](https://github.com/donghaoren), and [Halden Lin](https://github.com/haldenl). Please see the [contributors page](https://github.com/vega/vega-lite/graphs/contributors) for the full list of contributors.
+Vega-Lite gets significant contributions from its community. Please see the [contributors page](https://github.com/vega/vega-lite/graphs/contributors) for the full list of contributors.
 
 ## Citing Vega-Lite
 


### PR DESCRIPTION
The list is not up to date and I think it's best to link to the contributor page only. I don't mean to discount the contributions of anyone in that list but I think it should be much longer at this point and even longer in the future so to simplify things, I want to just link to the list that automatically updates. 

Once we have a governance model, we can link to how to become a contributor.