### PR TITLE
fix: Allow non-linear scale for stacked bars

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -39,9 +39,7 @@
         "valid",
         "values",
         "variance",
-        "variancep",
-        "exponential",
-        "exponentialb"
+        "variancep"
       ],
       "type": "string"
     },
@@ -17899,9 +17897,7 @@
         "valid",
         "values",
         "variance",
-        "variancep",
-        "exponential",
-        "exponentialb"
+        "variancep"
       ],
       "type": "string"
     },

--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -344,8 +344,8 @@ export function cannotStackRangedMark(channel: Channel) {
   return `Cannot stack "${channel}" if there is already "${channel}2".`;
 }
 
-export function cannotStackNonLinearScale(scaleType: ScaleType) {
-  return `Cannot stack non-linear scale (${scaleType}).`;
+export function stackNonLinearScale(scaleType: ScaleType) {
+  return `Stack is applied to a non-linear scale (${scaleType}).`;
 }
 
 export function stackNonSummativeAggregate(aggregate: Aggregate | string) {

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -245,9 +245,8 @@ export function stack(m: Mark | MarkDef, encoding: Encoding<string>): StackPrope
   // warn when stacking non-linear
   if (stackedFieldDef?.scale?.type && stackedFieldDef?.scale?.type !== ScaleType.LINEAR) {
     if (stackedFieldDef?.stack) {
-      log.warn(log.message.cannotStackNonLinearScale(stackedFieldDef.scale.type));
+      log.warn(log.message.stackNonLinearScale(stackedFieldDef.scale.type));
     }
-    return null;
   }
 
   // Check if it is a ranged mark

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -256,9 +256,9 @@ describe('stack', () => {
   });
 
   it(
-    'should always warn if the aggregated axis has non-linear scale',
+    'should always return stack and only warn for non-undefined stack if the aggregated axis has non-linear scale',
     log.wrap(localLogger => {
-      for (const s of ['center', 'zero', 'normalize'] as const) {
+      for (const s of [undefined, 'center', 'zero', 'normalize'] as const) {
         for (const scaleType of [ScaleType.LOG, ScaleType.POW, ScaleType.SQRT]) {
           const marks = s === undefined ? STACK_BY_DEFAULT_NON_POLAR_MARKS : STACKABLE_NON_POLAR_MARKS;
           for (const mark of marks) {
@@ -271,35 +271,19 @@ describe('stack', () => {
                 color: {field: 'site', type: 'nominal'}
               }
             };
-            expect(stack(spec.mark, spec.encoding)).toBeNull();
-
+            expect(stack(spec.mark, spec.encoding)).toBeTruthy();
             const warns = localLogger.warns;
-            expect(warns[warns.length - 1]).toEqual(log.message.cannotStackNonLinearScale(scaleType));
+
+            if (s !== undefined) {
+              expect(warns[warns.length - 1]).toEqual(log.message.stackNonLinearScale(scaleType));
+            } else {
+              expect(warns).toHaveLength(0);
+            }
           }
         }
       }
     })
   );
-
-  it('returns null if the aggregated axis has non-linear scale', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize'] as const) {
-      for (const scaleType of [ScaleType.LOG, ScaleType.POW, ScaleType.SQRT]) {
-        const marks = stacked === undefined ? STACK_BY_DEFAULT_NON_POLAR_MARKS : STACKABLE_NON_POLAR_MARKS;
-        for (const mark of marks) {
-          const spec: TopLevel<NormalizedUnitSpec> = {
-            data: {url: 'data/barley.json'},
-            mark,
-            encoding: {
-              x: {field: 'a', type: 'quantitative', aggregate: 'sum', scale: {type: scaleType}},
-              y: {field: 'variety', type: 'nominal'},
-              color: {field: 'site', type: 'nominal'}
-            }
-          };
-          expect(stack(spec.mark, spec.encoding)).toBeNull();
-        }
-      }
-    }
-  });
 
   it(
     'should throw warning if the aggregated axis has a non-summative aggregate',


### PR DESCRIPTION
## PR Description

Allow non-linear scale for stacked bars.

The old behavior was that we show warning and the stacked bars are layered.

Even though log scale doesn't seem to make sense for stacked bars (you can't compare the height for bars in the same column), but we want to ensure a consistent layout "stack" when the users switch between linear and non-linear scales, instead of changing the scale or layout unexpectedly on users' behalves.

[Example VL Editor link](https://vega.github.io/editor/#/url/vega-lite/N4Ig7glgJgLgFiAXANgKwGYA0I4FMIDmcMSqA7AEzYC2AhgE4DWSoMA9mwDYwQAOSMegFdc2AMac+A4aJAwAnr1xIQAIwYgAvtlwA7MWygRdBFiAAeZgGYRcnKCoDKbIfTHLsCpSt1tqx2k4tbHlrW3sVAGchagAKAFVHAAIAEQA1FKTHQNxIgEoQT0VlRBAARyFaXR4YWh4ANw8QSLEcsy8S5vlqTjZTbF5aKCMTJAAWbF0IdyQrQMjcTW0QA176MLsHUoBZWgArNnokgHE9emUl8TZdG1NEUDomMzZBsQgFJAAGADoKS5AoHVaGZ6oERJEkABtUDROKJVIZLI5fKkdDIMbIACcqAAHNhdgcjqddOckLohJxONhnK4ZohyZTtDCYglkulMtlOLkCvSKVSQATDicziUGfyaW5OgB5eiEAKcLJic56XicWihJnNFnw9lIrko3mU-H7IXE0mG8UuSUqABCtAWUCS1ySNo4jAA9I44IcYFl2PQNZhmXC2YjOdyyXzjYThSTRVGQBK6SA7Q6nbokgAFNWB4OshEc5E8sXR00iyNGxNW5Op3CO53HWjUC5BrUhgt6iOIMYYigARhxY0xpaJ5dKKXoTeB1Or8cZrdh+d14YNaFQYwo6BxfeQI9j5pAE6nhSrtOlsoI8sVyt0qvVwTzOrDRYr-MFo7jKiPdBPSc6tfrDMvR9JIADEIE4agHzbJdn31Hl0AoHFt0xT5hwFE0PwPb9p1Pa1SgA9MsxzaDFyfQt4KQPt0AwbFUE+dE9zNTocN-WdbXtOsiNdNgPWA+hfUcf1cxg8jOwNMg+zGGj6L7PsmLHQ9Jx-Gczw4tNnQAJVwQIkgAGQgKxcCSABRRpqghTUyNDCiuxLDCY2Yr9lNwv8VAAFUnIweGuQJ3T03ACD0KB3VA2gIADWouVI7UbPEnk+0xTEyDRHF0E+BTP3HFy2LU0ptLoRgW0fOKVwQnE0CStFMuwnLVPwlNOMApIAGE-Gmd1jknXg4GmJIADk2EaIIrNijsyqoz5NwoTExj7DKHLLLKlOPeqayaoiwrEGBKgVHiPQAQQE6ZotG9tlxfC0apYuq8PWjSM12AhaAAL2MYyjp4CRitE0rLr7ChkDXAHruc1a7v-DbnXctIYvOuCu03AdAexUHSja5soFCNa504M7YNsg0ZuQdAyBxTE0vQ99906DG62xiGVBlOVdF0xwlVwFUSPxsSJsQHdUDk6SezRkA6ax3KGoK2girhgn4tISgcUB1ASdF8WGbcgioYzfbPW9AS-UOETrPGy77Oppz0b8enJfuritJ0hUDKM0zzJgSyFzGi7KMQeiSbQ7EFstxSNbtyGHqSGG5d5y7JOQvsUqpzCaZUMOcfUh2M2ze8eb+32LZTq2xZtiWM+1yOMY6rraB6vrBuGmP87shMQ+W9PGdKRxeGMABaKUrCsJuzd90mkroqhFqw2nS819jSk8oZ3ggXzOH8wLgtC8LIraPOR5bys24PDutcayOnte96kk+k6ftNn2D7fIvQ9n8PM+a-jfXAyDh4fg1C8ci-TGc88oCiEJEaYukuouF4EkbYQ1bC-wRv-Vuz9lrbHAZAoI5cxR7z-sWVBgD0GYNaNgzuZ8s4ujdPrECQljZIMJjyJCOIyCzVJqLDBEDSFv1KMzS8rMFTsxvHeE23tkEEMPmgg8nCsE8JLtQHuaofK6AYQrfmDF0BokoMnIh0iSGBDkYRZ0MjSHuilEoScqi+ZC3QLNT41EOH6LIafaWss8HiNfI4rhBjy4UOajnUR8NGGeKnqnHYTi5GL28ivAR68gq6BCmFCK8gop3zEcEv2mJSbpU+BMUJxcTE+PIUYjM0d3EZIAUtPR3jnHzz8URbSukXbGTMnoD2VjLpoEBlJMgnxUCi3cnAWUlJcD0E9OApQugFhyL4VeIRnNbzcy9kEtRYxBYUA2WQZAZABlDIglyMZjgJl6Gmb4kpVDeI0MNnQgMHTR7pQwChXZwyDnjMiJM055DXFpJWdYmiZMNl5KPp0QZLzRlvI+U0U+5yynLPlnzaSmIsTpR2fkxSoL9ngqOe8k5UK6nnMac7QyLT3aexKvvFBkjdEgr2SMw5xypl4ryrguFsdfYzVQJifsnwsBouWhiulELcWGJ1q1dqYhOrdV6mIAaQ07B3K7MgfsFBpKouBR5WlrzsWQpFZHLaO1dJ6xvt9BVRMpp9LIILBiosDpQHdq4JlDVzl60-kbW55S1FomQDykm64bV2raQ63VlCq4SprnXGVDd5UeusWsimOIeWfGDlIzotr7Wkl8bMgR14FkiNNRIp+1KVBpsDRm4porXXfygjG82hCqmpoDdUINvionL1XnEzeSSd6nVZc3Slhb63FsbTtMt0LRWEv0sSt2bSyW-QpTyCm6BE5jATf69Njr7bNVheS-BSAaLol6bk5NRbSglqbaOup3z81IGQDucmfZ6LHsHae4dzbyEpAgJEXQuB5BJE0tAH58La1UufSAM9I6N0R0oY2Zs16rp8oPOBt9Y7I4BLg5U6eQ711yO7n3AeQ8a2+0FrNMYaFV0IdTdtGJwbmouoNoJYScG0pbNvb0oFKbi1UeuDMi8cyOZc1zr2+dVEVWaNVWQNVHHT1cZUWc0VobJW12lbKxuhGuykaXahVCNqZM0YaU7SdrtWkWXQ3WzD0nlE8JZTujx6jcQDhSjpyzcnUNLJsxkySWycmSZPWB3TLnoNNkA2yxVqtMSJykniCjnHnPlsjtuudu6UCIXmj2fp0WLPUd8VetTElb09gqk5rL5DW3KL8gFeJiTt4pN3kJpLSd0oA0nuqzL3HfG4d0P3QepmQPmb87FlDlCL5vW-dfY6Jrcs8ixBVW9qB0stf68VwbW62CBKA77SSs2krIVFppPwVQvpiuATxlmbN+OLME+5z1lrkIYl5QtvbdBqh9RPvi0VdHaGMcm+MPpE92O+cewdl7r9su4EKsFvtBbdv7eezK17zK+TfcQJo9ApH6I6NA4D2HR3bYBf8W5xLtmE35dVtDp7h34dOvHQZ5p06TNI4w2EkAWOKcg5K15NtsSKuduq6kuDYwk7euQMrUWAAJQ49BDgnf4Wd4RBP762Y2eTFhckosLfF-QSX6w8fcWoa6m5a2QsGgi6raSaupMgA11rqziO6u2YHGF0T8kMuW4l1L0H4OesDr61b93cXKEJYVxklGnxlbSTF277X-vmoKfDcpqNI07cZP9tssmzv1eR70w2ILXuI+a796fDrXWCNJ7UchCmlrdwu991H5b+mmlTuM+0pHrD+xSWaxbgA6rkGAozZPkKzbL3N8v0lqMZ8XbvkRe-0H71razhPg8WtD8L0Wk-p+z7e5HD71yvul75oLGiWTJKr5733uROW9-Ae90ztfZ+deOwb0Z0l-OgaAzRPdi3KQ2BiBiG0hgICqdI4J1acm9Z0g81E1w+k0J5tP9v9f9qh-8bd5wrs+Zx9FIv8f9mwEDbl79SlYYkcKAk0yBSNw8XcbQ1QxBGAccy4B9eNs15kBNDdIcQkFtyDaBKDqCADN0iI0MCCV0dwHlRY2CODKduDnRt8GN6EGczMmdhCqDRCoMP56MwIIJq1L8C4ZDi42p9BRkYB3RMxRkrBDgnsZhM06Ch9GC4MBwH0BdSN1Zrh3ABJ9DDDjCqhTDo968iUn8Z0tAABdJYIAA)

# Before
We can see overlapping.
![image](https://github.com/vega/vega-lite/assets/149440704/02103e9f-b86b-4126-a2ef-5eff1fd8456f)

# After
No overlapping.
![image](https://github.com/vega/vega-lite/assets/149440704/eb3be995-e2ad-467f-b70a-97b3ab468802)



## Checklist

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
