### PR TITLE
feat: Control grouping of pathmarks via `groupByOffset` option

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -17107,6 +17107,14 @@
           ],
           "description": "The minimum band size for bar and rectangle marks. __Default value:__ `0.25`"
         },
+        "offsetGroup": {
+          "description": "Controls automatic path grouping when `xOffset`/`yOffset` is used with path marks (`line`, `area`, `trail`).\n\n- `\"auto\"` (default) adds grouping by the corresponding base channel (`x` or `y`) to keep paths confined within lanes.\n- `\"none\"` disables this automatic grouping so only explicitly encoded grouping channels (`detail`, `color`, etc.) are used.",
+          "enum": [
+            "auto",
+            "none"
+          ],
+          "type": "string"
+        },
         "opacity": {
           "anyOf": [
             {
@@ -18642,6 +18650,14 @@
               "$ref": "#/definitions/ExprRef"
             }
           ]
+        },
+        "offsetGroup": {
+          "description": "Controls automatic path grouping when `xOffset`/`yOffset` is used with path marks (`line`, `area`, `trail`).\n\n- `\"auto\"` (default) adds grouping by the corresponding base channel (`x` or `y`) to keep paths confined within lanes.\n- `\"none\"` disables this automatic grouping so only explicitly encoded grouping channels (`detail`, `color`, etc.) are used.",
+          "enum": [
+            "auto",
+            "none"
+          ],
+          "type": "string"
         },
         "opacity": {
           "anyOf": [

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -17108,12 +17108,11 @@
           "description": "The minimum band size for bar and rectangle marks. __Default value:__ `0.25`"
         },
         "offsetGroup": {
-          "description": "Controls automatic path grouping when `xOffset`/`yOffset` is used with path marks (`line`, `area`, `trail`).\n\n- `\"auto\"` (default) adds grouping by the corresponding base channel (`x` or `y`) to keep paths confined within lanes.\n- `\"none\"` disables this automatic grouping so only explicitly encoded grouping channels (`detail`, `color`, etc.) are used.",
-          "enum": [
-            "auto",
-            "none"
-          ],
-          "type": "string"
+          "description": "For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).\n\n__Default value:__ `true`",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "opacity": {
           "anyOf": [
@@ -18652,12 +18651,11 @@
           ]
         },
         "offsetGroup": {
-          "description": "Controls automatic path grouping when `xOffset`/`yOffset` is used with path marks (`line`, `area`, `trail`).\n\n- `\"auto\"` (default) adds grouping by the corresponding base channel (`x` or `y`) to keep paths confined within lanes.\n- `\"none\"` disables this automatic grouping so only explicitly encoded grouping channels (`detail`, `color`, etc.) are used.",
-          "enum": [
-            "auto",
-            "none"
-          ],
-          "type": "string"
+          "description": "For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).\n\n__Default value:__ `true`",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "opacity": {
           "anyOf": [

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -16993,6 +16993,13 @@
             }
           ]
         },
+        "groupByOffset": {
+          "description": "For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).\n\n__Default value:__ `true`",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "height": {
           "anyOf": [
             {
@@ -17106,13 +17113,6 @@
             }
           ],
           "description": "The minimum band size for bar and rectangle marks. __Default value:__ `0.25`"
-        },
-        "offsetGroup": {
-          "description": "For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).\n\n__Default value:__ `true`",
-          "type": [
-            "boolean",
-            "null"
-          ]
         },
         "opacity": {
           "anyOf": [
@@ -18561,6 +18561,13 @@
             }
           ]
         },
+        "groupByOffset": {
+          "description": "For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).\n\n__Default value:__ `true`",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "height": {
           "anyOf": [
             {
@@ -18648,13 +18655,6 @@
             {
               "$ref": "#/definitions/ExprRef"
             }
-          ]
-        },
-        "offsetGroup": {
-          "description": "For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).\n\n__Default value:__ `true`",
-          "type": [
-            "boolean",
-            "null"
           ]
         },
         "opacity": {

--- a/src/compile/data/impute.ts
+++ b/src/compile/data/impute.ts
@@ -54,7 +54,7 @@ export class ImputeNode extends DataFlowNode {
       }
       const keyChannel = xDef.impute ? yDef : yDef.impute ? xDef : undefined;
       const {method, value, frame, keyvals} = imputedChannel.impute;
-      const groupbyFields = pathGroupingFields(model.mark, encoding);
+      const groupbyFields = pathGroupingFields(model.mark, encoding, model.markDef.offsetGroup ?? 'auto');
 
       return new ImputeNode(parent, {
         impute: imputedChannel.field,

--- a/src/compile/data/impute.ts
+++ b/src/compile/data/impute.ts
@@ -54,8 +54,8 @@ export class ImputeNode extends DataFlowNode {
       }
       const keyChannel = xDef.impute ? yDef : yDef.impute ? xDef : undefined;
       const {method, value, frame, keyvals} = imputedChannel.impute;
-      const offsetGroup = model.markDef.offsetGroup !== false && model.markDef.offsetGroup !== null;
-      const groupbyFields = pathGroupingFields(model.mark, encoding, offsetGroup);
+      const groupByOffset = model.markDef.groupByOffset !== false && model.markDef.groupByOffset !== null;
+      const groupbyFields = pathGroupingFields(model.mark, encoding, groupByOffset);
 
       return new ImputeNode(parent, {
         impute: imputedChannel.field,

--- a/src/compile/data/impute.ts
+++ b/src/compile/data/impute.ts
@@ -54,7 +54,8 @@ export class ImputeNode extends DataFlowNode {
       }
       const keyChannel = xDef.impute ? yDef : yDef.impute ? xDef : undefined;
       const {method, value, frame, keyvals} = imputedChannel.impute;
-      const groupbyFields = pathGroupingFields(model.mark, encoding, model.markDef.offsetGroup ?? 'auto');
+      const offsetGroup = model.markDef.offsetGroup !== false && model.markDef.offsetGroup !== null;
+      const groupbyFields = pathGroupingFields(model.mark, encoding, offsetGroup);
 
       return new ImputeNode(parent, {
         impute: imputedChannel.field,

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -39,7 +39,7 @@ const markCompiler: Record<Mark, MarkCompiler> = {
 
 export function parseMarkGroups(model: UnitModel): any[] {
   if (contains([LINE, AREA, TRAIL], model.mark)) {
-    const details = pathGroupingFields(model.mark, model.encoding);
+    const details = pathGroupingFields(model.mark, model.encoding, model.markDef.offsetGroup ?? 'auto');
     if (details.length > 0) {
       return getPathGroups(model, details);
     }

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -39,7 +39,8 @@ const markCompiler: Record<Mark, MarkCompiler> = {
 
 export function parseMarkGroups(model: UnitModel): any[] {
   if (contains([LINE, AREA, TRAIL], model.mark)) {
-    const details = pathGroupingFields(model.mark, model.encoding, model.markDef.offsetGroup ?? 'auto');
+    const offsetGroup = model.markDef.offsetGroup !== false && model.markDef.offsetGroup !== null;
+    const details = pathGroupingFields(model.mark, model.encoding, offsetGroup);
     if (details.length > 0) {
       return getPathGroups(model, details);
     }

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -39,8 +39,8 @@ const markCompiler: Record<Mark, MarkCompiler> = {
 
 export function parseMarkGroups(model: UnitModel): any[] {
   if (contains([LINE, AREA, TRAIL], model.mark)) {
-    const offsetGroup = model.markDef.offsetGroup !== false && model.markDef.offsetGroup !== null;
-    const details = pathGroupingFields(model.mark, model.encoding, offsetGroup);
+    const groupByOffset = model.markDef.groupByOffset !== false && model.markDef.groupByOffset !== null;
+    const details = pathGroupingFields(model.mark, model.encoding, groupByOffset);
     if (details.length > 0) {
       return getPathGroups(model, details);
     }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -716,7 +716,11 @@ export function reduce<T, U extends Record<any, any>>(
 /**
  * Returns list of path grouping fields for the given encoding
  */
-export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): string[] {
+export function pathGroupingFields(
+  mark: Mark,
+  encoding: Encoding<string>,
+  offsetGroup: 'auto' | 'none' = 'auto',
+): string[] {
   return keys(encoding).reduce((details, channel) => {
     switch (channel) {
       // x, y, x2, y2, lat, long, lat1, long2, order, tooltip, href, aria label, cursor should not cause lines to group
@@ -732,11 +736,15 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): stri
       case XOFFSET:
       case YOFFSET: {
         if (mark === 'line' || mark === 'area' || mark === 'trail') {
+          if (offsetGroup === 'none') {
+            return details;
+          }
+
           const offsetDef = encoding[channel];
           if (isFieldDef(offsetDef)) {
             const mainChannel = channel === XOFFSET ? X : Y;
             const mainDef = encoding[mainChannel];
-            if (isFieldDef(mainDef) && !mainDef.aggregate && !offsetDef.aggregate) {
+            if (isFieldDef(mainDef) && !mainDef.aggregate) {
               const mainField = vgField(mainDef, {});
               const offsetField = vgField(offsetDef, {});
               if (mainField && offsetField && mainField !== offsetField) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -716,7 +716,7 @@ export function reduce<T, U extends Record<any, any>>(
 /**
  * Returns list of path grouping fields for the given encoding
  */
-export function pathGroupingFields(mark: Mark, encoding: Encoding<string>, offsetGroup = true): string[] {
+export function pathGroupingFields(mark: Mark, encoding: Encoding<string>, groupByOffset = true): string[] {
   return keys(encoding).reduce((details, channel) => {
     switch (channel) {
       // x, y, x2, y2, lat, long, lat1, long2, order, tooltip, href, aria label, cursor should not cause lines to group
@@ -731,7 +731,7 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>, offse
 
       case XOFFSET:
       case YOFFSET: {
-        if (offsetGroup && (mark === 'line' || mark === 'area' || mark === 'trail')) {
+        if (groupByOffset && (mark === 'line' || mark === 'area' || mark === 'trail')) {
           const offsetDef = encoding[channel];
           if (isFieldDef(offsetDef)) {
             const mainChannel = channel === XOFFSET ? X : Y;

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -716,11 +716,7 @@ export function reduce<T, U extends Record<any, any>>(
 /**
  * Returns list of path grouping fields for the given encoding
  */
-export function pathGroupingFields(
-  mark: Mark,
-  encoding: Encoding<string>,
-  offsetGroup: 'auto' | 'none' = 'auto',
-): string[] {
+export function pathGroupingFields(mark: Mark, encoding: Encoding<string>, offsetGroup = true): string[] {
   return keys(encoding).reduce((details, channel) => {
     switch (channel) {
       // x, y, x2, y2, lat, long, lat1, long2, order, tooltip, href, aria label, cursor should not cause lines to group
@@ -735,11 +731,7 @@ export function pathGroupingFields(
 
       case XOFFSET:
       case YOFFSET: {
-        if (mark === 'line' || mark === 'area' || mark === 'trail') {
-          if (offsetGroup === 'none') {
-            return details;
-          }
-
+        if (offsetGroup && (mark === 'line' || mark === 'area' || mark === 'trail')) {
           const offsetDef = encoding[channel];
           if (isFieldDef(offsetDef)) {
             const mainChannel = channel === XOFFSET ? X : Y;

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -581,6 +581,14 @@ export interface MarkDefMixins<ES extends ExprRef | SignalRef> {
   y2Offset?: number | ES;
 
   /**
+   * Controls automatic path grouping when `xOffset`/`yOffset` is used with path marks (`line`, `area`, `trail`).
+   *
+   * - `"auto"` (default) adds grouping by the corresponding base channel (`x` or `y`) to keep paths confined within lanes.
+   * - `"none"` disables this automatic grouping so only explicitly encoded grouping channels (`detail`, `color`, etc.) are used.
+   */
+  offsetGroup?: 'auto' | 'none';
+
+  /**
    * Offset for theta.
    */
   thetaOffset?: number | ES;

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -355,12 +355,7 @@ export const defaultMarkConfig: MarkConfig<SignalRef> = {
 
 // TODO: replace with MarkConfigMixins[Mark] once https://github.com/vega/ts-json-schema-generator/issues/344 is fixed
 export type AnyMarkConfig<ES extends ExprRef | SignalRef> =
-  | MarkConfig<ES>
-  | AreaConfig<ES>
-  | BarConfig<ES>
-  | RectConfig<ES>
-  | LineConfig<ES>
-  | TickConfig<ES>;
+  MarkConfig<ES> | AreaConfig<ES> | BarConfig<ES> | RectConfig<ES> | LineConfig<ES> | TickConfig<ES>;
 
 export interface MarkConfigMixins<ES extends ExprRef | SignalRef> {
   /** Mark Config */
@@ -581,12 +576,11 @@ export interface MarkDefMixins<ES extends ExprRef | SignalRef> {
   y2Offset?: number | ES;
 
   /**
-   * Controls automatic path grouping when `xOffset`/`yOffset` is used with path marks (`line`, `area`, `trail`).
+   * For path marks (`line`, `area`, `trail`) with an `xOffset`/`yOffset` field, whether each path is grouped by the corresponding position channel (`x` or `y`) so it stays within its own offset lane. Set to `false` or `null` to disable this grouping and let paths connect across the position channel, using only explicitly encoded grouping channels (`detail`, `color`, etc.).
    *
-   * - `"auto"` (default) adds grouping by the corresponding base channel (`x` or `y`) to keep paths confined within lanes.
-   * - `"none"` disables this automatic grouping so only explicitly encoded grouping channels (`detail`, `color`, etc.) are used.
+   * __Default value:__ `true`
    */
-  offsetGroup?: 'auto' | 'none';
+  offsetGroup?: boolean | null;
 
   /**
    * Offset for theta.

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -355,7 +355,12 @@ export const defaultMarkConfig: MarkConfig<SignalRef> = {
 
 // TODO: replace with MarkConfigMixins[Mark] once https://github.com/vega/ts-json-schema-generator/issues/344 is fixed
 export type AnyMarkConfig<ES extends ExprRef | SignalRef> =
-  MarkConfig<ES> | AreaConfig<ES> | BarConfig<ES> | RectConfig<ES> | LineConfig<ES> | TickConfig<ES>;
+  | MarkConfig<ES>
+  | AreaConfig<ES>
+  | BarConfig<ES>
+  | RectConfig<ES>
+  | LineConfig<ES>
+  | TickConfig<ES>;
 
 export interface MarkConfigMixins<ES extends ExprRef | SignalRef> {
   /** Mark Config */

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -585,7 +585,7 @@ export interface MarkDefMixins<ES extends ExprRef | SignalRef> {
    *
    * __Default value:__ `true`
    */
-  offsetGroup?: boolean | null;
+  groupByOffset?: boolean | null;
 
   /**
    * Offset for theta.

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -233,6 +233,58 @@ describe('compile/compile', () => {
     expect(spec.autosize).toBe('fit');
   });
 
+  it('should auto-group line paths by the base channel when yOffset is aggregated', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {a: 'A', b: 28, c: 'x', d: 'm'},
+          {a: 'B', b: 55, c: 'x', d: 'm'},
+          {a: 'C', b: 43, c: 'x', d: 'n'},
+          {a: 'D', b: 91, c: 'x', d: 'n'},
+          {a: 'A', b: 88, c: 'y', d: 'm'},
+          {a: 'B', b: 55, c: 'y', d: 'm'},
+          {a: 'C', b: 43, c: 'y', d: 'n'},
+          {a: 'D', b: 55, c: 'y', d: 'n'},
+        ],
+      },
+      mark: 'line',
+      encoding: {
+        x: {field: 'a'},
+        y: {field: 'c'},
+        yOffset: {field: 'b', aggregate: 'sum', type: 'quantitative'},
+      },
+    });
+
+    expect(spec.marks[0].type).toBe('group');
+    expect((spec.marks[0] as any).from.facet.groupby).toEqual(['c']);
+  });
+
+  it('should disable offset auto-grouping for line paths when mark.offsetGroup is none', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {a: 'A', b: 28, c: 'x', d: 'm'},
+          {a: 'B', b: 55, c: 'x', d: 'm'},
+          {a: 'C', b: 43, c: 'x', d: 'n'},
+          {a: 'D', b: 91, c: 'x', d: 'n'},
+          {a: 'A', b: 88, c: 'y', d: 'm'},
+          {a: 'B', b: 55, c: 'y', d: 'm'},
+          {a: 'C', b: 43, c: 'y', d: 'n'},
+          {a: 'D', b: 55, c: 'y', d: 'n'},
+        ],
+      },
+      mark: {type: 'line', offsetGroup: 'none'},
+      encoding: {
+        x: {field: 'a'},
+        y: {field: 'c'},
+        yOffset: {field: 'b', type: 'quantitative'},
+        detail: {field: 'd', type: 'nominal'},
+      },
+    });
+
+    expect(spec.marks[0].type).toBe('group');
+    expect((spec.marks[0] as any).from.facet.groupby).toEqual(['d']);
+  });
   it('should use containerSize for width and autosize to fit-x/padding', () => {
     const {spec} = compile({
       width: 'container',

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -259,8 +259,8 @@ describe('compile/compile', () => {
     expect((spec.marks[0] as any).from.facet.groupby).toEqual(['c']);
   });
 
-  for (const offsetGroup of [false, null] as const) {
-    it(`should disable offset auto-grouping for line paths when mark.offsetGroup is ${offsetGroup}`, () => {
+  for (const groupByOffset of [false, null] as const) {
+    it(`should disable offset auto-grouping for line paths when mark.groupByOffset is ${groupByOffset}`, () => {
       const {spec} = compile({
         data: {
           values: [
@@ -274,7 +274,7 @@ describe('compile/compile', () => {
             {a: 'D', b: 55, c: 'y', d: 'n'},
           ],
         },
-        mark: {type: 'line', offsetGroup},
+        mark: {type: 'line', groupByOffset},
         encoding: {
           x: {field: 'a'},
           y: {field: 'c'},

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -259,32 +259,34 @@ describe('compile/compile', () => {
     expect((spec.marks[0] as any).from.facet.groupby).toEqual(['c']);
   });
 
-  it('should disable offset auto-grouping for line paths when mark.offsetGroup is none', () => {
-    const {spec} = compile({
-      data: {
-        values: [
-          {a: 'A', b: 28, c: 'x', d: 'm'},
-          {a: 'B', b: 55, c: 'x', d: 'm'},
-          {a: 'C', b: 43, c: 'x', d: 'n'},
-          {a: 'D', b: 91, c: 'x', d: 'n'},
-          {a: 'A', b: 88, c: 'y', d: 'm'},
-          {a: 'B', b: 55, c: 'y', d: 'm'},
-          {a: 'C', b: 43, c: 'y', d: 'n'},
-          {a: 'D', b: 55, c: 'y', d: 'n'},
-        ],
-      },
-      mark: {type: 'line', offsetGroup: 'none'},
-      encoding: {
-        x: {field: 'a'},
-        y: {field: 'c'},
-        yOffset: {field: 'b', type: 'quantitative'},
-        detail: {field: 'd', type: 'nominal'},
-      },
-    });
+  for (const offsetGroup of [false, null] as const) {
+    it(`should disable offset auto-grouping for line paths when mark.offsetGroup is ${offsetGroup}`, () => {
+      const {spec} = compile({
+        data: {
+          values: [
+            {a: 'A', b: 28, c: 'x', d: 'm'},
+            {a: 'B', b: 55, c: 'x', d: 'm'},
+            {a: 'C', b: 43, c: 'x', d: 'n'},
+            {a: 'D', b: 91, c: 'x', d: 'n'},
+            {a: 'A', b: 88, c: 'y', d: 'm'},
+            {a: 'B', b: 55, c: 'y', d: 'm'},
+            {a: 'C', b: 43, c: 'y', d: 'n'},
+            {a: 'D', b: 55, c: 'y', d: 'n'},
+          ],
+        },
+        mark: {type: 'line', offsetGroup},
+        encoding: {
+          x: {field: 'a'},
+          y: {field: 'c'},
+          yOffset: {field: 'b', type: 'quantitative'},
+          detail: {field: 'd', type: 'nominal'},
+        },
+      });
 
-    expect(spec.marks[0].type).toBe('group');
-    expect((spec.marks[0] as any).from.facet.groupby).toEqual(['d']);
-  });
+      expect(spec.marks[0].type).toBe('group');
+      expect((spec.marks[0] as any).from.facet.groupby).toEqual(['d']);
+    });
+  }
   it('should use containerSize for width and autosize to fit-x/padding', () => {
     const {spec} = compile({
       width: 'container',

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -539,6 +539,34 @@ describe('encoding', () => {
         ).toEqual(['a']);
       }
     });
+    it('should group by the main channel even if the offset field is aggregated', () => {
+      for (const mark of ['line', 'area', 'trail'] as const) {
+        expect(
+          pathGroupingFields(mark, {
+            x: {field: 'a', type: 'nominal'},
+            y: {field: 'c', type: 'nominal'},
+            yOffset: {field: 'b', aggregate: 'sum', type: 'quantitative'},
+          }),
+        ).toEqual(['c']);
+      }
+    });
+
+    it('should skip automatic main-channel grouping when offsetGroup is none', () => {
+      for (const mark of ['line', 'area', 'trail'] as const) {
+        expect(
+          pathGroupingFields(
+            mark,
+            {
+              x: {field: 'a', type: 'nominal'},
+              y: {field: 'c', type: 'nominal'},
+              yOffset: {field: 'b', type: 'quantitative'},
+              detail: {field: 'd', type: 'nominal'},
+            },
+            'none',
+          ),
+        ).toEqual(['d']);
+      }
+    });
   });
 
   describe('fieldDefs', () => {

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -551,7 +551,7 @@ describe('encoding', () => {
       }
     });
 
-    it('should skip automatic main-channel grouping when offsetGroup is none', () => {
+    it('should skip automatic main-channel grouping when offsetGroup is false', () => {
       for (const mark of ['line', 'area', 'trail'] as const) {
         expect(
           pathGroupingFields(
@@ -562,10 +562,20 @@ describe('encoding', () => {
               yOffset: {field: 'b', type: 'quantitative'},
               detail: {field: 'd', type: 'nominal'},
             },
-            'none',
+            false,
           ),
         ).toEqual(['d']);
       }
+    });
+
+    it('should default to automatic main-channel grouping when offsetGroup is omitted', () => {
+      expect(
+        pathGroupingFields('line', {
+          x: {field: 'a', type: 'nominal'},
+          y: {field: 'c', type: 'nominal'},
+          yOffset: {field: 'b', type: 'quantitative'},
+        }),
+      ).toEqual(['c']);
     });
   });
 

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -551,7 +551,7 @@ describe('encoding', () => {
       }
     });
 
-    it('should skip automatic main-channel grouping when offsetGroup is false', () => {
+    it('should skip automatic main-channel grouping when groupByOffset is false', () => {
       for (const mark of ['line', 'area', 'trail'] as const) {
         expect(
           pathGroupingFields(
@@ -568,7 +568,7 @@ describe('encoding', () => {
       }
     });
 
-    it('should default to automatic main-channel grouping when offsetGroup is omitted', () => {
+    it('should default to automatic main-channel grouping when groupByOffset is omitted', () => {
       expect(
         pathGroupingFields('line', {
           x: {field: 'a', type: 'nominal'},


### PR DESCRIPTION
Details in https://github.com/vega/vega-lite/pull/9822#issuecomment-4229202440

Setting `"offsetGroup": "none"` in the spec now creates the original chart before #9819:

<img width="131" height="97" alt="image" src="https://github.com/user-attachments/assets/118d2b8c-3773-4c7e-b064-7b37af7e1abd" />

```json
{
  "data": {
    "values": [
      {"a": "A", "b": 28, "c": "x", "d": "m"},
      {"a": "B", "b": 55, "c": "x", "d": "m"},
      {"a": "C", "b": 43, "c": "x", "d": "n"},
      {"a": "D", "b": 91, "c": "x", "d": "n"},
      {"a": "A", "b": 88, "c": "y", "d": "m"},
      {"a": "B", "b": 55, "c": "y", "d": "m"},
      {"a": "C", "b": 43, "c": "y", "d": "n"},
      {"a": "D", "b": 55, "c": "y", "d": "n"},


    ]
  },
  "mark": {"type": "line", "offsetGroup": "none"},
  "encoding": {
    "x": {"field": "a"},
    "yOffset": {"field": "b", "type": "quantitative"},
    "y": {"field": "c"},
  }
}
```

We could also add an example in the docs, but just putting this up first to show what the implementation would look like.

If we like this approach, I think we should wait to merge after https://github.com/vega/vega-lite/pull/9821, since this PR also contains that fix for testing purposes (just to have a clearer commit history and not two separate fixes coming from this one PR).

I think there is already some precedence for controlling behavior like this directly in the mark setting vs the encoding, such as the default stacking of some marks but not others (e.g. areas as per https://github.com/vega/vega-lite/pull/9018).

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [x] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
