### PR TITLE
fix: for issue when there are multiple aggregates with the same data field and aggregation operation

### DIFF
--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -164,7 +164,8 @@ export class AggregateNode extends DataFlowNode {
           meas['*']['count'] = new Set([as ? as : vgField(s, {forAs: true})]);
         } else {
           meas[field] ??= {};
-          meas[field][op] = new Set([as ? as : vgField(s, {forAs: true})]);
+          meas[field][op] ??= new Set();
+          meas[field][op].add(as ? as : vgField(s, {forAs: true}));
         }
       }
     }

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -313,6 +313,7 @@ function getMarkGroup(model: UnitModel, opt: {fromPrefix: string} = {fromPrefix:
   const key = encoding.key;
   const sort = getSort(model);
   const interactive = interactiveFlag(model);
+  interactive ? (model.markDef.cursor ??= 'pointer') : {};
   const aria = getMarkPropOrConfig('aria', markDef, config);
 
   const postEncodingTransform = markCompiler[mark].postEncodingTransform

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -1,3 +1,4 @@
+import {AggregateTransform, FieldRef} from 'vega';
 import {compile} from '../../src/compile/compile';
 import * as log from '../../src/log';
 
@@ -574,16 +575,16 @@ describe('compile/compile', () => {
   });
 });
 
-it('should generate right cursor', () => {
+it('should generate right tooltip', () => {
   const {spec} = compile({
     data: {url: 'data/population.json'},
-    params: [{name: 'select', select: 'point'}],
-    mark: 'bar',
+    mark: 'errorband',
     encoding: {
-      x: {field: 'a', type: 'ordinal'},
-      y: {field: 'b', type: 'quantitative'}
+      x: {field: 'age', type: 'ordinal'},
+      y: {field: 'people', type: 'quantitative'},
+      tooltip: {field: 'people', aggregate: 'mean'}
     }
   });
 
-  expect(spec.marks[0].encode.update.cursor).toEqual({value: 'pointer'});
+  expect(((spec.data[0].transform[0] as AggregateTransform).as as FieldRef[]).includes('mean_people')).toBeTruthy();
 });

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -573,3 +573,17 @@ describe('compile/compile', () => {
     expect(spec.autosize['resize']).toBeTruthy();
   });
 });
+
+it('should generate right cursor', () => {
+  const {spec} = compile({
+    data: {url: 'data/population.json'},
+    params: [{name: 'select', select: 'point'}],
+    mark: 'bar',
+    encoding: {
+      x: {field: 'a', type: 'ordinal'},
+      y: {field: 'b', type: 'quantitative'}
+    }
+  });
+
+  expect(spec.marks[0].encode.update.cursor).toEqual({value: 'pointer'});
+});

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -81,6 +81,9 @@ describe('Layered Selections', () => {
             ariaRoleDescription: {
               value: 'circle'
             },
+            cursor: {
+              value: 'pointer'
+            },
             description: {
               signal:
                 '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? datum["Origin"] : ""+datum["Origin"])'
@@ -129,6 +132,9 @@ describe('Layered Selections', () => {
             ariaRoleDescription: {
               value: 'square'
             },
+            cursor: {
+              value: 'pointer'
+            },
             description: {
               signal:
                 '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? datum["Origin"] : ""+datum["Origin"])'
@@ -171,6 +177,9 @@ describe('Layered Selections', () => {
             },
             ariaRoleDescription: {
               value: 'point'
+            },
+            cursor: {
+              value: 'pointer'
             },
             description: {
               signal:


### PR DESCRIPTION
## PR Description

Fixes #6184.
When there are multiple elements in AggregateTransform with the same data field and aggregation operation, the code is currently only keeping the first output field name

## Checklist

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.
