### PR TITLE
feat: allow signals in mark clip

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -16749,8 +16749,15 @@
           ]
         },
         "clip": {
-          "description": "Whether a mark be clipped to the enclosing group’s width and height.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Whether a mark be clipped to the enclosing group’s width and height."
         },
         "color": {
           "anyOf": [
@@ -18300,8 +18307,15 @@
           ]
         },
         "clip": {
-          "description": "Whether a mark be clipped to the enclosing group’s width and height.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Whether a mark be clipped to the enclosing group’s width and height."
         },
         "color": {
           "anyOf": [

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -5,7 +5,7 @@ import {isAggregate, pathGroupingFields} from '../../encoding';
 import {AREA, BAR, isPathMark, LINE, Mark, TRAIL} from '../../mark';
 import {isSortByEncoding, isSortField} from '../../sort';
 import {contains, getFirstDefined, isNullOrFalse, keys, omit, pick} from '../../util';
-import {VgCompare, VgEncodeEntry, VG_CORNERRADIUS_CHANNELS} from '../../vega.schema';
+import {VgCompare, VgEncodeEntry, VG_CORNERRADIUS_CHANNELS, isSignalRef} from '../../vega.schema';
 import {getMarkConfig, getMarkPropOrConfig, getStyles, signalOrValueRef, sortParams} from '../common';
 import {UnitModel} from '../unit';
 import {arc} from './arc';
@@ -323,7 +323,7 @@ function getMarkGroup(model: UnitModel, opt: {fromPrefix: string} = {fromPrefix:
     {
       name: model.getName('marks'),
       type: markCompiler[mark].vgMark,
-      ...(clip ? {clip: true} : {}),
+      ...(clip ? {clip: isSignalRef(clip) ? clip : true} : {}),
       ...(style ? {style} : {}),
       ...(key ? {key: key.field} : {}),
       ...(sort ? {sort} : {}),

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -38,7 +38,7 @@ export type GenericCompositeMarkDef<T> = GenericMarkDef<T> &
     /**
      * Whether a composite mark be clipped to the enclosing group’s width and height.
      */
-    clip?: boolean;
+    clip?: boolean | SignalRef;
   };
 
 export interface CompositeMarkTooltipSummary {

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -554,7 +554,7 @@ export interface MarkDefMixins<ES extends ExprRef | SignalRef> {
   /**
    * Whether a mark be clipped to the enclosing group’s width and height.
    */
-  clip?: boolean;
+  clip?: boolean | ES;
 
   // Offset properties should not be a part of config
 

--- a/test/compositemark/common.test.ts
+++ b/test/compositemark/common.test.ts
@@ -27,6 +27,22 @@ describe('common', () => {
     }
   });
 
+  it('should output a signal for clip when set on a mark def', () => {
+    const outputSpec = normalize({
+      data: {url: 'data/barley.json'},
+      mark: {type: 'errorbar', ticks: true, clip: {signal: 'true'}},
+      encoding: {x: {field: 'yield', type: 'quantitative'}}
+    });
+
+    const layer = isLayerSpec(outputSpec) && outputSpec.layer;
+    expect(layer).toBeTruthy();
+    for (const unitSpec of layer) {
+      const markDef: MarkDef = isUnitSpec(unitSpec) && isMarkDef(unitSpec.mark) && unitSpec.mark;
+      expect(markDef).toBeTruthy();
+      expect(markDef.clip).toEqual({signal: 'true'});
+    }
+  });
+
   it('should keep color encoding', () => {
     const outputSpec = normalize({
       data: {url: 'data/barley.json'},


### PR DESCRIPTION
## PR Description

Right now [mark clip](https://vega.github.io/vega-lite/docs/mark.html) only accepts a boolean as a property. [Vega itself accepts a signal](https://vega.github.io/vega/docs/marks/#clip) as an optional input. In order to round out the API, this PR adds the ability to also use a signal from the Vega-Lite side.

## Checklist

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
