### PR TITLE
fix: Ungroup pathmarks in offset channels also for aggregated fields

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -736,7 +736,7 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): stri
           if (isFieldDef(offsetDef)) {
             const mainChannel = channel === XOFFSET ? X : Y;
             const mainDef = encoding[mainChannel];
-            if (isFieldDef(mainDef) && !mainDef.aggregate && !offsetDef.aggregate) {
+            if (isFieldDef(mainDef) && !mainDef.aggregate) {
               const mainField = vgField(mainDef, {});
               const offsetField = vgField(offsetDef, {});
               if (mainField && offsetField && mainField !== offsetField) {

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -233,6 +233,32 @@ describe('compile/compile', () => {
     expect(spec.autosize).toBe('fit');
   });
 
+  it('should auto-group line paths by the base channel when yOffset is aggregated', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {a: 'A', b: 28, c: 'x', d: 'm'},
+          {a: 'B', b: 55, c: 'x', d: 'm'},
+          {a: 'C', b: 43, c: 'x', d: 'n'},
+          {a: 'D', b: 91, c: 'x', d: 'n'},
+          {a: 'A', b: 88, c: 'y', d: 'm'},
+          {a: 'B', b: 55, c: 'y', d: 'm'},
+          {a: 'C', b: 43, c: 'y', d: 'n'},
+          {a: 'D', b: 55, c: 'y', d: 'n'},
+        ],
+      },
+      mark: 'line',
+      encoding: {
+        x: {field: 'a'},
+        y: {field: 'c'},
+        yOffset: {field: 'b', aggregate: 'sum', type: 'quantitative'},
+      },
+    });
+
+    expect(spec.marks[0].type).toBe('group');
+    expect((spec.marks[0] as any).from.facet.groupby).toEqual(['c']);
+  });
+
   it('should use containerSize for width and autosize to fit-x/padding', () => {
     const {spec} = compile({
       width: 'container',

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -539,6 +539,18 @@ describe('encoding', () => {
         ).toEqual(['a']);
       }
     });
+
+    it('should group by the main channel even if the offset field is aggregated', () => {
+      for (const mark of ['line', 'area', 'trail'] as const) {
+        expect(
+          pathGroupingFields(mark, {
+            x: {field: 'a', type: 'nominal'},
+            y: {field: 'c', type: 'nominal'},
+            yOffset: {field: 'b', aggregate: 'sum', type: 'quantitative'},
+          }),
+        ).toEqual(['c']);
+      }
+    });
   });
 
   describe('fieldDefs', () => {


### PR DESCRIPTION
## PR Description

I missed testing with aggregated field properly in #9819, so an aggregation in the offset channel currently connects pathmarks incorrectly:
<img width="131" height="97" alt="image" src="https://github.com/user-attachments/assets/5b50b838-099b-4dea-8fb0-132b2e12dfcf" />


After this PR, pathmarks are correctly ungrouped also for aggregated fields:
<img width="131" height="97" alt="image" src="https://github.com/user-attachments/assets/09c04f95-1150-47d8-ab85-0a5b38269fd8" />



Spec for testing:

```json
{
  "data": {
    "values": [
      {"a": "A", "b": 28, "c": "x", "d": "m"},
      {"a": "B", "b": 55, "c": "x", "d": "m"},
      {"a": "C", "b": 43, "c": "x", "d": "n"},
      {"a": "D", "b": 91, "c": "x", "d": "n"},
      {"a": "A", "b": 88, "c": "y", "d": "m"},
      {"a": "B", "b": 55, "c": "y", "d": "m"},
      {"a": "C", "b": 43, "c": "y", "d": "n"},
      {"a": "D", "b": 55, "c": "y", "d": "n"},

    ]
  },
  "mark": {"type": "line"},
  "encoding": {
    "x": {"field": "a"},
    "yOffset": {"field": "b", "aggregate": "sum", "type": "quantitative"},
    "y": {"field": "c"}
  }
}
```


<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
