### PR TITLE
fix: facet missing data bug fix

### DIFF
--- a/examples/specs/test_trellis_cross_sort_missing.vl.json
+++ b/examples/specs/test_trellis_cross_sort_missing.vl.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+  "data": {
+    "values": [
+      {"first": "A", "second": "a", "value": "A/a"},
+      {"first": "B", "second": "a", "value": "B/a"},
+      {"first": "C", "second": "a", "value": "C/a"},
+      {"first": "A", "second": "b", "value": "A/b"},
+      {"first": "B", "second": "b", "value": "B/b"}
+    ]
+  },
+  "facet": {
+    "row": {"field": "second", "type": "nominal", "sort": ["a", "b"]},
+    "column": {"field": "first", "type": "nominal", "sort": ["A", "B", "C"]}
+  },
+  "spec": {
+    "width": 50,
+    "height": 50,
+    "layer": [
+      {
+        "mark": {"type": "text"},
+        "encoding": {
+          "x": {"value": 25},
+          "y": {"value": 25},
+          "text": {"field": "value", "type": "nominal"}
+        }
+      }
+    ]
+  }
+}

--- a/src/compile/data/facet.ts
+++ b/src/compile/data/facet.ts
@@ -1,5 +1,5 @@
 import type {AggregateOp} from 'vega';
-import {isArray} from 'vega-util';
+import {isArray, stringValue} from 'vega-util';
 import {isBinning} from '../../bin.js';
 import {COLUMN, FACET_CHANNELS, POSITION_SCALE_CHANNELS, ROW} from '../../channel.js';
 import {vgField} from '../../channeldef.js';
@@ -8,7 +8,7 @@ import {hasDiscreteDomain} from '../../scale.js';
 import {DEFAULT_SORT_OP, EncodingSortField, isSortField} from '../../sort.js';
 import {hash} from '../../util.js';
 import {isVgRangeStep, VgData} from '../../vega.schema.js';
-import {FacetModel} from '../facet.js';
+import type {FacetModel} from '../facet.js';
 import {HEADER_CHANNELS, HEADER_TYPES} from '../header/component.js';
 import {Model} from '../model.js';
 import {assembleDomain, getFieldFromDomain} from '../scale/domain.js';
@@ -18,6 +18,15 @@ import {DataFlowNode} from './dataflow.js';
 interface ChildIndependentFieldsWithStep {
   x?: string;
   y?: string;
+}
+
+function isCrossedFacetWithCustomSort(model: FacetModel) {
+  const {row, column} = model.facet;
+  return !!(row && column && (isCustomSortField(row) || isCustomSortField(column)));
+}
+
+function isCustomSortField(fieldDef?: FacetModel['facet']['row']) {
+  return !!fieldDef && (isSortField(fieldDef.sort) || Array.isArray(fieldDef.sort));
 }
 
 interface FacetChannelInfo {
@@ -61,7 +70,7 @@ export class FacetNode extends DataFlowNode {
           name: model.getName(`${channel}_domain`),
           fields: [vgField(fieldDef), ...(isBinning(bin) ? [vgField(fieldDef, {binSuffix: 'end'})] : [])],
           ...(isSortField(sort)
-            ? {sortField: sort}
+            ? {sortField: sort as EncodingSortField<string>}
             : isArray(sort)
               ? {sortIndexField: sortArrayIndexField(fieldDef, channel)}
               : {}),
@@ -128,7 +137,6 @@ export class FacetNode extends DataFlowNode {
     for (const channel of POSITION_SCALE_CHANNELS) {
       const childScaleComponent = this.childModel.component.scales[channel];
       if (childScaleComponent && !childScaleComponent.merged) {
-        // independent scale
         const type = childScaleComponent.get('type');
         const range = childScaleComponent.get('range');
 
@@ -256,6 +264,45 @@ export class FacetNode extends DataFlowNode {
     return data;
   }
 
+  private getFacetLookupField(channel: 'row' | 'column') {
+    return this.model.getName(`${channel}_facet_key`);
+  }
+
+  private getFacetLookupKeyExpr(fields: string[], datum: string) {
+    return `join([${fields
+      .map((field) => {
+        const fieldRef = `${datum}[${stringValue(field)}]`;
+        return `isValid(${fieldRef}) ? length(toString(${fieldRef})) + ':' + toString(${fieldRef}) : '-1:'`;
+      })
+      .join(', ')}], '|')`;
+  }
+
+  private assembleFacetLookupDomainData(channel: 'row' | 'column'): VgData | null {
+    const facetChannel = this[channel];
+
+    if (!facetChannel || (!facetChannel.sortField && !facetChannel.sortIndexField)) {
+      return null;
+    }
+
+    return {
+      name: this.model.getName(`${channel}_lookup_domain`),
+      source: facetChannel.name,
+      transform: [
+        {
+          type: 'formula',
+          expr: this.getFacetLookupKeyExpr(facetChannel.fields, 'datum'),
+          as: this.getFacetLookupField(channel),
+        },
+      ],
+    };
+  }
+
+  private assembleFacetSortLookupData(): VgData[] {
+    return ([ROW, COLUMN] as const)
+      .map((channel) => this.assembleFacetLookupDomainData(channel))
+      .filter((lookupData): lookupData is VgData => lookupData !== null);
+  }
+
   public assemble() {
     const data: VgData[] = [];
     let crossedDataName = null;
@@ -291,6 +338,10 @@ export class FacetNode extends DataFlowNode {
       if (this[channel]) {
         data.push(this.assembleRowColumnHeaderData(channel, crossedDataName, childIndependentFieldsWithStep));
       }
+    }
+
+    if (isCrossedFacetWithCustomSort(this.model)) {
+      data.push(...this.assembleFacetSortLookupData());
     }
 
     if (facet) {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,5 +1,5 @@
 import {AggregateOp, LayoutAlign, NewSignal, SignalRef} from 'vega';
-import {isArray} from 'vega-util';
+import {isArray, stringValue} from 'vega-util';
 import {isBinning} from '../bin.js';
 import {COLUMN, ExtendedChannel, FacetChannel, FACET_CHANNELS, POSITION_SCALE_CHANNELS, ROW} from '../channel.js';
 import {FieldName, FieldRefOption, initFieldDef, TypedFieldDef, vgField} from '../channeldef.js';
@@ -33,6 +33,15 @@ export function facetSortFieldName(
   opt?: FieldRefOption,
 ) {
   return vgField(sort, {suffix: `by_${vgField(fieldDef)}`, ...opt});
+}
+
+function isCrossedFacetWithCustomSort(facet: Pick<EncodingFacetMapping<string, SignalRef>, 'row' | 'column'>) {
+  const {row, column} = facet;
+  return !!(row && column && (isCustomSortField(row) || isCustomSortField(column)));
+}
+
+function isCustomSortField(fieldDef?: FacetFieldDef<string, SignalRef>) {
+  return !!fieldDef && (isSortField(fieldDef.sort) || Array.isArray(fieldDef.sort));
 }
 
 export class FacetModel extends ModelWithField {
@@ -294,6 +303,7 @@ export class FacetModel extends ModelWithField {
   private assembleFacet() {
     const {name, data} = this.component.data.facetRoot;
     const {row, column} = this.facet;
+    const cross = !!row && !!column;
     const {fields, ops, as} = this.getCardinalityAggregateForChild();
     const groupby: string[] = [];
 
@@ -311,28 +321,21 @@ export class FacetModel extends ModelWithField {
         if (isSortField(sort)) {
           const {field, op = DEFAULT_SORT_OP} = sort;
           const outputName = facetSortFieldName(fieldDef, sort);
-          if (row && column) {
-            // For crossed facet, use pre-calculate field as it requires a different groupby
-            // For each calculated field, apply max and assign them to the same name as
-            // all values of the same group should be the same anyway.
-            fields.push(outputName);
-            ops.push('max');
-            as.push(outputName);
-          } else {
+          if (!cross) {
             fields.push(field);
             ops.push(op);
             as.push(outputName);
           }
         } else if (isArray(sort)) {
           const outputName = sortArrayIndexField(fieldDef, channel);
-          fields.push(outputName);
-          ops.push('max');
-          as.push(outputName);
+          if (!cross) {
+            fields.push(outputName);
+            ops.push('max');
+            as.push(outputName);
+          }
         }
       }
     }
-
-    const cross = !!row && !!column;
 
     return {
       name,
@@ -349,11 +352,53 @@ export class FacetModel extends ModelWithField {
     };
   }
 
-  private facetSortFields(channel: FacetChannel): string[] {
+  private getFacetLookupField(channel: FacetChannel) {
+    return this.getName(`${channel}_facet_key`);
+  }
+
+  private facetLookupKeyExpr(channel: FacetChannel) {
+    const fieldDef = this.facet[channel];
+    const fields = [vgField(fieldDef, {expr: 'datum'})];
+
+    if (isBinning(fieldDef.bin)) {
+      fields.push(vgField(fieldDef, {expr: 'datum', binSuffix: 'end'}));
+    }
+
+    return `join([${fields
+      .map((field) => `isValid(${field}) ? length(toString(${field})) + ':' + toString(${field}) : '-1:'`)
+      .join(', ')}], '|')`;
+  }
+
+  private crossedFacetLookupSortExpr(channel: FacetChannel) {
+    const fieldDef = this.facet[channel];
+    if (!fieldDef || (!isSortField(fieldDef.sort) && !isArray(fieldDef.sort))) {
+      return undefined;
+    }
+
+    const lookupDataName = this.getName(`${channel}_lookup_domain`);
+    const lookupDataExpr = `data(${stringValue(lookupDataName)})`;
+    const lookupField = this.getFacetLookupField(channel);
+    const lookupIndexExpr = `indexof(pluck(${lookupDataExpr}, ${stringValue(lookupField)}), ${this.facetLookupKeyExpr(
+      channel,
+    )})`;
+    const sortValueField = isSortField(fieldDef.sort)
+      ? vgField(fieldDef.sort, {forAs: true})
+      : sortArrayIndexField(fieldDef, channel);
+
+    return `${lookupIndexExpr} >= 0 ? ${lookupDataExpr}[${lookupIndexExpr}][${stringValue(sortValueField)}] : null`;
+  }
+
+  private facetSortFields(channel: FacetChannel): (string | ExprRef)[] {
     const {facet} = this;
     const fieldDef = facet[channel];
 
     if (fieldDef) {
+      if (isCrossedFacetWithCustomSort(facet)) {
+        const lookupSortExpr = this.crossedFacetLookupSortExpr(channel);
+        if (lookupSortExpr) {
+          return [{expr: lookupSortExpr}];
+        }
+      }
       if (isSortField(fieldDef.sort)) {
         return [facetSortFieldName(fieldDef, fieldDef.sort, {expr: 'datum'})];
       } else if (isArray(fieldDef.sort)) {

--- a/test/compile/data/facet.test.ts
+++ b/test/compile/data/facet.test.ts
@@ -230,6 +230,55 @@ describe('compile/data/facet', () => {
         ],
       });
     });
+
+    it('should assemble lookup datasets for crossed custom facet sort metadata', () => {
+      const model = parseFacetModelWithScale({
+        $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+        data: {
+          name: 'a',
+        },
+        facet: {
+          row: {field: 'r', type: 'nominal', sort: {op: 'median', field: 'b'}},
+          column: {field: 'c', type: 'nominal', sort: ['c1', 'c2']},
+        },
+        spec: {
+          mark: 'rect',
+          encoding: {
+            y: {field: 'b', type: 'quantitative'},
+            x: {field: 'a', type: 'quantitative'},
+          },
+        },
+      });
+
+      const node = new FacetNode(null, model, 'facetName', 'dataName');
+      const data = node.assemble();
+
+      expect(data).toContainEqual({
+        name: 'row_lookup_domain',
+        source: 'row_domain',
+        transform: [
+          {
+            type: 'formula',
+            expr: `join([isValid(datum["r"]) ? length(toString(datum["r"])) + ':' + toString(datum["r"]) : '-1:'], '|')`,
+            as: 'row_facet_key',
+          },
+        ],
+      });
+
+      expect(data).toContainEqual({
+        name: 'column_lookup_domain',
+        source: 'column_domain',
+        transform: [
+          {
+            type: 'formula',
+            expr: `join([isValid(datum["c"]) ? length(toString(datum["c"])) + ':' + toString(datum["c"]) : '-1:'], '|')`,
+            as: 'column_facet_key',
+          },
+        ],
+      });
+
+      expect(data.find((d) => d.name === 'crossed_facet_domain')).toBeUndefined();
+    });
   });
 
   describe('dependentFields', () => {

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -11,6 +11,7 @@ import {parseFacetModel, parseFacetModelWithScale} from '../util.js';
 
 function getCellItems(view: View) {
   const cells: {x: number; y: number; datum: Record<string, unknown>}[] = [];
+  const scenegraph = view.scenegraph() as unknown as {root: unknown};
 
   function walk(item: any) {
     if (!item) {
@@ -28,7 +29,7 @@ function getCellItems(view: View) {
     }
   }
 
-  walk(view.scenegraph().root);
+  walk(scenegraph.root);
 
   return cells.sort((a, b) => a.y - b.y || a.x - b.x);
 }

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -1,5 +1,6 @@
-import type {SignalRef} from 'vega';
+import {parse, type SignalRef, View} from 'vega';
 import {ROW} from '../../src/channel.js';
+import {compile} from '../../src/compile/compile.js';
 import {FacetModel} from '../../src/compile/facet.js';
 import {assembleLabelTitle} from '../../src/compile/header/assemble.js';
 import * as log from '../../src/log/index.js';
@@ -7,6 +8,30 @@ import {DEFAULT_SPACING} from '../../src/spec/base.js';
 import {FacetFieldDef, FacetMapping} from '../../src/spec/facet.js';
 import {ORDINAL} from '../../src/type.js';
 import {parseFacetModel, parseFacetModelWithScale} from '../util.js';
+
+function getCellItems(view: View) {
+  const cells: {x: number; y: number; datum: Record<string, unknown>}[] = [];
+
+  function walk(item: any) {
+    if (!item) {
+      return;
+    }
+
+    if (item.mark?.name === 'cell' && item.datum) {
+      cells.push(item);
+    }
+
+    if (Array.isArray(item.items)) {
+      for (const child of item.items) {
+        walk(child);
+      }
+    }
+  }
+
+  walk(view.scenegraph().root);
+
+  return cells.sort((a, b) => a.y - b.y || a.x - b.x);
+}
 
 describe('FacetModel', () => {
   describe('initFacet', () => {
@@ -480,9 +505,18 @@ describe('FacetModel', () => {
 
       const marks = model.assembleMarks();
 
-      expect(marks[0].from.facet.aggregate.cross).toBeTruthy();
+      expect(marks[0].from).toEqual({
+        facet: expect.objectContaining({
+          name: 'facet',
+          groupby: ['a', 'b'],
+          aggregate: {cross: true},
+        }),
+      });
       expect(marks[0].sort).toEqual({
-        field: ['datum["row_a_sort_index"]', 'datum["column_b_sort_index"]'],
+        field: [
+          expect.objectContaining({expr: expect.stringContaining('["row_a_sort_index"]')}),
+          expect.objectContaining({expr: expect.stringContaining('["column_b_sort_index"]')}),
+        ],
         order: ['ascending', 'ascending'],
       });
     });
@@ -504,17 +538,99 @@ describe('FacetModel', () => {
 
       const marks = model.assembleMarks();
 
-      expect(marks[0].from.facet.aggregate).toEqual({
-        cross: true,
-        fields: ['median_d_by_a', 'median_e_by_b'],
-        ops: ['max', 'max'],
-        as: ['median_d_by_a', 'median_e_by_b'],
+      expect(marks[0].from).toEqual({
+        facet: expect.objectContaining({
+          name: 'facet',
+          groupby: ['a', 'b'],
+          aggregate: {cross: true},
+        }),
       });
 
       expect(marks[0].sort).toEqual({
-        field: ['datum["median_d_by_a"]', 'datum["median_e_by_b"]'],
+        field: [
+          expect.objectContaining({expr: expect.stringContaining('["median_d"]')}),
+          expect.objectContaining({expr: expect.stringContaining('["median_e"]')}),
+        ],
         order: ['ascending', 'ascending'],
       });
+    });
+
+    it('should create one crossed facet tuple per row-column pair at runtime', async () => {
+      const {spec} = compile({
+        data: {
+          values: [
+            {first: 'A', second: 'a', value: 'A/a'},
+            {first: 'B', second: 'a', value: 'B/a'},
+            {first: 'C', second: 'a', value: 'C/a'},
+            {first: 'A', second: 'b', value: 'A/b'},
+            {first: 'B', second: 'b', value: 'B/b'},
+          ],
+        },
+        facet: {
+          row: {field: 'second', type: 'ordinal', sort: ['a', 'b']},
+          column: {field: 'first', type: 'ordinal', sort: ['A', 'B', 'C']},
+        },
+        spec: {
+          mark: 'text',
+          encoding: {
+            text: {field: 'value'},
+          },
+        },
+      });
+
+      const view = new View(parse(spec), {renderer: 'none'});
+      await view.runAsync();
+
+      const cellItems = getCellItems(view);
+
+      expect(cellItems).toHaveLength(6);
+      expect(cellItems.map((item) => item.datum)).toEqual([
+        expect.objectContaining({first: 'A', second: 'a'}),
+        expect.objectContaining({first: 'B', second: 'a'}),
+        expect.objectContaining({first: 'C', second: 'a'}),
+        expect.objectContaining({first: 'A', second: 'b'}),
+        expect.objectContaining({first: 'B', second: 'b'}),
+        expect.objectContaining({first: 'C', second: 'b'}),
+      ]);
+    });
+
+    it('should populate sort field metadata for missing crossed facet tuples at runtime', async () => {
+      const {spec} = compile({
+        data: {
+          values: [
+            {first: 'A', second: 'a', row_order: 0, column_order: 0, value: 'A/a'},
+            {first: 'B', second: 'a', row_order: 0, column_order: 1, value: 'B/a'},
+            {first: 'C', second: 'a', row_order: 0, column_order: 2, value: 'C/a'},
+            {first: 'A', second: 'b', row_order: 1, column_order: 0, value: 'A/b'},
+            {first: 'B', second: 'b', row_order: 1, column_order: 1, value: 'B/b'},
+          ],
+        },
+        facet: {
+          row: {field: 'second', type: 'ordinal', sort: {field: 'row_order', op: 'max'}},
+          column: {field: 'first', type: 'ordinal', sort: {field: 'column_order', op: 'max'}},
+        },
+        spec: {
+          mark: 'text',
+          encoding: {
+            text: {field: 'value'},
+          },
+        },
+      });
+
+      const view = new View(parse(spec), {renderer: 'none'});
+      await view.runAsync();
+
+      const cellItems = getCellItems(view);
+
+      expect(cellItems).toHaveLength(6);
+      expect(cellItems.map((item) => item.datum)).toEqual([
+        expect.objectContaining({first: 'A', second: 'a'}),
+        expect.objectContaining({first: 'B', second: 'a'}),
+        expect.objectContaining({first: 'C', second: 'a'}),
+        expect.objectContaining({first: 'A', second: 'b'}),
+        expect.objectContaining({first: 'B', second: 'b'}),
+        expect.objectContaining({first: 'C', second: 'b'}),
+      ]);
     });
 
     it('should add calculate cardinality for independent scales', () => {


### PR DESCRIPTION
## PR Description

This is a suggested fix for https://github.com/vega/vega-lite/issues/5937 and potentially also https://github.com/vega/vega-lite/issues/8675 and https://github.com/vega/altair/issues/3588 and https://github.com/vega/altair/issues/3481

I included two examples demonstrating the bug. For instance the spec 

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "data": {"url": "data/cars.json"},
  "facet": {
    "column": {"field": "Origin", "sort": ["USA", "Europe", "Japan"]},
    "row": {"field": "Cylinders", "sort": {"field": "Horsepower", "op": "mean"}}
  },
  "spec": {
      "mark": "point",
      "encoding": {
        "x": {"field": "Horsepower", "type": "quantitative"},
        "y": {"field": "Acceleration", "type": "quantitative"},
        "color": {"field": "Origin", "type": "nominal"},
        "shape": {"field": "Cylinders", "type": "nominal"}
      }
  }
}
```

results in 

![visualization-2](https://github.com/user-attachments/assets/8eaddb17-466a-464f-9b20-7780518fecfd)

while it should look like this:

![facet_bug_cars](https://github.com/user-attachments/assets/1e6bda69-75fc-4055-b7cf-31d74917dde8)

I think the bug is due to the following. The key part of the compiled Vega spec looks like 

```json 
{
      "name": "cell",
      "type": "group",
      "style": "cell",
      "from": {
        "facet": {
          "name": "facet",
          "data": "source_0",
          "groupby": ["Cylinders", "Origin"],
          "aggregate": {
            "cross": true,
            "fields": [
              "mean_Horsepower_by_Cylinders",
              "column_Origin_sort_index"
            ],
            "ops": ["max", "max"],
            "as": ["mean_Horsepower_by_Cylinders", "column_Origin_sort_index"]
          }
        }
      },
}
```

As far as I understand this performs a `groupby` according to cylinders and origin, and then for each group determines `mean_Horsepower_by_Cylinders` and `column_Origin_sort_index ` used for sorting by aggregating over the data points in the facet and taking the max (it does not matter as the column sort index is the same for all points in the facet anyways, so one could also take e.g. the min). The problem arises when a facet is empty as then the aggregation cannot determine the valid sort index. As a result, some facets are not assigned a sort-index, see this screenshot from the Vega Editor -> Data Viewer -> cell:

<img width="378" alt="Screenshot 2024-09-17 at 00 32 24" src="https://github.com/user-attachments/assets/e7ca11de-39cb-4c13-bb51-102f94d5f45f">

For some reason the cells with missing sort-index result in some data points being placed in the wrong facet (not exactly sure what goes wrong here exactly). 

My bug fix suggestion simply replaces the above spec by 

```json
{
      "name": "cell",
      "type": "group",
      "style": "cell",
      "from": {
        "facet": {
          "name": "facet",
          "data": "source_0",
          "groupby": [
            "mean_Horsepower_by_Cylinders",
            "column_Origin_sort_index"
          ],
          "aggregate": {"cross": true}
        }
      },
}
```

i.e. it directly groups by the sort index, avoiding cells without assigned indices. This is simpler than the original code. For all examples I looked at, it worked. However, maybe I overlook some unintended side effects. 

Out of all the tests a single test in `test/compile/facet.test.ts` fails, namely line 507. As far as I can see this test directly checks the section of the compiled Vega spec outlined above, so in some sense I would expect it to fail. 

## Checklist

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully

