### PR TITLE
docs: Add button to copy code

### DIFF
--- a/site/static/index.ts
+++ b/site/static/index.ts
@@ -27,6 +27,74 @@ hljs.registerLanguage('html', xml);
 hljs.registerLanguage('css', css);
 hljs.registerLanguage('diff', diff);
 
+const COPY_FEEDBACK_TIMEOUT_MS = 2000;
+
+async function copyText(text: string) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', 'readonly');
+  textArea.style.position = 'fixed';
+  textArea.style.opacity = '0';
+  textArea.style.pointerEvents = 'none';
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textArea);
+
+  if (!copied) {
+    throw new Error('Copy command failed');
+  }
+}
+
+hljs.addPlugin({
+  'after:highlightElement': ({el, text}: {el: HTMLElement; text: string}) => {
+    const pre = el.parentElement;
+
+    if (!pre || pre.tagName !== 'PRE' || pre.querySelector('.code-copy-button')) {
+      return;
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'code-copy-button';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+    button.innerHTML =
+      '<span class="code-copy-label">Copy</span><span class="octicon octicon-clippy code-copy-icon-copy" aria-hidden="true"></span><span class="octicon octicon-check code-copy-icon-check" aria-hidden="true"></span>';
+
+    const label = button.querySelector('.code-copy-label') as HTMLSpanElement;
+    let resetTimeoutId: number | undefined;
+
+    button.addEventListener('click', async () => {
+      try {
+        await copyText(text);
+
+        if (resetTimeoutId !== undefined) {
+          window.clearTimeout(resetTimeoutId);
+        }
+
+        button.setAttribute('data-copied', 'true');
+        label.textContent = 'Copied';
+
+        resetTimeoutId = window.setTimeout(() => {
+          button.removeAttribute('data-copied');
+          label.textContent = 'Copy';
+        }, COPY_FEEDBACK_TIMEOUT_MS);
+      } catch (error) {
+        console.error('Failed to copy code block', error);
+      }
+    });
+
+    pre.classList.add('code-copy-wrapper');
+    pre.appendChild(button);
+  },
+});
+
 // highlight jekyll code blocks
 hljs.highlightAll();
 

--- a/site/static/main.css
+++ b/site/static/main.css
@@ -235,6 +235,67 @@ pre {
   padding: 8px 10px;
 }
 
+pre.code-copy-wrapper {
+  position: relative;
+  padding-right: 72px;
+}
+
+.code-copy-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid #d0d7de;
+  border-radius: 4px;
+  background: #fff;
+  color: #24292f;
+  font-size: 0.75em;
+  line-height: 1;
+  padding: 4px 6px;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+}
+
+pre.code-copy-wrapper:hover .code-copy-button,
+.code-copy-button:focus-visible,
+.code-copy-button[data-copied='true'] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.code-copy-button .code-copy-icon-check {
+  display: none;
+  color: #1a7f37;
+}
+
+.code-copy-button[data-copied='true'] {
+  border-color: #1a7f37;
+  color: #1a7f37;
+}
+
+.code-copy-button[data-copied='true'] .code-copy-icon-copy {
+  display: none;
+}
+
+.code-copy-button[data-copied='true'] .code-copy-icon-check {
+  display: inline-block;
+}
+
+.code-copy-button:focus-visible {
+  outline: 2px solid #0969da;
+  outline-offset: 2px;
+}
+
+@media (hover: none) {
+  .code-copy-button {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .hljs {
   padding: 0;
   background-color: transparent;


### PR DESCRIPTION
## PR Description

Minor QoL improvement that closes #9531. I find it a bit tedious to manually drag with the mouse to highlight text in the docs. This adds a little copy button [similar to what we have in the altair repo](https://altair-viz.github.io/gallery/simple_bar_chart.html).

![recording-2026-04-13_12 29 42-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/cfb6b733-86a2-4a3b-8783-ad31250b8d64)

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [ ] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
