### PR TITLE
build: Configure deployment previews with Vega Editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "clean": "yarn clean:build && del-cli 'site/data/*' 'examples/compiled/*.png' && find site/examples ! -name 'index.md' ! -name 'data' -type f -delete",
     "clean:build": "del-cli 'build/*' !build/vega-lite-schema.json",
     "data": "rsync -r node_modules/vega-datasets/data/* site/data",
+    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone <git@github.com>:vega/editor.git && cd editor && yarn --frozen-lockfile && yarn link vega-lite && yarn build",
     "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "yarn data && yarn schema && yarn build:site && yarn build:versions && scripts/create-example-pages.sh",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "clean": "yarn clean:build && del-cli 'site/data/*' 'examples/compiled/*.png' && find site/examples ! -name 'index.md' ! -name 'data' -type f -delete",
     "clean:build": "del-cli 'build/*' !build/vega-lite-schema.json",
     "data": "rsync -r node_modules/vega-datasets/data/* site/data",
-    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone https://github.com/vega/editor.git && cd editor && yarn --frozen-lockfile --ignore-scripts && yarn link vega-lite && yarn build:only",
+    "build-editor-preview": "scripts/build-editor-preview.sh",
     "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "yarn data && yarn schema && yarn build:site && yarn build:versions && scripts/create-example-pages.sh",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "clean": "yarn clean:build && del-cli 'site/data/*' 'examples/compiled/*.png' && find site/examples ! -name 'index.md' ! -name 'data' -type f -delete",
     "clean:build": "del-cli 'build/*' !build/vega-lite-schema.json",
     "data": "rsync -r node_modules/vega-datasets/data/* site/data",
-    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone https://github.com/vega/editor.git && cd editor && yarn --ignore-scripts && yarn link vega-lite && yarn build:only",
+    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone https://github.com/vega/editor.git && cd editor && yarn --frozen-lockfile --ignore-scripts && yarn link vega-lite && yarn build:only",
     "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "yarn data && yarn schema && yarn build:site && yarn build:versions && scripts/create-example-pages.sh",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "clean": "yarn clean:build && del-cli 'site/data/*' 'examples/compiled/*.png' && find site/examples ! -name 'index.md' ! -name 'data' -type f -delete",
     "clean:build": "del-cli 'build/*' !build/vega-lite-schema.json",
     "data": "rsync -r node_modules/vega-datasets/data/* site/data",
-    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone <git@github.com>:vega/editor.git && cd editor && yarn --frozen-lockfile && yarn link vega-lite && yarn build",
+    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone https://github.com/vega/editor.git && cd editor && yarn --frozen-lockfile && yarn link vega-lite && yarn build",
     "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "yarn data && yarn schema && yarn build:site && yarn build:versions && scripts/create-example-pages.sh",
@@ -139,5 +139,6 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "clean": "yarn clean:build && del-cli 'site/data/*' 'examples/compiled/*.png' && find site/examples ! -name 'index.md' ! -name 'data' -type f -delete",
     "clean:build": "del-cli 'build/*' !build/vega-lite-schema.json",
     "data": "rsync -r node_modules/vega-datasets/data/* site/data",
-    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone https://github.com/vega/editor.git && cd editor && yarn --frozen-lockfile && yarn link vega-lite && yarn build",
+    "build-editor-preview": "yarn --frozen-lockfile && yarn build && yarn link && git clone https://github.com/vega/editor.git && cd editor && yarn --ignore-scripts && yarn link vega-lite && yarn build:only",
     "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "yarn data && yarn schema && yarn build:site && yarn build:versions && scripts/create-example-pages.sh",

--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Build the docs site and replace the main build with the local copy of vega-lite
+echo "Attempting install"
+# apt install rsync
+
+yarn build
+yarn link
+git clone https://github.com/vega/editor.git
+
+#
+cd editor
+yarn --frozen-lockfile
+yarn link vega-lite
+
+
+# TODO: load in real files if RSYNC is installable?
+
+
+
+
+# TODO : need to create some vendor files?
+yarn build:only

--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -12,14 +12,25 @@ git clone https://github.com/vega/editor.git
 
 #
 cd editor
-yarn --frozen-lockfile
+yarn --frozen-lockfile --ignore-scripts
 yarn link vega-lite
 
+# TODO: load in real files if we can get rsync installed in the runner someday?
+# Put index.json files in public/spec/vega-lite and public/spec/vega
+echo "Creating stub index.json for each vega library"
 
-# TODO: load in real files if RSYNC is installable?
+mkdir -p public/spec/vega-lite
+mkdir -p public/spec/vega
+touch public/spec/vega-lite/index.json
+touch public/spec/vega/index.json
 
+cat <<EOF > public/spec/vega-lite/index.json
+{}
+EOF
 
+cat <<EOF > public/spec/vega/index.json
+{}
+EOF
 
-
-# TODO : need to create some vendor files?
+# TBD if some vendor files are needed
 yarn build:only

--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -33,4 +33,4 @@ cat <<EOF > public/spec/vega/index.json
 EOF
 
 # TBD if some vendor files are needed
-yarn build:only
+yarn run vite build --base /

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,3 @@ export type {Config} from './config';
 export {normalize} from './normalize';
 export type {TopLevelSpec} from './spec';
 export * from './util';
-
-console.log('Hello, this is proof of a dev build');

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export type {Config} from './config';
 export {normalize} from './normalize';
 export type {TopLevelSpec} from './spec';
 export * from './util';
+
+console.log('Hello, this is proof of a dev build');


### PR DESCRIPTION
## Motivation

- A cloudflare-based take on https://github.com/vega/vega-lite/issues/9276
- As discussed w/ @domoritz, Previewing the editor site is probably more useful than the docs site, so we're going after that first

## Changes

- Use explicit packageManager version so Cloudflare doesn't autoupgrade to yarn 3 (breaks lockfile)
- Add a build script (originally this was a 1-liner in package.json but it was getting hard to read) that
  - Builds vega-lite
  - Clones vega/editor and links the local vega-lite in place of the full build
  - Install `vega/editor` without running the `prepare` script. (The CI device doesn't have rsync installed).
  - Makes empty index.json for vega / vega-lite examples.
  - Build editor with vite with `/` as the base URL (previously it was erroring due to thinking it was under the `/editor` subdomain). Technically this is an abstraction leak but fixing it would involve modifying the vega/editor repo too and I'd like to contain this change to 1 repo if possible.

## Testing

- See Cloudflare comment below, confirm site loads

## Notes

- For now only `cameron.yick/*` branches have the previews since the build script is WIP. It's using my personal Cloudflare account for testing. I'll open it up to all (non dependabot/*) PRs this change is confirmed.
- I've filed an request to https://blog.cloudflare.com/cloudflare-new-oss-sponsorships-program to see if we can get deployment previews sponsored (they also sponsor D3, yarn). If not, I'll plan to discuss on Slack whether to keep Cloudflare or switch the config to a different account.
- Free plan limits: 500 builds/ month: https://developers.cloudflare.com/pages/platform/limits/ . 
