### PR TITLE
docs: Add Datadog Wildcard Widget + Custom Charts to the Ecosystems Page

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -28,6 +28,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [VizLinter](https://vizlinter.idvxlab.com/), an online editor that detects and fixes encoding issues based on vega-lite-linter.
 - [Datapane](https://github.com/datapane/datapane), a Python framework for building interactive reports from open-source visualization formats such as Vega-Lite.
 - [Graphpad](https://www.figma.com/community/widget/1027276088284051809), an editor for creating Vega-Lite or Vega visualizations in the Figma and Figjam collaborative design/whiteboarding tools.
+- [Datadog](https://www.datadoghq.com/), the monitoring and security platform, has a browser editor for Vega-Lite visualizations in several places: in dashboards and notebooks through the [Wildcard Widget](https://www.datadoghq.com/blog/wildcard-widget/), and in low-code apps through [custom charts](https://docs.datadoghq.com/actions/app_builder/components/custom_charts/).
 
 ## Tools for Scaling Vega-Lite Visualizations
 


### PR DESCRIPTION
## Motivation

- Keep `ecosystems.md` page up to date about commercial users of Wildcard Widget 
- (disclaimer: this is a project I worked on, Datadog is my employer).

## Changes

- Adds Datadog's "Wildcard Widget" and "Custom Chart" to the set of tools that allow authoring Vega / Vega-lite specifications

## Testing

- No impact on library runtime
- Any feedback on content or whether this went into the right section is welcome. 