### PR TITLE
docs: fix broken Observable URL in Top-K example

### DIFF
--- a/examples/specs/window_top_k_others.vl.json
+++ b/examples/specs/window_top_k_others.vl.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
-  "description": "Top-K plot with \"others\" by Trevor Manz, adapted from https://observablehq.com/@manzt/top-k-plot-with-others-vega-lite-example.",
+  "description": "Top-K plot with \"others\" by Trevor Manz, adapted from https://observablehq.com/collection/@manzt/vega-vega-lite-examples.",
   "title": "Top Directors by Average Worldwide Gross",
   "data": {"url": "data/movies.json"},
   "mark": "bar",


### PR DESCRIPTION
Fixes broken URL found during vega-datasets link checking (see https://github.com/vega/vega-datasets/pull/724)

The original Observable notebook by @manzt no longer exists at the previous URL. Update to link to his Vega/Vega-Lite examples collection instead, which provides proper attribution without broken links.