### PR TITLE
docs: Indicate what type of CI is made

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -8545,7 +8545,7 @@
       "properties": {
         "extent": {
           "$ref": "#/definitions/ErrorBarExtent",
-          "description": "The extent of the rule. Available options include:\n- `\"ci\"`: Extend the rule to the confidence interval of the mean.\n- `\"stderr\"`: The size of rule are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of rule are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the rule to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+          "description": "The extent of the rule. Available options include:\n- `\"ci\"`: Extend the rule to the 95% bootstrapped confidence interval of the mean.\n- `\"stderr\"`: The size of rule are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of rule are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the rule to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
         },
         "rule": {
           "anyOf": [
@@ -8601,7 +8601,7 @@
         },
         "extent": {
           "$ref": "#/definitions/ErrorBarExtent",
-          "description": "The extent of the rule. Available options include:\n- `\"ci\"`: Extend the rule to the confidence interval of the mean.\n- `\"stderr\"`: The size of rule are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of rule are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the rule to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+          "description": "The extent of the rule. Available options include:\n- `\"ci\"`: Extend the rule to the 95% bootstrapped confidence interval of the mean.\n- `\"stderr\"`: The size of rule are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of rule are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the rule to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
         },
         "opacity": {
           "description": "The opacity (value between [0,1]) of the mark.",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -8446,7 +8446,7 @@
         },
         "extent": {
           "$ref": "#/definitions/ErrorBarExtent",
-          "description": "The extent of the band. Available options include:\n- `\"ci\"`: Extend the band to the confidence interval of the mean.\n- `\"stderr\"`: The size of band are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of band are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the band to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+          "description": "The extent of the band. Available options include:\n- `\"ci\"`: Extend the band to the 95% bootstrapped confidence interval of the mean.\n- `\"stderr\"`: The size of band are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of band are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the band to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
         },
         "interpolate": {
           "$ref": "#/definitions/Interpolate",
@@ -8504,7 +8504,7 @@
         },
         "extent": {
           "$ref": "#/definitions/ErrorBarExtent",
-          "description": "The extent of the band. Available options include:\n- `\"ci\"`: Extend the band to the confidence interval of the mean.\n- `\"stderr\"`: The size of band are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of band are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the band to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+          "description": "The extent of the band. Available options include:\n- `\"ci\"`: Extend the band to the 95% bootstrapped confidence interval of the mean.\n- `\"stderr\"`: The size of band are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of band are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the band to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
         },
         "interpolate": {
           "$ref": "#/definitions/Interpolate",

--- a/src/compositemark/errorband.ts
+++ b/src/compositemark/errorband.ts
@@ -37,7 +37,7 @@ export interface ErrorBandConfig extends ErrorBandPartsMixins {
 
   /**
    * The extent of the band. Available options include:
-   * - `"ci"`: Extend the band to the confidence interval of the mean.
+   * - `"ci"`: Extend the band to the 95% bootstrapped confidence interval of the mean.
    * - `"stderr"`: The size of band are set to the value of standard error, extending from the mean.
    * - `"stdev"`: The size of band are set to the value of standard deviation, extending from the mean.
    * - `"iqr"`: Extend the band to the q1 and q3.

--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -96,7 +96,7 @@ export interface ErrorBarConfig extends ErrorBarPartsMixins {
 
   /**
    * The extent of the rule. Available options include:
-   * - `"ci"`: Extend the rule to the confidence interval of the mean.
+   * - `"ci"`: Extend the rule to the 95% bootstrapped confidence interval of the mean.
    * - `"stderr"`: The size of rule are set to the value of standard error, extending from the mean.
    * - `"stdev"`: The size of rule are set to the value of standard deviation, extending from the mean.
    * - `"iqr"`: Extend the rule to the q1 and q3.


### PR DESCRIPTION
Minor clarification to the docs so that it is clear what type of CI is added. This info is available in the aggregation docs, but not in the docstring to the errorbar and errorband marks.