### PR TITLE
chore: Add numfocus sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://app.hubspot.com/payments/GyPC972GD9Rt?referrer=PAYMENT_LINK


### PR DESCRIPTION
Suggesting to add this link to all the four main repos displayed on https://vega.github.io/ as per [this discussion](https://vega-js.slack.com/archives/C067QG4BZQT/p1738678358389039?thread_ts=1738618798.173569&cid=C067QG4BZQT)