### PR TITLE
feat: support newlines in tooltips

### DIFF
--- a/src/compile/mark/encode/tooltip.ts
+++ b/src/compile/mark/encode/tooltip.ts
@@ -16,7 +16,7 @@ import {Config} from '../../../config.js';
 import {Encoding, forEach} from '../../../encoding.js';
 import {StackProperties} from '../../../stack.js';
 import {Dict, entries} from '../../../util.js';
-import {isSignalRef} from '../../../vega.schema.js';
+import {isSignalRef, VgValueRef} from '../../../vega.schema.js';
 import {getMarkPropOrConfig} from '../../common.js';
 import {binFormatExpression, formatSignalRef} from '../../format.js';
 import {UnitModel} from '../../unit.js';
@@ -26,13 +26,14 @@ import {textRef} from './text.js';
 export function tooltip(model: UnitModel, opt: {reactiveGeom?: boolean} = {}) {
   const {encoding, markDef, config, stack} = model;
   const channelDef = encoding.tooltip;
+
   if (isArray(channelDef)) {
     return {tooltip: tooltipRefForEncoding({tooltip: channelDef}, stack, config, opt)};
   } else {
     const datum = opt.reactiveGeom ? 'datum.datum' : 'datum';
     const mainRefFn = (cDef: Encoding<string>['tooltip']) => {
       // use valueRef based on channelDef first
-      const tooltipRefFromChannelDef = textRef(cDef, config, datum);
+      const tooltipRefFromChannelDef = addLineBreaksToTooltip(cDef, config, datum);
       if (tooltipRefFromChannelDef) {
         return tooltipRefFromChannelDef;
       }
@@ -130,7 +131,7 @@ export function tooltipData(
       }).signal;
     }
 
-    value ??= textRef(fieldDef, formatConfig, expr).signal;
+    value ??= addLineBreaksToTooltip(fieldDef, formatConfig, expr).signal;
 
     tuples.push({channel, key, value});
   }
@@ -163,4 +164,24 @@ export function tooltipRefForEncoding(
 
   const keyValues = entries(data).map(([key, value]) => `"${key}": ${value}`);
   return keyValues.length > 0 ? {signal: `{${keyValues.join(', ')}}`} : undefined;
+}
+
+/**
+ * Transforms a tooltip value that is an array to a string with line breaks
+ */
+function addLineBreaksToTooltip(
+  channelDef: Encoding<string>['text' | 'tooltip'],
+  config: Config,
+  expr: 'datum' | 'datum.datum' = 'datum',
+): VgValueRef {
+  // tooltip fields with a format property are no strings
+  const fieldDefWithFormat = channelDef as {field: string; type: string; format: string};
+  if (fieldDefWithFormat?.type === 'nominal' && !fieldDefWithFormat.format) {
+    const fieldString = `datum["${fieldDefWithFormat.field}"]`;
+    return {
+      signal: `isValid(${fieldString}) ? isArray(${fieldString}) ? join(${fieldString}, '\\n') : ${fieldString} : ""+${fieldString}`,
+    };
+  }
+
+  return textRef(channelDef, config, expr);
 }

--- a/test/compile/mark/encode/tooltip.test.ts
+++ b/test/compile/mark/encode/tooltip.test.ts
@@ -137,7 +137,8 @@ describe('compile/mark/encode/tooltip', () => {
       });
       const props = tooltip(model);
       expect(props.tooltip).toEqual({
-        signal: '{"Foobar": isValid(datum["Foobar"]) ? datum["Foobar"] : ""+datum["Foobar"]}',
+        signal:
+          '{"Foobar": isValid(datum["Foobar"]) ? isArray(datum["Foobar"]) ? join(datum["Foobar"], \'\\n\') : datum["Foobar"] : ""+datum["Foobar"]}',
       });
     });
     it('generates correct keys and values for channels with title', () => {
@@ -149,7 +150,8 @@ describe('compile/mark/encode/tooltip', () => {
       });
       const props = tooltip(model);
       expect(props.tooltip).toEqual({
-        signal: '{"baz": isValid(datum["Foobar"]) ? datum["Foobar"] : ""+datum["Foobar"]}',
+        signal:
+          '{"baz": isValid(datum["Foobar"]) ? isArray(datum["Foobar"]) ? join(datum["Foobar"], \'\\n\') : datum["Foobar"] : ""+datum["Foobar"]}',
       });
     });
 
@@ -162,7 +164,8 @@ describe('compile/mark/encode/tooltip', () => {
       });
       const props = tooltip(model);
       expect(props.tooltip).toEqual({
-        signal: '{"\\"baz\\"": isValid(datum["Foobar"]) ? datum["Foobar"] : ""+datum["Foobar"]}',
+        signal:
+          '{"\\"baz\\"": isValid(datum["Foobar"]) ? isArray(datum["Foobar"]) ? join(datum["Foobar"], \'\\n\') : datum["Foobar"] : ""+datum["Foobar"]}',
       });
     });
   });

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -83,7 +83,7 @@ describe('Layered Selections', () => {
             },
             description: {
               signal:
-                '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? datum["Origin"] : ""+datum["Origin"])',
+                '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? isArray(datum["Origin"]) ? join(datum["Origin"], \'\\n\') : datum["Origin"] : ""+datum["Origin"])',
             },
             fill: {
               scale: 'color',
@@ -125,7 +125,7 @@ describe('Layered Selections', () => {
             },
             description: {
               signal:
-                '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? datum["Origin"] : ""+datum["Origin"])',
+                '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? isArray(datum["Origin"]) ? join(datum["Origin"], \'\\n\') : datum["Origin"] : ""+datum["Origin"])',
             },
             fill: {
               scale: 'color',
@@ -162,7 +162,7 @@ describe('Layered Selections', () => {
             },
             description: {
               signal:
-                '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? datum["Origin"] : ""+datum["Origin"])',
+                '"Horsepower: " + (format(datum["Horsepower"], "")) + "; Miles_per_Gallon: " + (format(datum["Miles_per_Gallon"], "")) + "; Origin: " + (isValid(datum["Origin"]) ? isArray(datum["Origin"]) ? join(datum["Origin"], \'\\n\') : datum["Origin"] : ""+datum["Origin"])',
             },
             fill: {
               value: 'transparent',


### PR DESCRIPTION
## PR Description

This PR adds support for rendering newlines in tooltips and potentially closes #7564.

A new function has been added in the tooltip encoder that transforms tooltip values that are arrays into strings joined by newline characters. This allows multi-line tooltip content to be displayed correctly.

To support this behavior visually, a small CSS update is required in the vega-tooltip package — see the accompanying PR in that repository.

### Example
With the new code, this example spec ([open in editor](https://vega.github.io/editor/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JAKyUAVhDYA7EABoQAdxoATemgBMABh1K1STClShZSBHDQhjTQVaXEkghnAhoA2qACecJACdtHS0AZiUoNgZZTDQARj0lTDgADxj0ehoIAAJMrMkGCEwsuTgs4VkrAF8FHz9A1F0tABZwyOig-RsUtI8bGFzcpCzMNjZBTBocRRU6GGHlNjKaCvcAXWragKCtMVaotJCErtTPEAAVfuzB4dHxyenVemGYfzhS8rdpmUssgEcGERlORkLJIbLeSJZKBIWRZCBvEDrdZKZD+ADW1iYWyUcFkETUyzIaFAyWJIAAZjQ4II1NZfFtqiBvGTKdTaegIvtpphvDgrOh-jCJsYJqQQIyRmMJlNUF4KVSaXS6uKavK2dZOe0lOS2P5kGlphs1Yr0t1xatWoJdWSnC5+SAAMR6JoANgAnG7xZVKkA)) will render a tooltip like this:

<img width="1023" height="406" alt="example-multiline-tooltip" src="https://github.com/user-attachments/assets/f0bd13e0-a397-4e77-8660-5ad59aeca345" />





