### PR TITLE
fix: for issue when there are multiple aggregates with the same data field and aggregation operation

### DIFF
--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -164,7 +164,8 @@ export class AggregateNode extends DataFlowNode {
           meas['*']['count'] = new Set([as ? as : vgField(s, {forAs: true})]);
         } else {
           meas[field] ??= {};
-          meas[field][op] = new Set([as ? as : vgField(s, {forAs: true})]);
+          meas[field][op] ??= new Set();
+          meas[field][op].add(as ? as : vgField(s, {forAs: true}));
         }
       }
     }

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -1,3 +1,4 @@
+import {AggregateTransform} from 'vega';
 import {compile} from '../../src/compile/compile';
 import * as log from '../../src/log';
 
@@ -572,4 +573,22 @@ describe('compile/compile', () => {
 
     expect(spec.autosize['resize']).toBeTruthy();
   });
+});
+
+it('should generate right tooltip', () => {
+  const {spec} = compile({
+    data: {url: 'data/population.json'},
+    mark: 'errorband',
+    encoding: {
+      x: {field: 'age', type: 'ordinal'},
+      y: {field: 'people', type: 'quantitative'},
+      tooltip: {field: 'people', aggregate: 'mean'}
+    }
+  });
+
+  expect((spec.data[0].transform[0] as AggregateTransform).as as string[]).toEqual([
+    'mean_people',
+    'center_people',
+    'extent_people'
+  ]);
 });


### PR DESCRIPTION
## PR Description

Fixes #6184.
When there are multiple elements in AggregateTransform with the same data field and aggregation operation, the code is currently only keeping the first output field name.

## Checklist

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.