### PR TITLE
fix: dedup example title

### DIFF
--- a/site/_data/examples.json
+++ b/site/_data/examples.json
@@ -869,7 +869,7 @@
       },
       {
         "name": "interactive_multi_line_pivot_tooltip",
-        "title": "Multi Series Line Chart with Tooltip",
+        "title": "Multi Series Line Chart with Tooltip via Pivot",
         "description": "The plot displays labels for all stock prices of the hovered time. This example uses a pivot transform to compute the data for the tooltip.",
         "png": true
       },


### PR DESCRIPTION
## PR Description

This PR deduplicates an example title in [examples.json](https://github.com/vega/vega-lite/blob/87bab0e88d555161748ac866428d8baaed157cb5/site/_data/examples.json) by updating the title of the `interactive_multi_line_pivot_tooltip` example to "Multi Series Line Chart with Tooltip via Pivot". Previously, both `interactive_multi_line_tooltip` and `interactive_multi_line_pivot_tooltip` shared the same title ("Multi Series Line Chart with Tooltip"). With this change, all example titles (which appear as the names of the examples on the example web site) within vega-lite are now unique, which will aid preparatory work in `vega/vega-datasets` to update the `README.md` to show which datasets are used in which vega/vega-lite/altair example galleries. Aside from this, the change also helps to differentiate two similar examples in the example gallery.


<img width="1074" height="259" alt="image" src="https://github.com/user-attachments/assets/6971a633-4521-4b44-b3b2-d07216593fd8" />


<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [x] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
