### PR TITLE
build: switch bundler for deploy previews back to parcel

### DIFF
--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -31,4 +31,5 @@ cat <<EOF > public/spec/vega/index.json
 EOF
 
 # Build the editor site in the dist folder
-yarn run build:only --public-url /
+# Disable sourcemaps as they exceed 25 MB in size
+yarn run build:only --public-url / --no-source-maps

--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -31,5 +31,6 @@ cat <<EOF > public/spec/vega/index.json
 EOF
 
 # Build the editor site in the dist folder
-# Disable sourcemaps as they exceed 25 MB in size
-yarn run build:only --public-url / --no-source-maps
+# Disable minification to make it easier to debug, and because sourcemaps
+# exceed 25 MB limit on cloudflare
+yarn run build:only --public-url / --no-optimize --no-source-maps

--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -2,15 +2,13 @@
 
 set -eo pipefail
 
-# Build the docs site and replace the main build with the local copy of vega-lite
-echo "Attempting install"
-# apt install rsync
+# Build the editor site and replace the main build with the local copy of vega-lite
+echo "Starting install"
 
 yarn build
 yarn link
 git clone https://github.com/vega/editor.git
 
-#
 cd editor
 yarn --frozen-lockfile --ignore-scripts
 yarn link vega-lite
@@ -32,5 +30,5 @@ cat <<EOF > public/spec/vega/index.json
 {}
 EOF
 
-# TBD if some vendor files are needed
-yarn run vite build --base /
+# Build the editor site in the dist folder
+yarn run build:only --public-url /


### PR DESCRIPTION
## Motivation

- Following https://github.com/vega/editor/pull/1420, https://github.com/vega/vega-lite/issues/9276 stopped working
- This updates the build command for compatibility with parcel.

## Changes

- Updates stale comments
- Don't mention vite, try to stick to the yarn build command (with 1 parcel specific flag https://github.com/parcel-bundler/parcel/issues/206#issuecomment-350697310 )

## Testing

- Check if deploy preview link loads correctly ( [src](https://cameron-yick-fix-deploy-prev.vega-lite.pages.dev/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JAKyUAVhDYA7EABoQAEzjQATjRyZ289AEEABBBoIcguIaZJ1h2DcyGA7nRiHETOMtXLDypJhUiioBKKigxEiCDGpoANqgYSD6wUxoAEwAHAC+ColoIABCqWhiYrn56ADCJagALADMFSBJACK1AJwAjM1JAKK1mT15LQUAYrViTSNJAOK1XR29BQASgwDsy+gAkpPp2QC6uSDI6gDWBdbqwXCyUGzKNLJkaKAAHq8gAGY0cILKBRQSkwAE8cHACrI2AgnlFgkg3jQIJ9BEhPIJ9M8LGgAAzZY4gz4-P4A9BpYFgiHoACODCQsh0gR0pBA+OyQA) )