### PR TITLE
docs: update links and materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Read about future plans in [our roadmap](https://github.com/vega/roadmap/project
 
 ## Team
 
-The development of Vega-Lite is led by the alumni and members of the [University of Washington Interactive Data Lab](https://idl.cs.washington.edu) (UW IDL), including [Kanit "Ham" Wongsuphasawat](https://twitter.com/kanitw) (now at Databricks), [Dominik Moritz](https://twitter.com/domoritz) (now at CMU and Apple), [Arvind Satyanarayan](https://twitter.com/arvindsatya1) (now at MIT), and [Jeffrey Heer](https://twitter.com/jeffrey_heer) (UW IDL).
+The development of Vega-Lite is led by the alumni and members of the [University of Washington Interactive Data Lab](https://idl.cs.washington.edu) (UW IDL), including [Kanit "Ham" Wongsuphasawat](https://kanitw.github.io) (now at Databricks), [Dominik Moritz](https://bsky.app/profile/domoritz.de) (now at CMU / Apple), [Arvind Satyanarayan](https://bsky.app/profile/arvind.bsky.social) (now at MIT), and [Jeffrey Heer](https://bsky.app/profile/jheer.org) (UW IDL).
 
 Vega-Lite gets significant contributions from its community. Please see the [contributors page](https://github.com/vega/vega-lite/graphs/contributors) for the full list of contributors.
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -6,8 +6,6 @@ description:
 
 baseurl: '/vega-lite' # the subpath of your site, e.g. /blog/
 url: 'https://vega.github.io' # the base hostname & protocol for your site
-twitter:
-  username: vega_vis
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/site/index.md
+++ b/site/index.md
@@ -48,7 +48,7 @@ images:
 
 Compared to [Vega](https://vega.github.io/vega), Vega-Lite provides a more concise and convenient form to author common visualizations. As Vega-Lite can compile its specifications to Vega specifications, users may use Vega-Lite as the _primary_ visualization tool and, if needed, transition to use the lower-level Vega for advanced use cases.
 
-For more information, read our [introduction article to Vega-Lite v2 on Medium](https://medium.com/@uwdata/de6661c12d58), watch our [OpenVis Conf talk about the new features in Vega-Lite v2](https://www.youtube.com/watch?v=9uaHRWj04D4), see the [documentation]({{ site.baseurl }}/docs/) and take a look at our [example gallery]({{ site.baseurl }}/examples/). Follow us on [Twitter at @vega_vis](https://twitter.com/vega_vis) to stay informed about updates.
+Check out the [documentation]({{ site.baseurl }}/docs/) and take a look at our [example gallery]({{ site.baseurl }}/examples/). Follow us on [Bluesky](https://bsky.app/profile/vega-vis.bsky.social) to stay informed about updates.
 
 ## Example
 
@@ -83,6 +83,7 @@ For more information, read our [introduction article to Vega-Lite v2 on Medium](
 - Award winning [research paper](https://idl.cs.washington.edu/papers/vega-lite) and [video of our OpenVis Conf talk](https://www.youtube.com/watch?v=9uaHRWj04D4) on the design of Vega-Lite
 - [The about page for the Vega project](https://vega.github.io/vega/about/)
 - Listen to a Data Stories episode about [Declarative Visualization with Vega-Lite and Altair](http://datastori.es/121-declarative-visualization-with-vega-lite-and-altair-with-dominik-moritz-jacob-vanderplas-kanit-ham-wongsuphasawat/)
+- Learn about visualization design principles in the [Visualization curriculum](https://observablehq.com/@uwdata/data-visualization-curriculum?collection=@uwdata/visualization-curriculum)
 - [JSON schema](http://json-schema.org/) specification for [Vega-Lite](https://github.com/vega/schema) ([latest](https://vega.github.io/schema/vega-lite/v6.json))
 - Ask questions about Vega-Lite on [Stack Overflow](https://stackoverflow.com/tags/vega-lite) or [Slack](https://bit.ly/join-vega-slack-2022)
 - Fork our [Observable Notebook](https://beta.observablehq.com/@domoritz/vega-lite-demo).
@@ -109,6 +110,6 @@ Vega-Lite is used by thousands of data enthusiasts, developers, journalists, dat
 
 ## Team
 
-The development of Vega-Lite is led by the alumni and members of the [University of Washington Interactive Data Lab](https://idl.cs.washington.edu) (UW IDL), including [Kanit "Ham" Wongsuphasawat](https://twitter.com/kanitw) (now at Databricks), [Dominik Moritz](https://twitter.com/domoritz) (now at CMU / Apple), [Arvind Satyanarayan](https://twitter.com/arvindsatya1) (now at MIT), and [Jeffrey Heer](https://twitter.com/jeffrey_heer) (UW IDL).
+The development of Vega-Lite is led by the alumni and members of the [University of Washington Interactive Data Lab](https://idl.cs.washington.edu) (UW IDL), including [Kanit "Ham" Wongsuphasawat](https://kanitw.github.io) (now at Databricks), [Dominik Moritz](https://bsky.app/profile/domoritz.de) (now at CMU / Apple), [Arvind Satyanarayan](https://bsky.app/profile/arvind.bsky.social) (now at MIT), and [Jeffrey Heer](https://bsky.app/profile/jheer.org) (UW IDL).
 
 Vega-Lite gets significant contributions from its community. Please see the [contributors page](https://github.com/vega/vega-lite/graphs/contributors) for the full list of contributors.


### PR DESCRIPTION
Twitter is bad so replace links, add link to curriculum, remove mention of Vega-Lite 2