### PR TITLE
feat: add support for signals in mark clip

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -16749,8 +16749,15 @@
           ]
         },
         "clip": {
-          "description": "Whether a mark be clipped to the enclosing group’s width and height.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Whether a mark be clipped to the enclosing group’s width and height."
         },
         "color": {
           "anyOf": [
@@ -18300,8 +18307,15 @@
           ]
         },
         "clip": {
-          "description": "Whether a mark be clipped to the enclosing group’s width and height.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Whether a mark be clipped to the enclosing group’s width and height."
         },
         "color": {
           "anyOf": [

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -5,7 +5,7 @@ import {isAggregate, pathGroupingFields} from '../../encoding';
 import {AREA, BAR, isPathMark, LINE, Mark, TRAIL} from '../../mark';
 import {isSortByEncoding, isSortField} from '../../sort';
 import {contains, getFirstDefined, isNullOrFalse, keys, omit, pick} from '../../util';
-import {VgCompare, VgEncodeEntry, VG_CORNERRADIUS_CHANNELS, isSignalRef} from '../../vega.schema';
+import {VgCompare, VgEncodeEntry, VG_CORNERRADIUS_CHANNELS} from '../../vega.schema';
 import {getMarkConfig, getMarkPropOrConfig, getStyles, signalOrValueRef, sortParams} from '../common';
 import {UnitModel} from '../unit';
 import {arc} from './arc';
@@ -308,8 +308,7 @@ export function getSort(model: UnitModel): VgCompare {
 function getMarkGroup(model: UnitModel, opt: {fromPrefix: string} = {fromPrefix: ''}) {
   const {mark, markDef, encoding, config} = model;
 
-  const clipDef = getFirstDefined(markDef.clip, scaleClip(model), projectionClip(model));
-  const clip = isSignalRef(clipDef) ? clipDef : clipDef ? true : undefined;
+  const clip = getFirstDefined(markDef.clip, scaleClip(model), projectionClip(model));
   const style = getStyles(markDef);
   const key = encoding.key;
   const sort = getSort(model);

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -5,7 +5,7 @@ import {isAggregate, pathGroupingFields} from '../../encoding';
 import {AREA, BAR, isPathMark, LINE, Mark, TRAIL} from '../../mark';
 import {isSortByEncoding, isSortField} from '../../sort';
 import {contains, getFirstDefined, isNullOrFalse, keys, omit, pick} from '../../util';
-import {VgCompare, VgEncodeEntry, VG_CORNERRADIUS_CHANNELS} from '../../vega.schema';
+import {VgCompare, VgEncodeEntry, VG_CORNERRADIUS_CHANNELS, isSignalRef} from '../../vega.schema';
 import {getMarkConfig, getMarkPropOrConfig, getStyles, signalOrValueRef, sortParams} from '../common';
 import {UnitModel} from '../unit';
 import {arc} from './arc';
@@ -308,7 +308,8 @@ export function getSort(model: UnitModel): VgCompare {
 function getMarkGroup(model: UnitModel, opt: {fromPrefix: string} = {fromPrefix: ''}) {
   const {mark, markDef, encoding, config} = model;
 
-  const clip = getFirstDefined(markDef.clip, scaleClip(model), projectionClip(model));
+  const clipDef = getFirstDefined(markDef.clip, scaleClip(model), projectionClip(model));
+  const clip = isSignalRef(clipDef) ? clipDef : clipDef ? true : undefined;
   const style = getStyles(markDef);
   const key = encoding.key;
   const sort = getSort(model);
@@ -323,7 +324,7 @@ function getMarkGroup(model: UnitModel, opt: {fromPrefix: string} = {fromPrefix:
     {
       name: model.getName('marks'),
       type: markCompiler[mark].vgMark,
-      ...(clip ? {clip: true} : {}),
+      ...(clip ? {clip} : {}),
       ...(style ? {style} : {}),
       ...(key ? {key: key.field} : {}),
       ...(sort ? {sort} : {}),

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -554,7 +554,7 @@ export interface MarkDefMixins<ES extends ExprRef | SignalRef> {
   /**
    * Whether a mark be clipped to the enclosing group’s width and height.
    */
-  clip?: boolean;
+  clip?: boolean | ES;
 
   // Offset properties should not be a part of config
 

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -546,7 +546,7 @@ describe('Mark', () => {
       expect(markGroup[0].clip).toEqual({signal: "datum['foo'] > 10"});
     });
 
-    it('should pass clip as a boolean if clip is a boolean', () => {
+    it('should pass clip as a boolean if clip is true', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: {
           type: 'bar',
@@ -559,6 +559,21 @@ describe('Mark', () => {
 
       const markGroup = parseMarkGroups(model);
       expect(markGroup[0].clip).toBe(true);
+    });
+
+    it('should not have clip defined if clip is false', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          clip: false
+        },
+        encoding: {
+          x: {type: 'quantitative', field: 'foo'}
+        }
+      });
+
+      const markGroup = parseMarkGroups(model);
+      expect(markGroup[0].clip).toBeUndefined();
     });
   });
 });

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -514,4 +514,51 @@ describe('Mark', () => {
       expect(mark[0].clip).toBe(true);
     });
   });
+
+  describe('signal clipping', () => {
+    it('should pass clip as a signal if clip is an expression', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          clip: {expr: "datum['foo'] > 10"}
+        },
+        encoding: {
+          x: {type: 'quantitative', field: 'foo'}
+        }
+      });
+
+      const markGroup = parseMarkGroups(model);
+      expect(markGroup[0].clip).toEqual({signal: "datum['foo'] > 10"});
+    });
+
+    it('should pass clip as a signal if clip is a signal', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          clip: {signal: "datum['foo'] > 10"}
+        },
+        encoding: {
+          x: {type: 'quantitative', field: 'foo'}
+        }
+      });
+
+      const markGroup = parseMarkGroups(model);
+      expect(markGroup[0].clip).toEqual({signal: "datum['foo'] > 10"});
+    });
+
+    it('should pass clip as a boolean if clip is a boolean', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          clip: true
+        },
+        encoding: {
+          x: {type: 'quantitative', field: 'foo'}
+        }
+      });
+
+      const markGroup = parseMarkGroups(model);
+      expect(markGroup[0].clip).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## PR Description

In Vega, [mark supports a signal for the `clip` property](https://vega.github.io/vega/docs/marks/#mark-clipping). To round out the Vega-Lite API, we should support it here as well, especially since it is trivial to add.

## Checklist

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [x] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
