### PR TITLE
fix: remove extra backtick in LegendConfig.labelOverlap documentation

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -14094,7 +14094,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The strategy to use for resolving overlap of labels in gradient legends. If `false`, no overlap reduction is attempted. If set to `true` or `\"parity\"`, a strategy of removing every other label is used. If set to `\"greedy\"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).\n\n__Default value:__ `\"greedy\"` for `log scales otherwise `true`."
+          "description": "The strategy to use for resolving overlap of labels in gradient legends. If `false`, no overlap reduction is attempted. If set to `true` or `\"parity\"`, a strategy of removing every other label is used. If set to `\"greedy\"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).\n\n__Default value:__ `\"greedy\"` for log scales otherwise `true`."
         },
         "labelPadding": {
           "anyOf": [

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -138,7 +138,7 @@ interface LegendMixins<ES extends ExprRef | SignalRef> {
   /**
    * The strategy to use for resolving overlap of labels in gradient legends. If `false`, no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used. If set to `"greedy"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).
    *
-   * __Default value:__ `"greedy"` for `log scales otherwise `true`.
+   * __Default value:__ `"greedy"` for log scales otherwise `true`.
    */
   labelOverlap?: LabelOverlap | ES; // override comment since our default differs from Vega
 


### PR DESCRIPTION
Replaces https://github.com/vega/vega-lite/pull/9558
Fixes https://github.com/vega/vega-lite/issues/9524