### PR TITLE
fix: correct y axis title in boxplot when mark.extent isnt set ##9223

### DIFF
--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -9,7 +9,7 @@ import {MarkInvalidMixins} from '../invalid';
 import {NormalizerParams} from '../normalize';
 import {GenericUnitSpec, NormalizedLayerSpec, NormalizedUnitSpec} from '../spec';
 import {AggregatedFieldDef, CalculateTransform, JoinAggregateTransform, Transform} from '../transform';
-import {isEmpty, omit, removePathFromField} from '../util';
+import {removePathFromField} from '../util';
 import {CompositeMarkNormalizer} from './base';
 import {
   compositeMarkContinuousAxis,
@@ -301,7 +301,6 @@ export function normalizeBoxPlot(
 
   const {scale, axis} = continuousAxisChannelDef;
   const title = getTitle(continuousAxisChannelDef);
-  const axisWithoutTitle = omit(axis, ['title']);
 
   const outlierLayersMixins = partLayerMixins<BoxPlotPartsMixins>(markDef, 'outliers', config.boxplot, {
     transform: [{filter: `(${fieldExpr} < ${lowerWhiskerExpr}) || (${fieldExpr} > ${upperWhiskerExpr})`}],
@@ -312,8 +311,7 @@ export function normalizeBoxPlot(
         type: continuousAxisChannelDef.type,
         ...(title !== undefined ? {title} : {}),
         ...(scale !== undefined ? {scale} : {}),
-        // add axis without title since we already added the title above
-        ...(isEmpty(axisWithoutTitle) ? {} : {axis: axisWithoutTitle})
+        ...(axis !== undefined ? {axis} : {})
       },
       ...encodingWithoutSizeColorContinuousAxisAndTooltip,
       ...(color ? {color} : {}),


### PR DESCRIPTION
closes #9223 

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully