### PR TITLE
fix: do not set opacity in normalized marks for path overlays if it's set in the config

### DIFF
--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -82,12 +82,11 @@ function cursor(markDef: MarkDef<Mark, SignalRef>, encoding: Encoding<string>, c
   return markDef.cursor;
 }
 
+export const DEFAULT_REDUCED_OPACITY = 0.7;
+
 function opacity(mark: Mark, encoding: Encoding<string>) {
-  if (contains([POINT, TICK, CIRCLE, SQUARE], mark)) {
-    // point-based marks
-    if (!isAggregate(encoding)) {
-      return 0.7;
-    }
+  if (contains([POINT, TICK, CIRCLE, SQUARE], mark) && !isAggregate(encoding)) {
+    return DEFAULT_REDUCED_OPACITY;
   }
   return undefined;
 }

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -61,8 +61,8 @@ export function initMarkdef(originalMarkDef: MarkDef, encoding: Encoding<string>
 
   // set opacity and filled if not specified in mark config
   const specifiedOpacity = getMarkPropOrConfig('opacity', markDef, config);
-  const specifiedfillOpacity = getMarkPropOrConfig('fillOpacity', markDef, config);
-  if (specifiedOpacity === undefined && specifiedfillOpacity === undefined) {
+  const specifiedFillOpacity = getMarkPropOrConfig('fillOpacity', markDef, config);
+  if (specifiedOpacity === undefined && specifiedFillOpacity === undefined) {
     markDef.opacity = opacity(markDef.type, encoding);
   }
 

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -10,6 +10,7 @@ import {stack} from '../stack.js';
 import {keys, omit, pick} from '../util.js';
 import {NonFacetUnitNormalizer, NormalizeLayerOrUnit, NormalizerParams} from './base.js';
 import {DEFAULT_REDUCED_OPACITY, initMarkdef} from '../compile/mark/init.js';
+import {getMarkPropOrConfig} from '../compile/common.js';
 
 type UnitSpecWithPathOverlay = GenericUnitSpec<Encoding<string>, Mark | MarkDef<'line' | 'area' | 'rule' | 'trail'>>;
 
@@ -119,10 +120,8 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
         ...(params ? {params} : {}),
         mark: dropLineAndPoint({
           ...(markDef.type === 'area' &&
-          markDef.opacity === undefined &&
-          markDef.fillOpacity === undefined &&
-          config[markDef.type]?.opacity === undefined &&
-          config[markDef.type]?.fillOpacity === undefined
+          getMarkPropOrConfig('opacity', markDef, config) == undefined &&
+          getMarkPropOrConfig('fillOpacity', markDef, config) == undefined
             ? {opacity: DEFAULT_REDUCED_OPACITY}
             : {}),
           ...markDef,

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -9,7 +9,7 @@ import {isUnitSpec} from '../spec/unit.js';
 import {stack} from '../stack.js';
 import {keys, omit, pick} from '../util.js';
 import {NonFacetUnitNormalizer, NormalizeLayerOrUnit, NormalizerParams} from './base.js';
-import {initMarkdef} from '../compile/mark/init.js';
+import {DEFAULT_REDUCED_OPACITY, initMarkdef} from '../compile/mark/init.js';
 
 type UnitSpecWithPathOverlay = GenericUnitSpec<Encoding<string>, Mark | MarkDef<'line' | 'area' | 'rule' | 'trail'>>;
 
@@ -117,7 +117,16 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
       {
         name,
         ...(params ? {params} : {}),
-        mark: dropLineAndPoint(markDef),
+        mark: dropLineAndPoint({
+          ...(markDef.type === 'area' &&
+          markDef.opacity === undefined &&
+          markDef.fillOpacity === undefined &&
+          config[markDef.type]?.opacity === undefined &&
+          config[markDef.type]?.fillOpacity === undefined
+            ? {opacity: DEFAULT_REDUCED_OPACITY}
+            : {}),
+          ...markDef,
+        }),
         // drop shape from encoding as this might be used to trigger point overlay
         encoding: omit(encoding, ['shape']),
       },
@@ -125,7 +134,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
 
     // FIXME: determine rules for applying selections.
 
-    // Need to copy stack config to overlayed layer
+    // Need to copy stack config to overlaid layer
     // FIXME: normalizer shouldn't call `initMarkdef`, a method from an init phase.
     const stackProps = stack(initMarkdef(markDef, encoding, config), encoding);
 

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -117,13 +117,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
       {
         name,
         ...(params ? {params} : {}),
-        mark: dropLineAndPoint({
-          // TODO: extract this 0.7 to be shared with default opacity for point/tick/...
-          ...(markDef.type === 'area' && markDef.opacity === undefined && markDef.fillOpacity === undefined
-            ? {opacity: 0.7}
-            : {}),
-          ...markDef,
-        }),
+        mark: dropLineAndPoint(markDef),
         // drop shape from encoding as this might be used to trigger point overlay
         encoding: omit(encoding, ['shape']),
       },


### PR DESCRIPTION
Fixes https://github.com/vega/vega-lite/issues/9548