### PR TITLE
build: add deployment previews for vega-lite documentation site

### DIFF
--- a/.github/workflows/deployment-preview.yml
+++ b/.github/workflows/deployment-preview.yml
@@ -1,4 +1,4 @@
-# .github/workflows/preview.yml
+# .github/workflows/deployment-preview.yml
 name: Deploy PR previews
 
 on:
@@ -8,6 +8,7 @@ on:
       - reopened
       - synchronize
       - closed
+      # TODO: should this be rerun on new commits?
 
 concurrency: preview-${{ github.ref }}
 
@@ -27,23 +28,47 @@ jobs:
           cache: 'yarn'
           node-version: latest
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
       - name: Install NPM dependencies
         run: yarn --frozen-lockfile
 
       - name: Prebuild website
         run: yarn presite
 
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./site
-          destination: ./_site
+      - name: Main site build script. Might need to bundle install
+        shell: bash
+        run: |
+          # Install bundle dependencies first
+          pushd site && bundle install && popd
+          # yarn build uses the wrong shell for some reason?
+          pushd site && bundle exec jekyll build && popd
+          # yarn build:jekyll
+
+      # - name: Build with Jekyll
+      #   uses: actions/jekyll-build-pages@v1
+      #   with:
+      #     source: site
+      #     destination: _site
       # End copy from a section of release-docs-and-schema.yml
+
+      # https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#file-permissions
+      # - name: Fix permissions
+      #   run: |
+      #     chmod -c -R +r "_site/" | while read line; do
+      #       echo "::warning title=Invalid file permissions automatically fixed::$line"
+      #     done
 
       - name: Deploy preview and post github comment
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./_site/
+          source-dir: site/_site
+          deploy-repository: vega/vega-lite-pr-previews
+          # TODO: ask Dom to create a token for this
+          token: ${{ secrets.PREVIEW_TOKEN }}
 
   cleanup-preview-docs:
     if: github.event.action == 'closed'
@@ -52,4 +77,4 @@ jobs:
       - name: Cleanup pr-preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./_site/
+          source-dir: site/_site

--- a/.github/workflows/deployment-preview.yml
+++ b/.github/workflows/deployment-preview.yml
@@ -1,0 +1,55 @@
+# .github/workflows/preview.yml
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  # TODO: do we still want to run these on dependabot/non-human branches?
+  deploy-preview-docs:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Copied from a section of release-docs-and-schema.yml
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          cache: 'yarn'
+          node-version: latest
+
+      - name: Install NPM dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Prebuild website
+        run: yarn presite
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./site
+          destination: ./_site
+      # End copy from a section of release-docs-and-schema.yml
+
+      - name: Deploy preview and post github comment
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site/
+
+  cleanup-preview-docs:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cleanup pr-preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site/

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -70,6 +70,8 @@ export interface CompileOptions {
  * @returns         An object containing the compiled Vega spec and normalized Vega-Lite spec.
  */
 export function compile(inputSpec: TopLevelSpec, opt: CompileOptions = {}) {
+  console.log('Check if this is the preview site!', inputSpec);
+
   // 0. Augment opt with default opts
   if (opt.logger) {
     // set the singleton logger to the provided logger


### PR DESCRIPTION
## Motivation

- A deployment preview is a hosted version of a static site created just with the contents of this branch
- If this works out, we could add a similar change to deploy the editor site down the line.
- https://github.com/vega/vega-lite/issues/9276

## Changes

> TK

Try configuring https://github.com/rossjrw/pr-preview-action

## Testing

- The comment on this PR should link to a version of the docs site that outputs a console.log every time the vega-lite `compile` function is called.

## Notes

- As far as being a part of native Github, this feature is currently only available to Github pages for GH employees ( https://github.com/orgs/community/discussions/7730 )
  - https://github.com/actions/deploy-pages/issues/180#issuecomment-1921081514
