### PR TITLE
fix: fix typo in time unit 'utcweekdayhours'

### DIFF
--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -177,7 +177,7 @@ export const UTC_MULTI_TIMEUNIT_INDEX = {
   utcmonthdatehoursminutesseconds: 1,
 
   utcweekday: 1,
-  utcweeksdayhours: 1,
+  utcweekdayhours: 1,
   utcweekdayhoursminutes: 1,
   utcweekdayhoursminutesseconds: 1,
 


### PR DESCRIPTION
It was missed in commit 12788a59a4c8313f56c0558163c26b3dce07756d.