### PR TITLE
fix: Ungroup pathmarks when used in offset channels (revert #9819)

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -727,26 +727,8 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): stri
       case URL:
       case X2:
       case Y2:
-        return details;
-
       case XOFFSET:
-      case YOFFSET: {
-        if (mark === 'line' || mark === 'area' || mark === 'trail') {
-          const offsetDef = encoding[channel];
-          if (isFieldDef(offsetDef)) {
-            const mainChannel = channel === XOFFSET ? X : Y;
-            const mainDef = encoding[mainChannel];
-            if (isFieldDef(mainDef) && !mainDef.aggregate && !offsetDef.aggregate) {
-              const mainField = vgField(mainDef, {});
-              const offsetField = vgField(offsetDef, {});
-              if (mainField && offsetField && mainField !== offsetField) {
-                details.push(mainField);
-              }
-            }
-          }
-        }
-        return details;
-      }
+      case YOFFSET:
       case THETA:
       case THETA2:
       case RADIUS:

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -520,25 +520,6 @@ describe('encoding', () => {
     it('should not include fields from tooltip', () => {
       expect(pathGroupingFields('line', {tooltip: {field: 'a', type: 'nominal'}})).toEqual([]);
     });
-
-    it('should group line/area/trail by the main channel when using an offset field', () => {
-      for (const mark of ['line', 'area', 'trail'] as const) {
-        expect(
-          pathGroupingFields(mark, {
-            x: {field: 'a', type: 'nominal'},
-            y: {field: 'c', type: 'nominal'},
-            yOffset: {field: 'b', type: 'quantitative'},
-          }),
-        ).toEqual(['c']);
-        expect(
-          pathGroupingFields(mark, {
-            x: {field: 'a', type: 'nominal'},
-            y: {field: 'c', type: 'nominal'},
-            xOffset: {field: 'b', type: 'quantitative'},
-          }),
-        ).toEqual(['a']);
-      }
-    });
   });
 
   describe('fieldDefs', () => {

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -520,6 +520,25 @@ describe('encoding', () => {
     it('should not include fields from tooltip', () => {
       expect(pathGroupingFields('line', {tooltip: {field: 'a', type: 'nominal'}})).toEqual([]);
     });
+
+    it('should not group line/area/trail by the main channel when using an offset field', () => {
+      for (const mark of ['line', 'area', 'trail'] as const) {
+        expect(
+          pathGroupingFields(mark, {
+            x: {field: 'a', type: 'nominal'},
+            y: {field: 'c', type: 'nominal'},
+            yOffset: {field: 'b', type: 'quantitative'},
+          }),
+        ).not.toEqual(['c']);
+        expect(
+          pathGroupingFields(mark, {
+            x: {field: 'a', type: 'nominal'},
+            y: {field: 'c', type: 'nominal'},
+            xOffset: {field: 'b', type: 'quantitative'},
+          }),
+        ).not.toEqual(['a']);
+      }
+    });
   });
 
   describe('fieldDefs', () => {


### PR DESCRIPTION
See https://github.com/vega/vega-lite/pull/9819#issuecomment-4223518214