### PR TITLE
fix: remove extra backtick in LegendConfig.labelOverlap documentation

### DIFF
--- a/src/legend.ts
+++ b/src/legend.ts
@@ -138,7 +138,7 @@ interface LegendMixins<ES extends ExprRef | SignalRef> {
   /**
    * The strategy to use for resolving overlap of labels in gradient legends. If `false`, no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used. If set to `"greedy"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).
    *
-   * __Default value:__ `"greedy"` for `log scales otherwise `true`.
+   * __Default value:__ `"greedy"` for log scales otherwise `true`.
    */
   labelOverlap?: LabelOverlap | ES; // override comment since our default differs from Vega
 


### PR DESCRIPTION
… #9524

## PR Description 
@domoritz 

Deleted the extra backtick inside of the legend.ts file

<details>
  <summary><h2>Checklist</h2></summary>

- [ ] This PR is atomic (i.e., it fixes one issue at a time).
- [ ] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [ ] `yarn test` runs successfully
- For new features:
  - [ ] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
