### PR TITLE
fix: turn off aira for the generated voronoi layer from nearest spec

### DIFF
--- a/src/compile/selection/nearest.ts
+++ b/src/compile/selection/nearest.ts
@@ -32,6 +32,7 @@ const nearest: SelectionCompiler<'point'> = {
       name: model.getName(VORONOI),
       type: 'path',
       interactive: true,
+      aria: false,
       from: {data: model.getName('marks')},
       encode: {
         update: {


### PR DESCRIPTION
## PR Description

This PR fixes https://github.com/vega/vega-lite/issues/9623 by disabling aria related attributes added to the generated voronoi layer when using `nearest: true`.

Before:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/c2770453-d658-4a33-be29-d087a3b52272" />
After:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/78786ce1-31c5-4bc9-a473-2c7f528ceb19" />

Context: Vega internally [decides](https://github.com/vega/vega/blob/83f4b9629c688836bc1a2fc2dbce84b298a3b975/packages/vega-scenegraph/src/util/aria.js#L89-L97) the aria attributes based on the user specified mark spec. The currently specified mark spec from Vega-Lite (in `nearest.ts`) does not disable aria or provide any description hence it produces `aria-role="graphics-symbol"` without an `aria-label` and is failing the a11y test. 

An alternative fix could be to add something like `description: "Voronoi layer for " + model.getName(VORONOI)` instead of `aria: false`, but this layer is invisible and does not gain much from having a11y attributes.


<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [ ] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
