### PR TITLE
fix: links in docs

### DIFF
--- a/site/docs/overview.md
+++ b/site/docs/overview.md
@@ -7,7 +7,7 @@ permalink: /docs/
 
 **Vega-Lite** is a high-level grammar for interactive graphics. It provides a concise JSON syntax for supporting rapid generation of interactive multi-view visualizations to support analysis. Vega-Lite can serve as a declarative format for describing and creating data visualizations. To use Vega-Lite, our compiler compiles a Vega-Lite specification into a lower-level, more detailed [Vega](https://vega.github.io/vega) specifications and rendered using Vega's compiler.
 
-This documentation describes the [JSON specification language](#spec) and how to [use Vega-Lite visualizations]({{site.baseurl}}/usage/embed.html) in a web application.
+This documentation describes the [JSON specification language](spec.html) and how to [use Vega-Lite visualizations]({{site.baseurl}}/usage/embed.html) in a web application.
 
 <form action="https://google.com/search" method="get" class="search">
   <input type="hidden" name="q" value="site:https://vega.github.io/vega-lite/docs/">

--- a/site/docs/parameter/select.md
+++ b/site/docs/parameter/select.md
@@ -56,9 +56,9 @@ A [selection's type](parameter.html#select) determines which data values fall wi
 
 ### Selection Projection with `encodings` and `fields`
 
-In the scatterplot example below, highlight <select name="point" onchange="buildProjection('point')"><option value="multi">multiple</option><option value="single">a single</option></select>: <label onclick="buildProjection('point')"><input type="checkbox" name="point" value="cylinders" />Cylinder(s)</label> <label onclick="buildProjection('point')"><input type="checkbox" name="point" value="origin" />Origin(s)</label>.
+In the scatterplot example below, highlight <select name="point_vis" onchange="buildProjection('point_vis')"><option value="multi">multiple</option><option value="single">a single</option></select>: <label onclick="buildProjection('point_vis')"><input type="checkbox" name="point_vis" value="cylinders" />Cylinder(s)</label> <label onclick="buildProjection('point_vis')"><input type="checkbox" name="point_vis" value="origin" />Origin(s)</label>.
 
-<div id="point" class="vl-example" data-name="selection_project_multi"></div>
+<div id="point_vis" class="vl-example" data-name="selection_project_multi"></div>
 
 With interval selections, we can use the projection to restrict the region to just the <label onclick="buildProjection('interval_vis')"><input type="checkbox" name="interval_vis" value="x" />horizontal (`x`)</label> and/or <label onclick="buildProjection('interval_vis')"><input type="checkbox" name="interval_vis" value="y" />vertical (`y`)</label> dimensions.
 

--- a/site/docs/parameter/select.md
+++ b/site/docs/parameter/select.md
@@ -60,9 +60,9 @@ In the scatterplot example below, highlight <select name="point" onchange="build
 
 <div id="point" class="vl-example" data-name="selection_project_multi"></div>
 
-With interval selections, we can use the projection to restrict the region to just the <label onclick="buildProjection('interval')"><input type="checkbox" name="interval" value="x" />horizontal (`x`)</label> and/or <label onclick="buildProjection('interval')"><input type="checkbox" name="interval" value="y" />vertical (`y`)</label> dimensions.
+With interval selections, we can use the projection to restrict the region to just the <label onclick="buildProjection('interval_vis')"><input type="checkbox" name="interval_vis" value="x" />horizontal (`x`)</label> and/or <label onclick="buildProjection('interval_vis')"><input type="checkbox" name="interval_vis" value="y" />vertical (`y`)</label> dimensions.
 
-<div id="interval" class="vl-example" data-name="selection_project_interval"></div>
+<div id="interval_vis" class="vl-example" data-name="selection_project_interval"></div>
 
 #### Current Limitations
 


### PR DESCRIPTION
## PR Description

Fixes these links on https://vega.github.io/vega-lite/docs/:
> This documentation describes the [JSON specification language](https://vega.github.io/vega-lite/docs/#spec)
> ...
> - [Point Selection Properties](https://vega.github.io/vega-lite/docs/selection.html#point)
> - [Interval Selection Properties](https://vega.github.io/vega-lite/docs/selection.html#interval)

