### PR TITLE
test: Check error message contents when testing compiler for animated point selections

### DIFF
--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -628,7 +628,7 @@ describe('Animated Selection', () => {
         }
       });
       facetModel.parseSelections();
-    }).toThrow(Error);
+    }).toThrow(`ERROR: ${log.message.MULTI_VIEW_ANIMATION_UNSUPPORTED}`);
 
     expect(() => {
       const layerModel = parseModel({
@@ -679,7 +679,7 @@ describe('Animated Selection', () => {
         }
       });
       layerModel.parseSelections();
-    }).toThrow(Error);
+    }).toThrow(`ERROR: ${log.message.MULTI_VIEW_ANIMATION_UNSUPPORTED}`);
 
     expect(() => {
       const concatModel = parseModel({
@@ -730,6 +730,6 @@ describe('Animated Selection', () => {
         }
       });
       concatModel.parseSelections();
-    }).toThrow(Error);
+    }).toThrow(`ERROR: ${log.message.MULTI_VIEW_ANIMATION_UNSUPPORTED}`);
   });
 });


### PR DESCRIPTION
## Motivation

- Assist w/ verifying the correct ESM update ( https://github.com/vega/vega/issues/3990 / https://github.com/vega/vega-lite/pull/9527)

## Changes

- No functional change at runtime. 
- In test: make sure errors contain text relating to specific compiler error messages are thrown, rather than asserting _any_ error was thrown.

## Notes

- Docs on Jest's toThrow [options](https://jestjs.io/docs/expect#tothrowerror)
- Our error is thrown by the [common logger](https://github.com/vega/vega-lite/blob/309e7b44165b21d84d53c29274676116d503713e/src/log/index.ts#L50)
