### PR TITLE
feat(validate): include field and channel in invalid field type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,6 +1480,7 @@
       "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -2205,6 +2206,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2573,6 +2575,7 @@
       "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -2658,6 +2661,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -2863,6 +2867,7 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -3089,6 +3094,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4918,6 +4924,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5490,6 +5497,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5551,6 +5559,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8299,6 +8308,7 @@
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -8410,6 +8420,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8751,6 +8762,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "21.1.1",
@@ -8802,7 +8814,6 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8898,6 +8909,7 @@
       "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9994,7 +10006,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -10048,6 +10061,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10195,6 +10209,7 @@
       "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
       "integrity": "sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "vega-crossfilter": "~5.1.0",
         "vega-dataflow": "~6.1.0",
@@ -10453,7 +10468,6 @@
       "integrity": "sha512-SgL/s0Ddoq2Do0GFd9pOMtJmWW1YOjht98v/fixnpnWi+7hijWRha1tAziDeQLOBwsv5NmjzrJXpYhedRAbv2A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
@@ -10484,7 +10498,6 @@
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -10499,8 +10512,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/vega-lite/node_modules/string-width": {
       "version": "4.2.3",
@@ -10508,7 +10520,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10524,7 +10535,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10538,7 +10548,6 @@
       "integrity": "sha512-aw6hGpTSiakAe5KqCsnpXNsBgN823IMq84x2Gg1pJj+H6zxlEfN4FCibPAC0PYWOmSvCRUoXMr7b/wWiwsiPIg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.6",
         "vega-util": "^2.0.0"
@@ -10549,8 +10558,7 @@
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
       "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-lite/node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -10558,7 +10566,6 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10577,7 +10584,6 @@
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10830,6 +10836,7 @@
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10960,6 +10967,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -135,9 +135,9 @@ export type ValueDefWithCondition<F extends FieldDef<any> | DatumDef<any>, V ext
    * A field definition or one or more value definition(s) with a parameter predicate.
    */
   condition?:
-    | Conditional<F>
-    | Conditional<ValueDef<V | ExprRef | SignalRef>>
-    | Conditional<ValueDef<V | ExprRef | SignalRef>>[];
+  | Conditional<F>
+  | Conditional<ValueDef<V | ExprRef | SignalRef>>
+  | Conditional<ValueDef<V | ExprRef | SignalRef>>[];
 };
 
 export type StringValueDefWithCondition<F extends Field, T extends Type = StandardType> = ValueDefWithCondition<
@@ -390,8 +390,8 @@ export interface DatumDef<
   F extends Field = string,
   V extends PrimitiveValue | DateTime | ExprRef | SignalRef = PrimitiveValue | DateTime | ExprRef | SignalRef,
 > extends Partial<TypeMixins<Type>>,
-    BandMixins,
-    TitleMixins {
+  BandMixins,
+  TitleMixins {
   /**
    * A constant value in data domain.
    */
@@ -665,7 +665,7 @@ export function isOrderOnlyDef<F extends Field>(
 
 export type OrderValueDef = ConditionValueDefMixins<number> & NumericValueDef;
 
-export interface StringFieldDef<F extends Field> extends FieldDefWithoutScale<F, StandardType>, FormatMixins {}
+export interface StringFieldDef<F extends Field> extends FieldDefWithoutScale<F, StandardType>, FormatMixins { }
 
 export type FieldDef<F extends Field, T extends Type = any> = SecondaryFieldDef<F> | TypedFieldDef<F, T>;
 export type ChannelDef<F extends Field = string> = Encoding<F>[keyof Encoding<F>];
@@ -879,7 +879,16 @@ export function isDiscrete(def: TypedFieldDef<Field> | DatumDef<any, any>) {
     case 'temporal':
       return false;
   }
-  throw new Error(log.message.invalidFieldType(def.type));
+  throw new Error(
+    log.message.invalidFieldType(
+      (def as any)?.type ?? 'undefined',
+      {field: (def as any)?.field, channel: (def as any)?.channel ?? 'unknown'}
+    ) + ' [from channeldef.ts]'
+  );
+
+
+
+
 }
 
 export function isDiscretizing(def: TypedFieldDef<Field> | DatumDef<any, any>) {

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -146,5 +146,23 @@ function defaultType(
   }
 
   /* istanbul ignore next: should never reach this */
-  throw new Error(log.message.invalidFieldType(fieldDef.type));
+
+
+  throw new Error(
+    log.message.invalidFieldType(
+      (def as any)?.type ?? 'undefined',
+      {
+        field: (def as any)?.field ?? '(unknown)',
+        channel: (def as any)?.channel ?? '(unknown)'
+      }
+    )
+  );
+
+
+
+
+
+
+
+
 }

--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -134,8 +134,7 @@ export function selectionAsScaleDomainWrongEncodings(
   field: string,
 ) {
   return (
-    `${
-      !encodings.length ? 'No ' : 'Multiple '
+    `${!encodings.length ? 'No ' : 'Multiple '
     }matching ${stringValue(encoding)} encoding found for selection ${stringValue(extent.param)}. ` +
     `Using "field": ${stringValue(field)}.`
   );
@@ -194,9 +193,24 @@ export function primitiveChannelDef(
   return `Channel ${channel} is a ${type}. Converted to {value: ${stringify(value)}}.`;
 }
 
-export function invalidFieldType(type: Type) {
-  return `Invalid field type "${type}".`;
+export function invalidFieldType(
+  type: unknown,
+  opts?: {field?: string; channel?: string}
+) {
+  const field = opts?.field;
+  const channel = opts?.channel;
+
+  const prefix = `Invalid field type "${String(type)}"`;
+  const context =
+    field || channel
+      ? ` for ${field ? `field "${field}"` : ''}${field && channel ? ' on ' : ''}${channel ? `channel "${channel}"` : ''
+      }.`
+      : '.';
+
+  return prefix + context;
 }
+
+
 
 export function invalidFieldTypeForCountAggregate(type: Type, aggregate: Aggregate | string) {
   return `Invalid field type "${type}" for aggregate: "${aggregate}", using "quantitative" instead.`;
@@ -211,9 +225,8 @@ export function missingFieldType(channel: Channel, newType: Type) {
 }
 export function droppingColor(type: 'encoding' | 'property', opt: {fill?: boolean; stroke?: boolean}) {
   const {fill, stroke} = opt;
-  return `Dropping color ${type} as the plot also has ${
-    fill && stroke ? 'fill and stroke' : fill ? 'fill' : 'stroke'
-  }.`;
+  return `Dropping color ${type} as the plot also has ${fill && stroke ? 'fill and stroke' : fill ? 'fill' : 'stroke'
+    }.`;
 }
 
 export function relativeBandSizeNotSupported(sizeChannel: 'width' | 'height') {
@@ -258,9 +271,8 @@ export function facetChannelDropped(channels: FacetChannel[]) {
 }
 
 export function discreteChannelCannotEncode(channel: Channel, type: Type) {
-  return `Using discrete channel "${channel}" to encode "${type}" field can be misleading as it does not encode ${
-    type === 'ordinal' ? 'order' : 'magnitude'
-  }.`;
+  return `Using discrete channel "${channel}" to encode "${type}" field can be misleading as it does not encode ${type === 'ordinal' ? 'order' : 'magnitude'
+    }.`;
 }
 
 // MARK
@@ -396,9 +408,8 @@ export function droppedDay(d: DateTime | DateTimeExpr) {
 }
 
 export function errorBarCenterAndExtentAreNotNeeded(center: ErrorBarCenter, extent: ErrorBarExtent) {
-  return `${extent ? 'extent ' : ''}${extent && center ? 'and ' : ''}${center ? 'center ' : ''}${
-    extent && center ? 'are ' : 'is '
-  }not needed when data are aggregated.`;
+  return `${extent ? 'extent ' : ''}${extent && center ? 'and ' : ''}${center ? 'center ' : ''}${extent && center ? 'are ' : 'is '
+    }not needed when data are aggregated.`;
 }
 
 export function errorBarCenterIsUsedWithWrongExtent(

--- a/test/error-messages.type.invalid.test.ts
+++ b/test/error-messages.type.invalid.test.ts
@@ -1,0 +1,22 @@
+import {describe, it, expect} from 'vitest';
+import {compile} from '../src/compile/compile';
+
+describe('invalid type error messaging', () => {
+  it('mentions the invalid type, channel, and field', () => {
+    const spec: any = {
+      $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+      data: {values: [{x: 1, y: 2}]},
+      mark: 'point',
+      encoding: {
+        x: {field: 'x', type: 'bool'}, // intentionally invalid
+        y: {field: 'y', type: 'quantitative'}
+      }
+    };
+
+    expect(() => compile(spec))
+      .toThrow(/Invalid (field )?type\s*"(bool|undefined)".*(channel\s*"x".*field\s*"x"|field\s*"x".*channel\s*"x")/i);
+    ;
+
+
+  });
+});


### PR DESCRIPTION
#This PR improves the invalidFieldType error messages by including both the field and channel information in the output.
Adds optional opts parameter ({ field?, channel? }) to log.message.invalidFieldType.
Updates relevant call sites (channeldef.ts, scale/type.ts) to pass this context where available.
Adds unit test test/error-messages.type.invalid.test.ts verifying that invalid type errors mention both the field and channel names.
Example new error message:
Invalid field type "bool" for field "x" on channel "x".