### PR TITLE
docs: fix field name typo for interactive_area_brush example

### DIFF
--- a/site/_data/examples.json
+++ b/site/_data/examples.json
@@ -838,7 +838,7 @@
       {
         "name": "interactive_area_brush",
         "title": "Area Chart with Rectangular Brush",
-        "descripton": "In this example, we apply an `interval` selection to select subset of data in an area chart. The selected data is highlighted in gold by the second layer of an area mark that `filter`s its data by the `brush` selection."
+        "description": "In this example, we apply an `interval` selection to select subset of data in an area chart. The selected data is highlighted in gold by the second layer of an area mark that `filter`s its data by the `brush` selection."
       },
       {
         "name": "interactive_paintbrush",


### PR DESCRIPTION
## PR Description

The `interactive_area_brush` entry in `examples.json` has `"descripton"` (missing an `i`) instead of `"description"`. Because [`create-example-pages`](https://github.com/vega/vega-lite/blob/main/scripts/create-example-pages#L36) checks `example.description`, the misspelled field is silently ignored, and the [gallery page](https://vega.github.io/vega-lite/examples/interactive_area_brush.html) renders with no description text.

The entry has a [description](https://github.com/vega/vega-lite/blob/main/site/_data/examples.json#L841), but it never renders because of the typo:

> In this example, we apply an `interval` selection to select subset of data in an area chart. The selected data is highlighted in gold by the second layer of an area mark that `filter`s its data by the `brush` selection.

The [gallery page](https://vega.github.io/vega-lite/examples/interactive_area_brush.html) currently shows no description text:

<!-- upload docs/ideation/screenshot-area-brush-cropped.png and paste image link here -->

Just for future reference, [`create-example-pages`](https://github.com/vega/vega-lite/blob/main/scripts/create-example-pages#L36-L39) first checks for a `description` field in the example's `examples.json` entry. If none is found, it falls back to the `description` field in the `.vl.json` spec file. In this case, `examples.json` has the description under a misspelled key, and the [spec file](https://github.com/vega/vega-lite/blob/main/examples/specs/interactive_area_brush.vl.json) has no description at all — so neither source provides one.

Found while working on gallery example metadata in vega/vega-datasets#776.

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [ ] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
