### PR TITLE
Fix setting height/width to 0

### DIFF
--- a/src/compile/layoutsize/assemble.ts
+++ b/src/compile/layoutsize/assemble.ts
@@ -20,7 +20,7 @@ export function assembleLayoutSignals(model: Model): NewSignal[] {
 export function sizeSignals(model: Model, sizeType: LayoutSizeType): (NewSignal | InitSignal)[] {
   const channel = sizeType === 'width' ? 'x' : 'y';
   const size = model.component.layoutSize.get(sizeType);
-  if (!size || size === 'merged') {
+  if (size === undefined || size === null || size === 'merged') {
     return [];
   }
 
@@ -92,12 +92,12 @@ export function sizeExpr(scaleName: string, scaleComponent: ScaleComponent, card
   paddingInner =
     type === 'band'
       ? // only band has real paddingInner
-        paddingInner !== undefined
+      paddingInner !== undefined
         ? paddingInner
         : padding
       : // For point, as calculated in https://github.com/vega/vega-scale/blob/master/src/band.js#L128,
-        // it's equivalent to have paddingInner = 1 since there is only n-1 steps between n points.
-        1;
+      // it's equivalent to have paddingInner = 1 since there is only n-1 steps between n points.
+      1;
   return `bandspace(${cardinality}, ${signalOrStringValue(paddingInner)}, ${signalOrStringValue(
     paddingOuter,
   )}) * ${scaleName}_step`;

--- a/src/compile/layoutsize/parse.ts
+++ b/src/compile/layoutsize/parse.ts
@@ -97,7 +97,7 @@ export function parseUnitLayoutSize(model: UnitModel) {
   for (const channel of POSITION_SCALE_CHANNELS) {
     const sizeType = getSizeChannel(channel);
 
-    if (size[sizeType]) {
+    if (size[sizeType] !== undefined) {
       const specifiedSize = size[sizeType];
       component.layoutSize.set(sizeType, isStep(specifiedSize) ? 'step' : specifiedSize, true);
     } else {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -107,10 +107,10 @@ export class UnitModel extends ModelWithField {
       encoding,
       size: isFrameMixins(spec)
         ? {
-            ...parentGivenSize,
-            ...(spec.width ? {width: spec.width} : {}),
-            ...(spec.height ? {height: spec.height} : {}),
-          }
+          ...parentGivenSize,
+          ...(spec.width !== undefined ? {width: spec.width} : {}),
+          ...(spec.height !== undefined ? {height: spec.height} : {}),
+        }
         : parentGivenSize,
     });
 


### PR DESCRIPTION
## PR Description

This PR fixes https://github.com/vega/vega-lite/issues/7798

The problem was that in three places where truthy/falsy checks were being used instead of explicit undefined checks:

### Expected Outcome:

Now when you test in the Vega Editor with height/width: 0, it should respect that setting instead of falling back to the default height of 300.

<details>
  <summary><h2>Checklist</h2></summary>

- [ ] This PR is atomic (i.e., it fixes one issue at a time).
- [ ] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [ ] `npm test` runs successfully
- For new features:
  - [ ] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
