### PR TITLE
fix: use child signal for radius if faceted

### DIFF
--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -238,16 +238,16 @@ function fullWidthOrHeightRange(
     // For y continuous scale, we have to start from the height as the bottom part has the max value.
     return center
       ? [
-        SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal),
-        SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal)
-      ]
+          SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal),
+          SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal)
+        ]
       : [SignalRefWrapper.fromName(getSignalName, sizeSignal), 0];
   } else {
     return center
       ? [
-        SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal),
-        SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal)
-      ]
+          SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal),
+          SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal)
+        ]
       : [0, SignalRefWrapper.fromName(getSignalName, sizeSignal)];
   }
 }

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -63,6 +63,7 @@ import {Explicit, makeExplicit, makeImplicit} from '../split';
 import {UnitModel} from '../unit';
 import {ScaleComponentIndex} from './component';
 import {durationExpr} from '../../timeunit';
+import {isFacetModel} from '../model';
 
 export const RANGE_PROPERTIES: (keyof Scale)[] = ['range', 'scheme'];
 
@@ -237,16 +238,16 @@ function fullWidthOrHeightRange(
     // For y continuous scale, we have to start from the height as the bottom part has the max value.
     return center
       ? [
-          SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal),
-          SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal)
-        ]
+        SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal),
+        SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal)
+      ]
       : [SignalRefWrapper.fromName(getSignalName, sizeSignal), 0];
   } else {
     return center
       ? [
-          SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal),
-          SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal)
-        ]
+        SignalRefWrapper.fromName(name => `-${getSignalName(name)}/2`, sizeSignal),
+        SignalRefWrapper.fromName(name => `${getSignalName(name)}/2`, sizeSignal)
+      ]
       : [0, SignalRefWrapper.fromName(getSignalName, sizeSignal)];
   }
 }
@@ -306,11 +307,12 @@ function defaultRange(channel: ScaleChannel, model: UnitModel): VgRange {
 
     case RADIUS: {
       // max radius = half od min(width,height)
+
       return [
         0,
         new SignalRefWrapper(() => {
-          const w = model.getSignalName('width');
-          const h = model.getSignalName('height');
+          const w = isFacetModel(model.parent) ? model.getSignalName('child_width') : model.getSignalName('width');
+          const h = isFacetModel(model.parent) ? model.getSignalName('child_height') : model.getSignalName('height');
           return `min(${w},${h})/2`;
         })
       ];

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -312,7 +312,7 @@ function defaultRange(channel: ScaleChannel, model: UnitModel): VgRange {
         0,
         new SignalRefWrapper(() => {
           const w = model.getSignalName(isFacetModel(model.parent) ? 'child_width' : 'width');
-          const h = model.getSignalName(isFacetModel(model.parent) ?'child_height' : 'height');
+          const h = model.getSignalName(isFacetModel(model.parent) ? 'child_height' : 'height');
           return `min(${w},${h})/2`;
         })
       ];

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -311,8 +311,8 @@ function defaultRange(channel: ScaleChannel, model: UnitModel): VgRange {
       return [
         0,
         new SignalRefWrapper(() => {
-          const w = isFacetModel(model.parent) ? model.getSignalName('child_width') : model.getSignalName('width');
-          const h = isFacetModel(model.parent) ? model.getSignalName('child_height') : model.getSignalName('height');
+          const w = model.getSignalName(isFacetModel(model.parent) ? 'child_width' : 'width');
+          const h = model.getSignalName(isFacetModel(model.parent) ?'child_height' : 'height');
           return `min(${w},${h})/2`;
         })
       ];


### PR DESCRIPTION
close #8754 
I found that the range for radius using width and height without checking if the model  is faceted
https://github.com/vega/vega-lite/blob/c33f46bad7f80f779e463a8a36481f888f18e222/src/compile/scale/range.ts#L311-L314