### PR TITLE
fix: display title when set in config.axisX/axisY.title

### DIFF
--- a/src/axis.ts
+++ b/src/axis.ts
@@ -16,7 +16,7 @@ import type {
 import {ConditionalPredicate, Value, ValueDef} from './channeldef';
 import {DateTime} from './datetime';
 import {ExprRef} from './expr';
-import {Guide, GuideEncodingEntry, TitleMixins, VlOnlyGuideConfig} from './guide';
+import {Guide, GuideEncodingEntry, TitleMixins} from './guide';
 import {Flag, keys} from './util';
 import {MapExcludeValueRefAndReplaceSignalWith, VgEncodeChannel} from './vega.schema';
 import {hasOwnProperty} from 'vega-util';
@@ -337,7 +337,7 @@ export interface AxisPropsWithCondition<ES extends ExprRef | SignalRef> {
 }
 
 export type AxisConfig<ES extends ExprRef | SignalRef> = Guide &
-  VlOnlyGuideConfig &
+  TitleMixins &
   AxisConfigBaseWithConditionalAndSignal<ES> & {
     /**
      * Disable axis by default.

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -214,7 +214,8 @@ const propsToAlwaysIncludeConfig = new Set([
   'labelExpr',
   'tickCount',
   'position',
-  'tickMinStep'
+  'tickMinStep',
+  'title'
 ]);
 
 function parseAxis(channel: PositionScaleChannel, model: UnitModel): AxisComponent {

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -50,11 +50,12 @@ describe('Axis', () => {
             type: 'quantitative'
           }
         },
-        config: {axisQuantitative: {labelAlign: 'right'}}
+        config: {axisQuantitative: {labelAlign: 'right'}, axisX: {title: 'foo'}}
       });
       const axisComponent = parseUnitAxes(model);
       expect(axisComponent['x']).toHaveLength(1);
       expect(axisComponent['x'][0].implicit.labelAlign).toBe('right');
+      expect(axisComponent['x'][0].implicit.title).toBe('foo');
     });
 
     it('should produce grid, orient, tickCount, labelExpr in the component when axis config is specified.', () => {


### PR DESCRIPTION
potentially closes #9429

This fixes the compilation process from vega lite to vega by accounting for the title property inside the config.
@domoritz suggested removing support for setting the axis title inside the config entirely, but due to the consensus in #4057 I chose this solution instead.

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully