### PR TITLE
chore: replace outdated jest config style

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,11 +5,14 @@ const config = {
   coverageDirectory: './coverage/',
   collectCoverage: false,
   setupFiles: ['./test/jest.overrides.ts'],
-  globals: {
-    'ts-jest': {
-      diagnostics: false,
-      useESM: true
-    }
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        diagnostics: false,
+        useESM: true
+      }
+    ]
   }
 };
 


### PR DESCRIPTION
Resolves this warning

<img width="854" alt="Screenshot 2024-01-31 at 09 19 49" src="https://github.com/vega/vega-lite/assets/589034/72b5f67d-5ebe-40c8-a024-cf5be7e16869">
