### PR TITLE
fix: Ungroup pathmarks when used in offset channels

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -728,7 +728,23 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): stri
       case X2:
       case Y2:
       case XOFFSET:
-      case YOFFSET:
+      case YOFFSET: {
+        if (mark === 'line' || mark === 'area' || mark === 'trail') {
+          const offsetDef = encoding[channel];
+          if (isFieldDef(offsetDef)) {
+            const mainChannel = getMainChannelFromOffsetChannel(channel as typeof XOFFSET | typeof YOFFSET);
+            const mainDef = encoding[mainChannel];
+            if (isFieldDef(mainDef) && !mainDef.aggregate && !offsetDef.aggregate) {
+              const mainField = vgField(mainDef, {});
+              const offsetField = vgField(offsetDef, {});
+              if (mainField && offsetField && mainField !== offsetField) {
+                details.push(mainField);
+              }
+            }
+          }
+        }
+        return details;
+      }
       case THETA:
       case THETA2:
       case RADIUS:

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -727,12 +727,14 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): stri
       case URL:
       case X2:
       case Y2:
+        return details;
+
       case XOFFSET:
       case YOFFSET: {
         if (mark === 'line' || mark === 'area' || mark === 'trail') {
           const offsetDef = encoding[channel];
           if (isFieldDef(offsetDef)) {
-            const mainChannel = getMainChannelFromOffsetChannel(channel as typeof XOFFSET | typeof YOFFSET);
+            const mainChannel = channel === XOFFSET ? X : Y;
             const mainDef = encoding[mainChannel];
             if (isFieldDef(mainDef) && !mainDef.aggregate && !offsetDef.aggregate) {
               const mainField = vgField(mainDef, {});

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -520,6 +520,25 @@ describe('encoding', () => {
     it('should not include fields from tooltip', () => {
       expect(pathGroupingFields('line', {tooltip: {field: 'a', type: 'nominal'}})).toEqual([]);
     });
+
+    it('should group line/area/trail by the main channel when using an offset field', () => {
+      for (const mark of ['line', 'area', 'trail'] as const) {
+        expect(
+          pathGroupingFields(mark, {
+            x: {field: 'a', type: 'nominal'},
+            y: {field: 'c', type: 'nominal'},
+            yOffset: {field: 'b', type: 'quantitative'},
+          }),
+        ).toEqual(['c']);
+        expect(
+          pathGroupingFields(mark, {
+            x: {field: 'a', type: 'nominal'},
+            y: {field: 'c', type: 'nominal'},
+            xOffset: {field: 'b', type: 'quantitative'},
+          }),
+        ).toEqual(['a']);
+      }
+    });
   });
 
   describe('fieldDefs', () => {


### PR DESCRIPTION
## PR Description

Previously, pathmarks like line/trail/area, would be grouped across the y/x encoding rather than creating a separate pathmark per category in the encoding in the main channel (e.g. the y-encoding if yOffset is used).

For example, take the following spec:

```json
{
  "data": {
    "values": [
      {"a": "A", "b": 28, "c": "x", "d": "m"},
      {"a": "B", "b": 55, "c": "x", "d": "m"},
      {"a": "C", "b": 43, "c": "x", "d": "n"},
      {"a": "D", "b": 91, "c": "x", "d": "n"},
      {"a": "A", "b": 88, "c": "y", "d": "m"},
      {"a": "B", "b": 55, "c": "y", "d": "m"},
      {"a": "C", "b": 43, "c": "y", "d": "n"},
      {"a": "D", "b": 55, "c": "y", "d": "n"},


    ]
  },
  "mark": {"type": "trail"},
  "encoding": {
    "x": {"field": "a"},
    "yOffset": {"field": "b", "type": "quantitative"},
    "y": {"field": "c"},
  }
}
```

Before this PR, it would generate a nonsensical chart:
<img width="131" height="97" alt="image" src="https://github.com/user-attachments/assets/f1a526df-9a6c-437e-9057-75984f464875" />

If `"detail": {"field": "c"}` was added to the spec above, it would instead generate this more useful chart with with "spark lines":
<img width="131" height="97" alt="image" src="https://github.com/user-attachments/assets/daac48e8-4b63-40fb-95e0-2b4cedaaf597" />

The drawback with having to use `details` is that it is difficult to discover and that it is not longer possible to group by another field in the `details` encoding. After this PR, the spark lines chart is generated without the need to use details which leaves it open for another grouping.


<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.