### PR TITLE
Fix:  align stack order only for nominal color domains

### DIFF
--- a/src/compile/mark/encode/aria.ts
+++ b/src/compile/mark/encode/aria.ts
@@ -77,6 +77,7 @@ export function description(model: UnitModel) {
   return {
     description: {
       signal: entries(data)
+        .filter(([key]) => !key.startsWith('_')) // remove internal/private signals from aria description
         .map(([key, value], index) => `"${index > 0 ? '; ' : ''}${key}: " + (${value})`)
         .join(' + '),
     },

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -235,12 +235,13 @@ export class UnitModel extends ModelWithField {
     const colorEncoding = isFieldDef(colorField) ? colorField : undefined;
     const field = colorEncoding?.field;
     const scale = colorEncoding?.scale;
+    const colorEncodingType = colorEncoding?.type;
     const domain = scale?.domain;
     const offset = xOffset || yOffset;
     const offsetEncoding = isFieldDef(offset) ? offset : undefined;
     const orderFieldName = `_${field}_sort_index`;
 
-    if (!order && Array.isArray(domain) && typeof field === 'string') {
+    if (!order && Array.isArray(domain) && typeof field === 'string' && colorEncodingType === 'nominal') {
       // align grouped bar order with color domain
       if (offsetEncoding && !offsetEncoding.sort) {
         offsetEncoding.sort = domain as [];


### PR DESCRIPTION
## PR Description

Refines [PR: fix: align stack order with color domain](https://github.com/vega/vega-lite/pull/9641):

- Only for specs with nominal color encoding the stack order is aligned with a custom color domain (if one is provided).
- The internal field that is use to order the stack is no longer added to aria-labels in the SVG 


