### PR TITLE
feat: export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
+    "./types_unstable/*": {
+      "types": "./build/*"
+    },
     "./vega-lite-schema.json": "./build/vega-lite-schema.json"
   },
   "unpkg": "build/vega-lite.min.js",

--- a/src/compile/format.ts
+++ b/src/compile/format.ts
@@ -21,6 +21,7 @@ import {stringify} from '../util.js';
 import {isSignalRef} from '../vega.schema.js';
 import {TimeUnit} from './../timeunit.js';
 import {datumDefToExpr} from './mark/encode/valueref.js';
+import {BIN_RANGE_DELIMITER} from './common.js';
 
 export function isCustomFormatType(formatType: string) {
   return formatType && formatType !== 'number' && formatType !== 'time';
@@ -29,8 +30,6 @@ export function isCustomFormatType(formatType: string) {
 function customFormatExpr(formatType: string, field: string, format: Format) {
   return `${formatType}(${field}${format ? `, ${stringify(format)}` : ''})`;
 }
-
-export const BIN_RANGE_DELIMITER = ' \u2013 ';
 
 export function formatSignalRef({
   fieldOrDatumDef,

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -15,7 +15,7 @@ import {TopLevel} from './toplevel.js';
 import {FacetedUnitSpec, GenericUnitSpec, NormalizedUnitSpec, TopLevelUnitSpec, UnitSpecWithFrame} from './unit.js';
 
 export type {BaseSpec, LayoutSizeMixins} from './base.js';
-export type {GenericHConcatSpec, GenericVConcatSpec, NormalizedConcatSpec} from './concat.js';
+export type {GenericConcatSpec, GenericHConcatSpec, GenericVConcatSpec, NormalizedConcatSpec} from './concat.js';
 export {isAnyConcatSpec, isHConcatSpec, isVConcatSpec} from './concat.js';
 export type {GenericFacetSpec, NormalizedFacetSpec} from './facet.js';
 export {isFacetSpec} from './facet.js';
@@ -24,7 +24,14 @@ export {isLayerSpec} from './layer.js';
 export type {RepeatSpec} from './repeat.js';
 export {isRepeatSpec} from './repeat.js';
 export type {TopLevel} from './toplevel.js';
-export type {FacetedUnitSpec, GenericUnitSpec, NormalizedUnitSpec, UnitSpec} from './unit.js';
+export type {
+  FacetedUnitSpec,
+  GenericUnitSpec,
+  NormalizedUnitSpec,
+  UnitSpec,
+  TopLevelUnitSpec,
+  UnitSpecWithFrame,
+} from './unit.js';
 export {isUnitSpec} from './unit.js';
 
 /**


### PR DESCRIPTION
Fixes #9583, fixes #9222

Simpler version of #9584

You can use this new feature to import types from arbitrary files. 

```ts
import type {TopLevelUnitSpec} from 'vega-lite/types_unstable/spec/unit.d.ts';
import type {Field} from 'vega-lite/types_unstable/channeldef.d.ts';

const spec: TopLevelUnitSpec<Field> = {
  $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
  description: 'A simple bar chart with embedded data.',
  data: {
    values: [
      {a: 'A', b: 28},
      {a: 'B', b: 55},
      {a: 'C', b: 43},
    ],
  },
  mark: 'bar',
  encoding: {
    x: {field: 'a', type: 'ordinal'},
    y: {field: 'b', type: 'quantitative'},
  },
};

```