### PR TITLE
docs: fix broken link in docs/window.html

### DIFF
--- a/site/docs/transform/window.md
+++ b/site/docs/transform/window.md
@@ -66,7 +66,7 @@ The window transform performs calculations over sorted groups of data objects. T
 
 ## Window Only Operation Reference
 
-The valid operations include all [aggregate operations](../aggregate/#ops) plus the following window operations.
+The valid operations include all [aggregate operations](aggregate.html#ops) plus the following window operations.
 
 | Operation | Parameter | Description |
 | :-- | :-: | :-- |


### PR DESCRIPTION
The link from the vega lite window documentation to the list of operations on the aggregate page is incorrectly formatted and 404s. This PR fixes the formatting.