### PR TITLE
fix: recalculate labelAlign and labelBaseline after repositioning dual axes

### DIFF
--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -13,7 +13,15 @@ import {UnitModel} from '../unit.js';
 import {AxisComponent, AxisComponentIndex, AxisComponentProps, AXIS_COMPONENT_PROPERTIES} from './component.js';
 import {getAxisConfig, getAxisConfigs} from './config.js';
 import * as encode from './encode.js';
-import {AxisRuleParams, axisRules, defaultOrient, getFieldDefTitle, getLabelAngle} from './properties.js';
+import {
+  AxisRuleParams,
+  axisRules,
+  defaultLabelAlign,
+  defaultLabelBaseline,
+  defaultOrient,
+  getFieldDefTitle,
+  getLabelAngle,
+} from './properties.js';
 import {guideFormat, guideFormatType} from '../format.js';
 
 export function parseUnitAxes(model: UnitModel): AxisComponentIndex {
@@ -81,6 +89,35 @@ export function parseLayerAxes(model: LayerModel) {
             const oppositeOrient = OPPOSITE_ORIENT[orient];
             if (axisCount[orient] > axisCount[oppositeOrient]) {
               axisComponent.set('orient', oppositeOrient, false);
+
+              // Recalculate orient-dependent label properties for the new orient
+              // (https://github.com/vega/vega-lite/issues/3773)
+              let labelAngle: number | SignalRef | undefined;
+              if (child instanceof UnitModel) {
+                const fieldOrDatumDef = getFieldOrDatumDef(child.encoding[channel]) as
+                  | PositionFieldDef<string>
+                  | PositionDatumDef<string>;
+                const axis = child.axis(channel) || {};
+                const scaleType = child.getScaleComponent(channel)?.get('type');
+                if (fieldOrDatumDef && scaleType) {
+                  const axisConfigs = getAxisConfigs(channel, scaleType, orient, child.config);
+                  labelAngle = getLabelAngle(fieldOrDatumDef, axis, channel, child.config.style, axisConfigs);
+                }
+              }
+              if (labelAngle !== undefined) {
+                if (!axisComponent.getWithExplicit('labelAlign').explicit) {
+                  const newAlign = defaultLabelAlign(labelAngle, oppositeOrient, channel);
+                  if (newAlign !== undefined) {
+                    axisComponent.set('labelAlign', newAlign, false);
+                  }
+                }
+                if (!axisComponent.getWithExplicit('labelBaseline').explicit) {
+                  const newBaseline = defaultLabelBaseline(labelAngle, oppositeOrient, channel);
+                  if (newBaseline !== undefined) {
+                    axisComponent.set('labelBaseline', newBaseline, false);
+                  }
+                }
+              }
             }
           }
           axisCount[orient]++;

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -575,5 +575,252 @@ describe('Axis', () => {
       expect(axisComponents.x[0].get('title')).toBe('Hello, World');
       expect(axisComponents.y[0].get('title')).toBeNull();
     });
+
+    it('recalculates labelAlign and labelBaseline when orient is flipped for dual y-axis (issue #3773)', () => {
+      const model = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'a',
+                type: 'quantitative',
+                axis: {labelAngle: 0},
+              },
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'b',
+                type: 'quantitative',
+                axis: {labelAngle: 0},
+              },
+            },
+          },
+        ],
+        resolve: {
+          scale: {y: 'independent'},
+        },
+      });
+      model.parseScale();
+      parseLayerAxes(model);
+      const axisComponents = model.component.axes;
+
+      // The second y-axis should be flipped to orient='right'
+      expect(axisComponents.y).toHaveLength(2);
+      expect(axisComponents.y[0].get('orient')).toBe('left');
+      expect(axisComponents.y[1].get('orient')).toBe('right');
+
+      // At angle=0 for y-axis: left orient → 'right' align, right orient → 'left' align
+      expect(axisComponents.y[0].get('labelAlign')).toBe('right');
+      expect(axisComponents.y[1].get('labelAlign')).toBe('left');
+    });
+
+    it('recalculates labelBaseline when orient is flipped for dual y-axis at angle=60 (issue #3773)', () => {
+      const model = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'a',
+                type: 'quantitative',
+                axis: {labelAngle: 60},
+              },
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'b',
+                type: 'quantitative',
+                axis: {labelAngle: 60},
+              },
+            },
+          },
+        ],
+        resolve: {
+          scale: {y: 'independent'},
+        },
+      });
+      model.parseScale();
+      parseLayerAxes(model);
+      const axisComponents = model.component.axes;
+
+      expect(axisComponents.y[1].get('orient')).toBe('right');
+
+      // At angle=60 for y-axis: left orient → 'top' baseline, right orient → 'bottom' baseline
+      expect(axisComponents.y[0].get('labelBaseline')).toBe('top');
+      expect(axisComponents.y[1].get('labelBaseline')).toBe('bottom');
+    });
+
+    it('does not override explicit labelAlign when orient is flipped (issue #3773)', () => {
+      const model = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'a',
+                type: 'quantitative',
+                axis: {labelAngle: 0},
+              },
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'b',
+                type: 'quantitative',
+                axis: {labelAngle: 0, labelAlign: 'center'},
+              },
+            },
+          },
+        ],
+        resolve: {
+          scale: {y: 'independent'},
+        },
+      });
+      model.parseScale();
+      parseLayerAxes(model);
+      const axisComponents = model.component.axes;
+
+      // Explicit labelAlign should be preserved even after orient flip
+      expect(axisComponents.y[1].get('orient')).toBe('right');
+      expect(axisComponents.y[1].get('labelAlign')).toBe('center');
+    });
+
+    it('does not override explicit labelBaseline when orient is flipped (issue #3773)', () => {
+      const model = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'a',
+                type: 'quantitative',
+                axis: {labelAngle: 60},
+              },
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'b',
+                type: 'quantitative',
+                axis: {labelAngle: 60, labelBaseline: 'middle'},
+              },
+            },
+          },
+        ],
+        resolve: {
+          scale: {y: 'independent'},
+        },
+      });
+      model.parseScale();
+      parseLayerAxes(model);
+      const axisComponents = model.component.axes;
+
+      // Explicit labelBaseline should be preserved even after orient flip
+      expect(axisComponents.y[1].get('orient')).toBe('right');
+      expect(axisComponents.y[1].get('labelBaseline')).toBe('middle');
+    });
+
+    it('recalculates labelAlign when labelAngle comes from config (issue #3773)', () => {
+      const model = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {field: 'a', type: 'quantitative'},
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {field: 'b', type: 'quantitative'},
+            },
+          },
+        ],
+        resolve: {
+          scale: {y: 'independent'},
+        },
+        config: {
+          axisY: {labelAngle: 45},
+        },
+      });
+      model.parseScale();
+      parseLayerAxes(model);
+      const axisComponents = model.component.axes;
+
+      expect(axisComponents.y[0].get('orient')).toBe('left');
+      expect(axisComponents.y[1].get('orient')).toBe('right');
+
+      // labelAngle from config should still trigger recalculation
+      expect(axisComponents.y[0].get('labelAlign')).toBe('right');
+      expect(axisComponents.y[1].get('labelAlign')).toBe('left');
+    });
+
+    it('recalculates labelAlign and labelBaseline when orient is flipped for dual x-axis (issue #3773)', () => {
+      const model = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {
+                field: 'a',
+                type: 'quantitative',
+                axis: {labelAngle: 90},
+              },
+              y: {field: 'date', type: 'temporal'},
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {
+                field: 'b',
+                type: 'quantitative',
+                axis: {labelAngle: 90},
+              },
+              y: {field: 'date', type: 'temporal'},
+            },
+          },
+        ],
+        resolve: {
+          scale: {x: 'independent'},
+        },
+      });
+      model.parseScale();
+      parseLayerAxes(model);
+      const axisComponents = model.component.axes;
+
+      expect(axisComponents.x).toHaveLength(2);
+      expect(axisComponents.x[0].get('orient')).toBe('bottom');
+      expect(axisComponents.x[1].get('orient')).toBe('top');
+
+      // At angle=90 for x-axis: bottom orient → 'left' align, top orient → 'right' align
+      expect(axisComponents.x[0].get('labelAlign')).toBe('left');
+      expect(axisComponents.x[1].get('labelAlign')).toBe('right');
+
+      // At angle=90 for x-axis: bottom orient → 'middle' baseline, top orient → 'middle' baseline
+      expect(axisComponents.x[0].get('labelBaseline')).toBe('middle');
+      expect(axisComponents.x[1].get('labelBaseline')).toBe('middle');
+    });
   });
 });

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -111,4 +111,50 @@ describe('Layer', () => {
       expect(model.component.axes['x'][1].implicit.orient).toBe('top');
     });
   });
+
+  describe('dual y-axis chart with label angle', () => {
+    it('should recalculate labelAlign for the flipped axis (issue #3773)', () => {
+      const dualYModel = parseLayerModel({
+        layer: [
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'temp',
+                type: 'quantitative',
+                axis: {labelAngle: 0},
+              },
+            },
+          },
+          {
+            mark: 'line',
+            encoding: {
+              x: {field: 'date', type: 'temporal'},
+              y: {
+                field: 'precip',
+                type: 'quantitative',
+                axis: {labelAngle: 0},
+              },
+            },
+          },
+        ],
+        resolve: {
+          scale: {y: 'independent'},
+        },
+      });
+      dualYModel.parseScale();
+      dualYModel.parseAxesAndHeaders();
+
+      const yAxes = dualYModel.component.axes['y'];
+      expect(yAxes).toHaveLength(2);
+      expect(yAxes[0].get('orient')).toBe('left');
+      expect(yAxes[1].get('orient')).toBe('right');
+
+      // At angle=0, left axis labels should align right (toward chart),
+      // right axis labels should align left (toward chart)
+      expect(yAxes[0].get('labelAlign')).toBe('right');
+      expect(yAxes[1].get('labelAlign')).toBe('left');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3773

When parseLayerAxes() repositions a second axis to the opposite orient, labelAlign and labelBaseline (already computed for the original orient) were stale. Resolve labelAngle from all sources (axis or config) using getLabelAngle (matching parseAxis), then recompute both properties for the new orient.

Using the example from the reported issue:

**before** (config labelAngle 0)
<img width="382" height="283" alt="image" src="https://github.com/user-attachments/assets/8d200000-8ad4-46ac-9fca-4b15dc336344" />

**after**
<img width="1008" height="329" alt="Screenshot 2026-04-10 at 5 08 08 PM" src="https://github.com/user-attachments/assets/268e2638-f0f5-429b-846e-42b11d49606a" />
<img width="1007" height="332" alt="Screenshot 2026-04-10 at 5 08 40 PM" src="https://github.com/user-attachments/assets/73017bcc-867b-4831-8c6d-ee2fd3557830" />

## PR Description

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
