### PR TITLE
ci: update codecov action so we don't use deprecated node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         run: yarn jest test/ --collectCoverage=true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3.1.6
 
   test-cli:
     name: CLI


### PR DESCRIPTION
Resolve this warning

<img width="1069" alt="Screenshot 2024-01-31 at 09 22 57" src="https://github.com/vega/vega-lite/assets/589034/644be683-021d-4072-9551-084944e13f1a">
