### PR TITLE
docs: add APL plugin to ecosystem

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -68,6 +68,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [Jekyll Diagrams](https://github.com/zhustec/jekyll-diagrams) A Jekyll plugin with support for Vega & Vega-Lite and others diagramming libraries.
 - [Liquid Diagrams](https://github.com/zhustec/liquid-diagrams) A Liquid plugin with support for Vega & Vega-Lite and others diagramming libraries.
 - [Vega-Lite-Linter](https://github.com/idvxlab/vega-lite-linter) is a python package to help users detect and fix encoding issues.
+- [VegaLite](https://github.com/JoshDavid/VegaLite) is a library for [Dyalog APL](https://www.dyalog.com) to build and render Vega-Lite specifications from your data.
 
 ## Programming / Data Science Environment that supports Vega-Lite
 


### PR DESCRIPTION
Add [VegaLite](https://github.com/JoshDavid/VegaLite) to the VegaLite ecosystem, which is a plugin for the Dyalog APL programming language to build & render VegaLite visualizations. 

Related issue: https://github.com/JoshDavid/VegaLite/issues/9 