### PR TITLE
docs: link to valid bar chart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You can find more details, [documentation](https://vega.github.io/vega-lite/docs/), [examples](https://vega.github.io/vega-lite/examples/), [usage instructions](https://vega.github.io/vega-lite/usage/embed.html), and [tutorials](https://vega.github.io/vega-lite/tutorials/getting_started.html) on the [Vega-Lite website](https://vega.github.io/vega-lite/).
 
-Try using Vega-Lite in the online [Vega Editor](https://vega.github.io/editor/#/custom/vega-lite).
+Try using Vega-Lite in the online [Vega Editor](https://vega.github.io/editor/#/examples/vega-lite/bar).
 
 Contributions are also welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution and development guidelines and our [Code of Conduct](https://vega.github.io/vega/about/code-of-conduct/).
 


### PR DESCRIPTION
## replace link leading to an invalid specification error message in the online editor

I was doing some research on which lib to use for visualizations in one of my side projects.
Stumbled upon Vega/Vega-Lite via https://github.com/altair-viz/altair and really liked what I saw in terms of the approach it takes to visualization.

When reading up on Vega-Lite, I noticed that this link in your README leads to an error message in the online editor: https://vega.github.io/editor/#/custom/vega-lite

This can be confusing, especially on mobile. I suggest swapping in a link to a simple example instead.