### PR TITLE
fix: boxplot doesn't alias fields with escaped characters correctly

### DIFF
--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -388,15 +388,15 @@ function boxParams(
       : [
           // This is for the  original k-IQR, which we do not expose
           {
-            calculate: `datum["upper_box_${continuousFieldName}"] - datum["lower_box_${continuousFieldName}"]`,
+            calculate: `datum["upper_box_${aliasedFieldName}"] - datum["lower_box_${aliasedFieldName}"]`,
             as: `iqr_${aliasedFieldName}`
           },
           {
-            calculate: `min(datum["upper_box_${continuousFieldName}"] + datum["iqr_${continuousFieldName}"] * ${extent}, datum["max_${continuousFieldName}"])`,
+            calculate: `min(datum["upper_box_${aliasedFieldName}"] + datum["iqr_${aliasedFieldName}"] * ${extent}, datum["max_${aliasedFieldName}"])`,
             as: `upper_whisker_${aliasedFieldName}`
           },
           {
-            calculate: `max(datum["lower_box_${continuousFieldName}"] - datum["iqr_${continuousFieldName}"] * ${extent}, datum["min_${continuousFieldName}"])`,
+            calculate: `max(datum["lower_box_${aliasedFieldName}"] - datum["iqr_${aliasedFieldName}"] * ${extent}, datum["min_${aliasedFieldName}"])`,
             as: `lower_whisker_${aliasedFieldName}`
           }
         ];

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -131,7 +131,7 @@ describe('normalizeBoxMinMax', () => {
           {
             op: 'q1',
             field: 'three\\.four',
-            as: 'lower_box_three.four'
+            as: 'lower_box_three.four' // aliases should be unescaped
           },
           {
             op: 'q3',
@@ -154,7 +154,7 @@ describe('normalizeBoxMinMax', () => {
             as: 'upper_whisker_three.four'
           }
         ],
-        groupby: ['one\\.two'] // should group by age
+        groupby: ['one\\.two'] // field refernece should be escaped
       }
     ]);
   });

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -154,7 +154,7 @@ describe('normalizeBoxMinMax', () => {
             as: 'upper_whisker_three.four'
           }
         ],
-        groupby: ['one\\.two'] // field refernece should be escaped
+        groupby: ['one\\.two'] // field reference should be escaped
       }
     ]);
   });

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -89,6 +89,76 @@ describe('normalizeBoxMinMax', () => {
     ]);
   });
 
+  it('should produce correct transform with values that include periods in field names', () => {
+    const output = normalize(
+      {
+        description: 'A box plot showing median, min, and max in the US population distribution of age groups in 2000.',
+        data: {
+          values: [
+            {'foo.bar': 10},
+            {'foo.bar': 20},
+            {'foo.bar': 30},
+            {'foo.bar': 40},
+            {'foo.bar': 50},
+            {'foo.bar': 60},
+            {'foo.bar': 70},
+            {'foo.bar': 80},
+            {'foo.bar': 90},
+            {'foo.bar': 100}
+          ]
+        },
+        mark: {
+          type: 'boxplot',
+          extent: 'min-max',
+          size: 5
+        },
+        encoding: {
+          x: {field: 'one\\.two', type: 'quantitative'},
+          y: {
+            field: 'three\\.four',
+            type: 'quantitative',
+            axis: {title: 'Population'}
+          },
+          color: {value: 'skyblue'}
+        }
+      },
+      defaultConfig
+    );
+
+    expect(output.transform).toEqual([
+      {
+        aggregate: [
+          {
+            op: 'q1',
+            field: 'three\\.four',
+            as: 'lower_box_three.four'
+          },
+          {
+            op: 'q3',
+            field: 'three\\.four',
+            as: 'upper_box_three.four'
+          },
+          {
+            op: 'median',
+            field: 'three\\.four',
+            as: 'mid_box_three.four'
+          },
+          {
+            op: 'min',
+            field: 'three\\.four',
+            as: 'lower_whisker_three.four'
+          },
+          {
+            op: 'max',
+            field: 'three\\.four',
+            as: 'upper_whisker_three.four'
+          }
+        ],
+        groupby: ['one\\.two'] // should group by age
+      }
+    ]);
+  });
+
   it('should produce an error if neither the x axis or y axis is specified', () => {
     expect(() => {
       normalize(


### PR DESCRIPTION
Internal version of https://github.com/vega/vega-lite/pull/9284

Fields like foo.bar are transformed into boxplot parts by creating aliased calculated fields like:

lower_box_foo\\.bar

Aliases don't accept escaped field names. This strips the escaped characters.## PR Description
