### PR TITLE
fix: exclude `timeUnit` fields from tooltip newline shortcut path

### DIFF
--- a/src/compile/mark/encode/tooltip.ts
+++ b/src/compile/mark/encode/tooltip.ts
@@ -178,6 +178,7 @@ function addLineBreaksToTooltip(
   if (
     isFieldDef(channelDef) &&
     isDiscrete(channelDef.type) &&
+    !channelDef.timeUnit &&
     !getFormatMixins(channelDef).format &&
     !getFormatMixins(channelDef).formatType
   ) {

--- a/test/compile/mark/encode/tooltip.test.ts
+++ b/test/compile/mark/encode/tooltip.test.ts
@@ -219,6 +219,23 @@ describe('compile/mark/encode/tooltip', () => {
       });
     });
 
+    it('generates tooltip via textRef for discrete fields with timeUnit', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {type: 'bar', tooltip: true},
+        encoding: {
+          x: {field: 'date', timeUnit: 'yearmonth', type: 'nominal'},
+          y: {aggregate: 'count', type: 'quantitative'},
+        },
+      });
+      const props = tooltip(model);
+      expect(props.tooltip).toBeDefined();
+      const sig = (props.tooltip as {signal: string}).signal;
+      // Should use the transformed field name (yearmonth_date) via textRef,
+      // not the raw field name (date) from the shortcut path
+      expect(sig).not.toContain('datum["date"]');
+      expect(sig).toContain('yearmonth_date');
+    });
+
     it('generates correct keys and values for channels with title with quotes', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: {type: 'point', tooltip: true},


### PR DESCRIPTION
## PR Description
Fixes a bug where tooltips display "undefined" for discrete fields (nominal/ordinal) that have a `timeUnit` transform (e.g., `yearmonth`).
The `addLineBreaksToTooltip` function introduced in #9678 takes a shortcut that directly accesses `channelDef.field` (the raw field name) for discrete fields without a format. For fields with a `timeUnit`, this produces the wrong field reference — e.g., `datum["date"]` instead of `datum["yearmonth_date"]` — because vega-lite's aggregation transforms rename the field. Since the raw field no longer exists in the aggregated data, the tooltip renders as the string `"undefined"`.
This PR adds a `!channelDef.timeUnit` guard so that fields with a `timeUnit` fall through to `textRef`, which:
1. Uses `vgField()` to resolve the correct transformed field name (e.g., `yearmonth_date`)
2. Routes through `formatSignalRef` → `timeFormatExpression` for proper time formatting (e.g., "Feb 2026" instead of a raw timestamp)
### Trigger conditions (all must be true)
- Field has a `timeUnit` (e.g., `yearmonth`, `month`, `year`)
- Field type is discrete (`:N` nominal or `:O` ordinal)
- No explicit `format` or `formatType` specified
- Tooltip uses `content: "encoding"` or mark-level `tooltip: true`
### Related
- Reported via streamlit/streamlit#14361
- Introduced by #9678 (support newlines in tooltips)
- Not addressed by #9707 (which fixed a different `datum` vs `datum.datum` tooltip issue)

**Checklist**
- [X] This PR is atomic (i.e., it fixes one issue at a time).
- [X] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [X] `npm test` runs successfully