### PR TITLE
feat: Enable animations for lines

### DIFF
--- a/examples/compiled/animated_gapminder.vg.json
+++ b/examples/compiled/animated_gapminder.vg.json
@@ -67,6 +67,7 @@
     {"name": "min_extent", "init": "extent(animation_frame_domain)[0]"},
     {"name": "max_range_extent", "init": "extent(range('time'))[1]"},
     {"name": "anim_value", "update": "invert('time', eased_anim_clock)"},
+    {"name": "animation_frame_value", "update": "anim_value"},
     {
       "name": "animation_frame_tuple",
       "on": [

--- a/examples/compiled/animated_gapminder.vg.json
+++ b/examples/compiled/animated_gapminder.vg.json
@@ -11,12 +11,7 @@
       "name": "source_0",
       "url": "data/gapminder.json",
       "format": {"type": "json"},
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "isValid(datum[\"fertility\"]) && isFinite(+datum[\"fertility\"]) && isValid(datum[\"life_expect\"]) && isFinite(+datum[\"life_expect\"])"
-        }
-      ]
+      "transform": []
     },
     {
       "name": "source_0_curr",
@@ -25,6 +20,10 @@
         {
           "type": "filter",
           "expr": "!length(data(\"animation_frame_store\")) || vlSelectionTest(\"animation_frame_store\", datum)"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"fertility\"]) && isFinite(+datum[\"fertility\"]) && isValid(datum[\"life_expect\"]) && isFinite(+datum[\"life_expect\"])"
         }
       ]
     }
@@ -66,14 +65,19 @@
     {"name": "animation_frame_domain", "init": "domain('time')"},
     {"name": "min_extent", "init": "extent(animation_frame_domain)[0]"},
     {"name": "max_range_extent", "init": "extent(range('time'))[1]"},
-    {"name": "anim_value", "update": "invert('time', eased_anim_clock)"},
-    {"name": "animation_frame_value", "update": "anim_value"},
+    {
+      "name": "animation_frame_value",
+      "update": "invert('time', eased_anim_clock)"
+    },
     {
       "name": "animation_frame_tuple",
       "on": [
         {
-          "events": [{"signal": "eased_anim_clock"}, {"signal": "anim_value"}],
-          "update": "{unit: \"\", fields: animation_frame_tuple_fields, values: [anim_value ? anim_value : min_extent]}",
+          "events": [
+            {"signal": "eased_anim_clock"},
+            {"signal": "animation_frame_value"}
+          ],
+          "update": "{unit: \"\", fields: animation_frame_tuple_fields, values: [animation_frame_value ? animation_frame_value : min_extent]}",
           "force": true
         }
       ]

--- a/examples/compiled/animated_hop.vg.json
+++ b/examples/compiled/animated_hop.vg.json
@@ -67,6 +67,7 @@
     {"name": "min_extent", "init": "extent(animation_frame_domain)[0]"},
     {"name": "max_range_extent", "init": "extent(range('time'))[1]"},
     {"name": "anim_value", "update": "invert('time', eased_anim_clock)"},
+    {"name": "animation_frame_value", "update": "anim_value"},
     {
       "name": "animation_frame_tuple",
       "on": [

--- a/examples/compiled/animated_hop.vg.json
+++ b/examples/compiled/animated_hop.vg.json
@@ -11,12 +11,7 @@
       "name": "source_0",
       "url": "data/seattle-weather.csv",
       "format": {"type": "csv"},
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "isValid(datum[\"precipitation\"]) && isFinite(+datum[\"precipitation\"])"
-        }
-      ]
+      "transform": []
     },
     {
       "name": "source_0_curr",
@@ -25,6 +20,10 @@
         {
           "type": "filter",
           "expr": "!length(data(\"animation_frame_store\")) || vlSelectionTest(\"animation_frame_store\", datum)"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"precipitation\"]) && isFinite(+datum[\"precipitation\"])"
         }
       ]
     }
@@ -66,14 +65,19 @@
     {"name": "animation_frame_domain", "init": "domain('time')"},
     {"name": "min_extent", "init": "extent(animation_frame_domain)[0]"},
     {"name": "max_range_extent", "init": "extent(range('time'))[1]"},
-    {"name": "anim_value", "update": "invert('time', eased_anim_clock)"},
-    {"name": "animation_frame_value", "update": "anim_value"},
+    {
+      "name": "animation_frame_value",
+      "update": "invert('time', eased_anim_clock)"
+    },
     {
       "name": "animation_frame_tuple",
       "on": [
         {
-          "events": [{"signal": "eased_anim_clock"}, {"signal": "anim_value"}],
-          "update": "{unit: \"\", fields: animation_frame_tuple_fields, values: [anim_value ? anim_value : min_extent]}",
+          "events": [
+            {"signal": "eased_anim_clock"},
+            {"signal": "animation_frame_value"}
+          ],
+          "update": "{unit: \"\", fields: animation_frame_tuple_fields, values: [animation_frame_value ? animation_frame_value : min_extent]}",
           "force": true
         }
       ]

--- a/src/compile/data/expressions.ts
+++ b/src/compile/data/expressions.ts
@@ -38,3 +38,41 @@ export function getDependentFields(expression: string) {
 
   return dependents;
 }
+
+export function getDependentSignals(expression: string) {
+  const ast = parseExpression(expression);
+  const dependents = new Set<string>();
+
+  function visit(node: any) {
+    switch (node.type) {
+      case 'Identifier':
+        if (node.name !== 'datum') {
+          dependents.add(node.name);
+        }
+        break;
+      case 'MemberExpression':
+        visit(node.object);
+        if (node.computed) {
+          visit(node.property);
+        }
+        break;
+      case 'CallExpression':
+        node.arguments.forEach(visit);
+        break;
+      case 'Property':
+        visit(node.value);
+        break;
+      default:
+        for (const child of Object.values(node)) {
+          if (Array.isArray(child)) {
+            child.forEach((item) => item?.type && visit(item));
+          } else if ((child as any)?.type) {
+            visit(child);
+          }
+        }
+    }
+  }
+
+  visit(ast);
+  return dependents;
+}

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -155,9 +155,10 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
       const sourceName = model.lookupDataSource(model.getDataName(DataSourceType.Main));
       const sourceData = data.find((d) => d.name === sourceName);
 
-      // find the filter transform for the current selection
-      const sourceDataFilter = sourceData.transform.find(
-        (t) => t.type === 'filter' && t.expr.includes('vlSelectionTest'),
+      // find animation-related filters to be applied on the per-frame dataset
+      const timerValueSignal = `${selCmpt.name}_value`;
+      const sourceDataFilters = sourceData.transform.filter(
+        (t) => t.type === 'filter' && (t.expr.includes('vlSelectionTest') || t.expr.includes(timerValueSignal)),
       );
 
       // create dataset to hold current animation frame
@@ -166,11 +167,11 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
         source: sourceData.name,
       };
 
-      if (sourceDataFilter) {
+      if (sourceDataFilters.length > 0) {
         // remove it from the original dataset
-        sourceData.transform = sourceData.transform.filter((t) => t !== sourceDataFilter);
-        // add the selection filter to the animation dataset
-        currentFrame.transform = [sourceDataFilter];
+        sourceData.transform = sourceData.transform.filter((t) => !sourceDataFilters.includes(t));
+        // add the animation filters to the animation dataset
+        currentFrame.transform = sourceDataFilters;
       }
 
       animationData.push(currentFrame);

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -160,19 +160,20 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
         (t) => t.type === 'filter' && t.expr.includes('vlSelectionTest'),
       );
 
+      // create dataset to hold current animation frame
+      const currentFrame: VgData = {
+        name: sourceData.name + CURR,
+        source: sourceData.name,
+      };
+
       if (sourceDataFilter) {
         // remove it from the original dataset
         sourceData.transform = sourceData.transform.filter((t) => t !== sourceDataFilter);
-
-        // create dataset to hold current animation frame
-        const currentFrame: VgData = {
-          name: sourceData.name + CURR,
-          source: sourceData.name,
-          transform: [sourceDataFilter], // add the selection filter to the animation dataset
-        };
-
-        animationData.push(currentFrame);
+        // add the selection filter to the animation dataset
+        currentFrame.transform = [sourceDataFilter];
       }
+
+      animationData.push(currentFrame);
     }
   }
 

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -16,6 +16,7 @@ import {parseSelectionExtent} from './parse.js';
 import {SelectionProjection} from './project.js';
 import {CURR} from './point.js';
 import {DataSourceType} from '../../data.js';
+import {getDependentSignals} from '../data/expressions.js';
 
 export function assembleProjection(proj: SelectionProjection) {
   const {signals, hasLegend, index, ...rest} = proj;
@@ -157,8 +158,11 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
 
       // find animation-related filters to be applied on the per-frame dataset
       const timerValueSignal = `${selCmpt.name}_value`;
+      const timerStore = `data(${stringValue(selCmpt.name + STORE)})`;
       const animationStart = (sourceData.transform ?? []).findIndex(
-        (t) => t.type === 'filter' && (t.expr.includes('vlSelectionTest') || t.expr.includes(timerValueSignal)),
+        (t) =>
+          t.type === 'filter' &&
+          (t.expr.includes(timerStore) || getDependentSignals(t.expr).has(timerValueSignal)),
       );
 
       // create dataset to hold current animation frame

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -161,8 +161,7 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
       const timerStore = `data(${stringValue(selCmpt.name + STORE)})`;
       const animationStart = (sourceData.transform ?? []).findIndex(
         (t) =>
-          t.type === 'filter' &&
-          (t.expr.includes(timerStore) || getDependentSignals(t.expr).has(timerValueSignal)),
+          t.type === 'filter' && (t.expr.includes(timerStore) || getDependentSignals(t.expr).has(timerValueSignal)),
       );
 
       // create dataset to hold current animation frame

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -157,7 +157,7 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
 
       // find animation-related filters to be applied on the per-frame dataset
       const timerValueSignal = `${selCmpt.name}_value`;
-      const sourceDataFilters = sourceData.transform.filter(
+      const sourceDataFilters = (sourceData.transform ?? []).filter(
         (t) => t.type === 'filter' && (t.expr.includes('vlSelectionTest') || t.expr.includes(timerValueSignal)),
       );
 

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -157,7 +157,7 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
 
       // find animation-related filters to be applied on the per-frame dataset
       const timerValueSignal = `${selCmpt.name}_value`;
-      const sourceDataFilters = (sourceData.transform ?? []).filter(
+      const animationStart = (sourceData.transform ?? []).findIndex(
         (t) => t.type === 'filter' && (t.expr.includes('vlSelectionTest') || t.expr.includes(timerValueSignal)),
       );
 
@@ -167,11 +167,9 @@ export function assembleUnitSelectionData(model: UnitModel, data: readonly VgDat
         source: sourceData.name,
       };
 
-      if (sourceDataFilters.length > 0) {
-        // remove it from the original dataset
-        sourceData.transform = sourceData.transform.filter((t) => !sourceDataFilters.includes(t));
-        // add the animation filters to the animation dataset
-        currentFrame.transform = sourceDataFilters;
+      if (animationStart >= 0) {
+        // Preserve transform ordering by moving the animation filter and everything downstream of it.
+        currentFrame.transform = sourceData.transform.splice(animationStart);
       }
 
       animationData.push(currentFrame);

--- a/src/compile/selection/point.ts
+++ b/src/compile/selection/point.ts
@@ -34,6 +34,7 @@ const animationSignals = (selectionName: string, scaleName: string): Signal[] =>
     {name: MAX_RANGE_EXTENT, init: `extent(range('${scaleName}'))[1]`},
     // {name: 't_index', update: `indexof(${selectionName}_domain, anim_value)`},
     {name: ANIM_VALUE, update: `invert('${scaleName}', ${EASED_ANIM_CLOCK})`},
+    {name: `${selectionName}_value`, update: ANIM_VALUE},
   ];
 };
 

--- a/src/compile/selection/point.ts
+++ b/src/compile/selection/point.ts
@@ -8,7 +8,6 @@ import {TUPLE_FIELDS} from './project.js';
 import {TIME} from '../../channel.js';
 
 export const CURR = '_curr';
-export const ANIM_VALUE = 'anim_value';
 export const ANIM_CLOCK = 'anim_clock';
 export const EASED_ANIM_CLOCK = 'eased_anim_clock';
 export const MIN_EXTENT = 'min_extent';
@@ -18,6 +17,7 @@ export const IS_PLAYING = 'is_playing';
 export const THROTTLE = (1 / 60) * 1000; // 60 FPS
 
 const animationSignals = (selectionName: string, scaleName: string): Signal[] => {
+  const animationValue = `${selectionName}_value`;
   return [
     // timer signals
     {
@@ -32,9 +32,8 @@ const animationSignals = (selectionName: string, scaleName: string): Signal[] =>
     {name: MIN_EXTENT, init: `extent(${selectionName}_domain)[0]`},
     // {name: 'max_extent', init: `extent(${selectionName}_domain)[1]`},
     {name: MAX_RANGE_EXTENT, init: `extent(range('${scaleName}'))[1]`},
-    // {name: 't_index', update: `indexof(${selectionName}_domain, anim_value)`},
-    {name: ANIM_VALUE, update: `invert('${scaleName}', ${EASED_ANIM_CLOCK})`},
-    {name: `${selectionName}_value`, update: ANIM_VALUE},
+    // {name: 't_index', update: `indexof(${selectionName}_domain, ${animationValue})`},
+    {name: animationValue, update: `invert('${scaleName}', ${EASED_ANIM_CLOCK})`},
   ];
 };
 
@@ -72,6 +71,7 @@ const point: SelectionCompiler<'point'> = {
   signals: (model, selCmpt, signals) => {
     const name = selCmpt.name;
     const fieldsSg = name + TUPLE_FIELDS;
+    const animationValue = `${name}_value`;
     const project = selCmpt.project;
     const datum = '(item().isVoronoi ? datum.datum : datum)';
 
@@ -98,7 +98,7 @@ const point: SelectionCompiler<'point'> = {
     if (selCmpt.project.hasSelectionId) {
       update += `${SELECTION_ID}: ${datum}[${stringValue(SELECTION_ID)}]`;
     } else if (isTimerSelection(selCmpt)) {
-      update += `fields: ${fieldsSg}, values: [${ANIM_VALUE} ? ${ANIM_VALUE} : ${MIN_EXTENT}]`;
+      update += `fields: ${fieldsSg}, values: [${animationValue} ? ${animationValue} : ${MIN_EXTENT}]`;
     } else {
       const values = project.items
         .map((p) => {
@@ -121,7 +121,7 @@ const point: SelectionCompiler<'point'> = {
           name: name + TUPLE,
           on: [
             {
-              events: [{signal: EASED_ANIM_CLOCK}, {signal: ANIM_VALUE}],
+              events: [{signal: EASED_ANIM_CLOCK}, {signal: animationValue}],
               update: `{${update}}`,
               force: true,
             },

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -58,6 +58,7 @@ import {
   assembleUnitSelectionMarks,
   assembleUnitSelectionSignals,
 } from './selection/assemble.js';
+import {isTimerSelection} from './selection/index.js';
 import {parseUnitSelection} from './selection/parse.js';
 import {CURR} from './selection/point.js';
 
@@ -303,10 +304,14 @@ export class UnitModel extends ModelWithField {
    * Corrects the data references in marks after assemble.
    */
   public correctDataNames = (mark: VgMarkGroup) => {
+    const hasTimerAnimation = keys(this.component.selection ?? {}).some((name) =>
+      isTimerSelection(this.component.selection[name]),
+    );
+
     // for normal data references
     if (mark.from?.data) {
       mark.from.data = this.lookupDataSource(mark.from.data);
-      if ('time' in this.encoding) {
+      if (hasTimerAnimation && 'time' in this.encoding) {
         mark.from.data = mark.from.data + CURR;
       }
     }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -319,10 +319,9 @@ export class UnitModel extends ModelWithField {
     // for access to facet data
     if (mark.from?.facet?.data) {
       mark.from.facet.data = this.lookupDataSource(mark.from.facet.data);
-      // TOOD(jzong) uncomment this when it's time to implement facet animation
-      // if ('time' in this.encoding) {
-      //   mark.from.facet.data = mark.from.facet.data + CURR;
-      // }
+      if (hasTimerAnimation && 'time' in this.encoding) {
+        mark.from.facet.data = mark.from.facet.data + CURR;
+      }
     }
 
     return mark;

--- a/test/compile/data/expressions.test.ts
+++ b/test/compile/data/expressions.test.ts
@@ -1,4 +1,4 @@
-import {getDependentFields} from '../../../src/compile/data/expressions.js';
+import {getDependentFields, getDependentSignals} from '../../../src/compile/data/expressions.js';
 
 describe('compile/data/expressions', () => {
   describe('getDependentFields', () => {
@@ -13,6 +13,15 @@ describe('compile/data/expressions', () => {
     it('calculates right dependent fields for nested field', () => {
       expect(getDependentFields('datum.x.y')).toEqual(new Set(['x', 'x.y']));
       expect(getDependentFields('datum["x.y"]')).toEqual(new Set(['x.y']));
+    });
+  });
+
+  describe('getDependentSignals', () => {
+    it('distinguishes signal references from datum fields and function names', () => {
+      expect(getDependentSignals('max(frame_value, datum.frame_value, datum[field_name])')).toEqual(
+        new Set(['frame_value', 'field_name']),
+      );
+      expect(getDependentSignals('datum["frame_value"]')).toEqual(new Set());
     });
   });
 });

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -564,6 +564,58 @@ describe('Animated Selection', () => {
     expect(marks[0].from.data).toBe('source_0_curr');
   });
 
+  it('assigns correct animation frame dataset to faceted path groups', () => {
+    const groupedLineModel = parseUnitModelWithScaleAndSelection({
+      data: {
+        values: [
+          {z: 'a', x: 0, y: 0},
+          {z: 'a', x: 1, y: 0.2},
+          {z: 'a', x: 2, y: 0.39},
+          {z: 'b', x: 2, y: 1.0},
+          {z: 'b', x: 1, y: 0.8},
+          {z: 'b', x: 0, y: 0.6},
+        ],
+      },
+      params: [
+        {
+          name: 'avl',
+          select: {
+            type: 'point',
+            fields: ['x'],
+            on: 'timer',
+          },
+        },
+      ],
+      transform: [{filter: 'datum.x <= avl_value'}],
+      mark: 'line',
+      encoding: {
+        x: {
+          field: 'x',
+          type: 'quantitative',
+        },
+        y: {
+          field: 'y',
+          type: 'quantitative',
+        },
+        color: {
+          field: 'z',
+          type: 'nominal',
+        },
+        time: {
+          field: 'x',
+          type: 'ordinal',
+        },
+      },
+    });
+
+    groupedLineModel.parseData();
+    optimizeDataflow(groupedLineModel.component.data, groupedLineModel);
+    groupedLineModel.parseMarkGroup();
+
+    const marks = groupedLineModel.assembleMarks();
+    expect(marks[0].from.facet.data).toMatch(/_curr$/);
+  });
+
   it(
     'does not build extra signals for duplicate selection',
     log.wrap((localLogger) => {

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -450,6 +450,7 @@ describe('Animated Selection', () => {
         {name: 'max_range_extent', init: "extent(range('time'))[1]"},
         // {name: 't_index', update: 'indexof(avl_domain, anim_value)'},
         {name: 'anim_value', update: "invert('time', eased_anim_clock)"},
+        {name: 'avl_value', update: 'anim_value'},
       ]),
     );
   });
@@ -502,6 +503,58 @@ describe('Animated Selection', () => {
           ],
         },
       ]),
+    );
+  });
+
+  it('moves timer value filters onto animation frame dataset', () => {
+    const valueFilterModel = parseUnitModelWithScaleAndSelection({
+      data: {
+        url: 'data/gapminder.json',
+      },
+      params: [
+        {
+          name: 'avl',
+          select: {
+            type: 'point',
+            fields: ['year'],
+            on: 'timer',
+          },
+        },
+      ],
+      transform: [
+        {
+          filter: 'datum.year <= avl_value',
+        },
+      ],
+      mark: 'point',
+      encoding: {
+        x: {
+          field: 'fertility',
+          type: 'quantitative',
+        },
+        y: {
+          field: 'life_expect',
+          type: 'quantitative',
+        },
+        time: {
+          field: 'year',
+          type: 'ordinal',
+        },
+      },
+    });
+
+    valueFilterModel.parseData();
+    optimizeDataflow(valueFilterModel.component.data, valueFilterModel);
+
+    const datasets = assembleUnitSelectionData(valueFilterModel, assembleRootData(valueFilterModel.component.data, {}));
+    const source = datasets.find((d) => d.name === 'source_0');
+    const currentFrame = datasets.find((d) => d.name === 'source_0_curr');
+
+    expect(source.transform).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({expr: 'datum.year <= avl_value'})]),
+    );
+    expect(currentFrame.transform).toEqual(
+      expect.arrayContaining([expect.objectContaining({expr: 'datum.year <= avl_value'})]),
     );
   });
 
@@ -576,6 +629,7 @@ describe('Animated Selection', () => {
           {name: 'max_range_extent', init: "extent(range('time'))[1]"},
           // {name: 't_index', update: 'indexof(avl_domain, anim_value)'},
           {name: 'anim_value', update: "invert('time', eased_anim_clock)"},
+          {name: 'avl_value', update: 'anim_value'},
         ]),
       );
       expect(localLogger.warns).toHaveLength(1);

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -531,9 +531,9 @@ describe('Animated Selection', () => {
     untransformedModel.parseData();
     optimizeDataflow(untransformedModel.component.data, untransformedModel);
 
-    expect(assembleUnitSelectionData(untransformedModel, assembleRootData(untransformedModel.component.data, {}))).toEqual(
-      expect.arrayContaining([{name: 'source_0_curr', source: 'source_0'}]),
-    );
+    expect(
+      assembleUnitSelectionData(untransformedModel, assembleRootData(untransformedModel.component.data, {})),
+    ).toEqual(expect.arrayContaining([{name: 'source_0_curr', source: 'source_0'}]));
   });
 
   it('moves timer value filters onto animation frame dataset', () => {
@@ -597,10 +597,7 @@ describe('Animated Selection', () => {
         ],
       },
       params: [{name: 'avl', select: {type: 'point', fields: ['year'], on: 'timer'}}],
-      transform: [
-        {filter: 'datum.year <= avl_value'},
-        {joinaggregate: [{op: 'sum', field: 'value', as: 'total'}]},
-      ],
+      transform: [{filter: 'datum.year <= avl_value'}, {joinaggregate: [{op: 'sum', field: 'value', as: 'total'}]}],
       mark: 'line',
       encoding: {
         x: {field: 'year', type: 'ordinal'},
@@ -669,9 +666,7 @@ describe('Animated Selection', () => {
     const currentFrame = datasets.find((d) => d.name.endsWith('_curr'));
     const source = datasets.find((d) => d.name === currentFrame.source);
 
-    expect(source.transform).toEqual([
-      expect.objectContaining({expr: expect.stringContaining('data("pick_store")')}),
-    ]);
+    expect(source.transform).toEqual([expect.objectContaining({expr: expect.stringContaining('data("pick_store")')})]);
     expect(currentFrame.transform[0]).toEqual(expect.objectContaining({expr: 'datum.year <= avl_value'}));
   });
 

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -506,6 +506,25 @@ describe('Animated Selection', () => {
     );
   });
 
+  it('builds animation frame datasets when the source has no transforms', () => {
+    const untransformedModel = parseUnitModelWithScaleAndSelection({
+      data: {values: [{category: 'a', frame: 'first'}]},
+      params: [{name: 'avl', select: {type: 'point', fields: ['frame'], on: 'timer'}}],
+      mark: 'point',
+      encoding: {
+        x: {field: 'category', type: 'nominal'},
+        time: {field: 'frame', type: 'ordinal'},
+      },
+    });
+
+    untransformedModel.parseData();
+    optimizeDataflow(untransformedModel.component.data, untransformedModel);
+
+    expect(assembleUnitSelectionData(untransformedModel, assembleRootData(untransformedModel.component.data, {}))).toEqual(
+      expect.arrayContaining([{name: 'source_0_curr', source: 'source_0'}]),
+    );
+  });
+
   it('moves timer value filters onto animation frame dataset', () => {
     const valueFilterModel = parseUnitModelWithScaleAndSelection({
       data: {

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -506,20 +506,15 @@ describe('Animated Selection', () => {
   });
 
   it('builds animation frame datasets', () => {
-    expect(assembleUnitSelectionData(model, assembleRootData(model.component.data, {}))).toEqual(
-      expect.arrayContaining([
-        {
-          name: 'source_0_curr',
-          source: 'source_0',
-          transform: [
-            {
-              type: 'filter',
-              expr: '!length(data("avl_store")) || vlSelectionTest("avl_store", datum)',
-            },
-          ],
-        },
-      ]),
+    const currentFrame = assembleUnitSelectionData(model, assembleRootData(model.component.data, {})).find(
+      (data) => data.name === 'source_0_curr',
     );
+
+    expect(currentFrame).toEqual(expect.objectContaining({name: 'source_0_curr', source: 'source_0'}));
+    expect(currentFrame.transform[0]).toEqual({
+      type: 'filter',
+      expr: '!length(data("avl_store")) || vlSelectionTest("avl_store", datum)',
+    });
   });
 
   it('builds animation frame datasets when the source has no transforms', () => {
@@ -591,6 +586,39 @@ describe('Animated Selection', () => {
     expect(currentFrame.transform).toEqual(
       expect.arrayContaining([expect.objectContaining({expr: 'datum.year <= avl_value'})]),
     );
+  });
+
+  it('preserves transforms downstream of timer value filters', () => {
+    const aggregateModel = parseUnitModelWithScaleAndSelection({
+      data: {
+        values: [
+          {year: 2000, value: 1},
+          {year: 2001, value: 2},
+        ],
+      },
+      params: [{name: 'avl', select: {type: 'point', fields: ['year'], on: 'timer'}}],
+      transform: [
+        {filter: 'datum.year <= avl_value'},
+        {joinaggregate: [{op: 'sum', field: 'value', as: 'total'}]},
+      ],
+      mark: 'line',
+      encoding: {
+        x: {field: 'year', type: 'ordinal'},
+        y: {field: 'total', type: 'quantitative'},
+        time: {field: 'year', type: 'ordinal'},
+      },
+    });
+
+    aggregateModel.parseData();
+    optimizeDataflow(aggregateModel.component.data, aggregateModel);
+
+    const datasets = assembleUnitSelectionData(aggregateModel, assembleRootData(aggregateModel.component.data, {}));
+    const currentFrame = datasets.find((d) => d.name.endsWith('_curr'));
+    const source = datasets.find((d) => d.name === currentFrame.source);
+
+    expect(source.transform).toEqual([]);
+    expect(currentFrame.transform.map((transform) => transform.type)).toEqual(['filter', 'joinaggregate']);
+    expect(currentFrame.transform[0]).toEqual(expect.objectContaining({expr: 'datum.year <= avl_value'}));
   });
 
   it('assigns correct animation frame dataset to marks', () => {

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -405,8 +405,8 @@ describe('Animated Selection', () => {
           name: 'avl_tuple',
           on: [
             {
-              events: [{signal: 'eased_anim_clock'}, {signal: 'anim_value'}],
-              update: '{unit: "", fields: avl_tuple_fields, values: [anim_value ? anim_value : min_extent]}',
+              events: [{signal: 'eased_anim_clock'}, {signal: 'avl_value'}],
+              update: '{unit: "", fields: avl_tuple_fields, values: [avl_value ? avl_value : min_extent]}',
               force: true,
             },
           ],
@@ -448,9 +448,8 @@ describe('Animated Selection', () => {
         {name: 'min_extent', init: 'extent(avl_domain)[0]'},
         // {name: 'max_extent', init: 'extent(avl_domain)[1]'},
         {name: 'max_range_extent', init: "extent(range('time'))[1]"},
-        // {name: 't_index', update: 'indexof(avl_domain, anim_value)'},
-        {name: 'anim_value', update: "invert('time', eased_anim_clock)"},
-        {name: 'avl_value', update: 'anim_value'},
+        // {name: 't_index', update: 'indexof(avl_domain, avl_value)'},
+        {name: 'avl_value', update: "invert('time', eased_anim_clock)"},
       ]),
     );
   });
@@ -470,6 +469,23 @@ describe('Animated Selection', () => {
         },
       ]),
     );
+  });
+
+  it('does not duplicate the value signal for a selection named anim', () => {
+    const animModel = parseUnitModelWithScaleAndSelection({
+      data: {values: [{year: 2000}]},
+      params: [{name: 'anim', select: {type: 'point', fields: ['year'], on: 'timer'}}],
+      mark: 'point',
+      encoding: {
+        x: {field: 'year', type: 'quantitative'},
+        time: {field: 'year', type: 'quantitative'},
+      },
+    });
+
+    const signals = assembleUnitSelectionSignals(animModel, []);
+    expect(signals.filter((signal) => signal.name === 'anim_value')).toEqual([
+      {name: 'anim_value', update: "invert('time', eased_anim_clock)"},
+    ]);
   });
 
   it('builds top-level signals', () => {
@@ -698,9 +714,8 @@ describe('Animated Selection', () => {
           {name: 'min_extent', init: 'extent(avl_domain)[0]'},
           // {name: 'max_extent', init: 'extent(avl_domain)[1]'},
           {name: 'max_range_extent', init: "extent(range('time'))[1]"},
-          // {name: 't_index', update: 'indexof(avl_domain, anim_value)'},
-          {name: 'anim_value', update: "invert('time', eased_anim_clock)"},
-          {name: 'avl_value', update: 'anim_value'},
+          // {name: 't_index', update: 'indexof(avl_domain, avl_value)'},
+          {name: 'avl_value', update: "invert('time', eased_anim_clock)"},
         ]),
       );
       expect(localLogger.warns).toHaveLength(1);

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -788,7 +788,7 @@ describe('Animated Selection', () => {
       modelDuplicateSelection.parseData();
       optimizeDataflow(modelDuplicateSelection.component.data, modelDuplicateSelection);
 
-      const signals = assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(modelDuplicateSelection, []);
       // TODO(jzong): uncomment commented signals when implementing interpolation
       expect(signals).toEqual(
         expect.arrayContaining([
@@ -800,6 +800,8 @@ describe('Animated Selection', () => {
           {name: 'avl_value', update: "invert('time', eased_anim_clock)"},
         ]),
       );
+      expect(signals.filter((signal) => signal.name === 'avl_value')).toHaveLength(1);
+      expect(signals.some((signal) => signal.name === 'avl_2_value')).toBe(false);
       expect(localLogger.warns).toHaveLength(1);
     }),
   );

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -621,6 +621,60 @@ describe('Animated Selection', () => {
     expect(currentFrame.transform[0]).toEqual(expect.objectContaining({expr: 'datum.year <= avl_value'}));
   });
 
+  it('does not treat a datum field as the timer value signal', () => {
+    const fieldFilterModel = parseUnitModelWithScaleAndSelection({
+      data: {values: [{year: 2000, avl_value: 1}]},
+      params: [{name: 'avl', select: {type: 'point', fields: ['year'], on: 'timer'}}],
+      transform: [{filter: 'datum.avl_value > 0'}],
+      mark: 'point',
+      encoding: {
+        x: {field: 'year', type: 'ordinal'},
+        time: {field: 'year', type: 'ordinal'},
+      },
+    });
+
+    fieldFilterModel.parseData();
+    optimizeDataflow(fieldFilterModel.component.data, fieldFilterModel);
+
+    const datasets = assembleUnitSelectionData(fieldFilterModel, assembleRootData(fieldFilterModel.component.data, {}));
+    const currentFrame = datasets.find((d) => d.name.endsWith('_curr'));
+    const source = datasets.find((d) => d.name === currentFrame.source);
+
+    expect(source.transform).toEqual([expect.objectContaining({expr: 'datum.avl_value > 0'})]);
+    expect(currentFrame.transform).toBeUndefined();
+  });
+
+  it('keeps unrelated selection filters upstream of the animation frame', () => {
+    const multipleSelectionModel = parseUnitModelWithScaleAndSelection({
+      data: {values: [{year: 2000, category: 'a'}]},
+      params: [
+        {name: 'avl', select: {type: 'point', fields: ['year'], on: 'timer'}},
+        {name: 'pick', select: {type: 'point', fields: ['category']}},
+      ],
+      transform: [{filter: {param: 'pick'}}, {filter: 'datum.year <= avl_value'}],
+      mark: 'point',
+      encoding: {
+        x: {field: 'category', type: 'nominal'},
+        time: {field: 'year', type: 'ordinal'},
+      },
+    });
+
+    multipleSelectionModel.parseData();
+    optimizeDataflow(multipleSelectionModel.component.data, multipleSelectionModel);
+
+    const datasets = assembleUnitSelectionData(
+      multipleSelectionModel,
+      assembleRootData(multipleSelectionModel.component.data, {}),
+    );
+    const currentFrame = datasets.find((d) => d.name.endsWith('_curr'));
+    const source = datasets.find((d) => d.name === currentFrame.source);
+
+    expect(source.transform).toEqual([
+      expect.objectContaining({expr: expect.stringContaining('data("pick_store")')}),
+    ]);
+    expect(currentFrame.transform[0]).toEqual(expect.objectContaining({expr: 'datum.year <= avl_value'}));
+  });
+
   it('assigns correct animation frame dataset to marks', () => {
     model.parseMarkGroup();
     const marks = model.assembleMarks();


### PR DESCRIPTION
While I was testing out the new animations features, I noticed that pathmarks such as lines and areas are currently not working with the new `time` encoding, something I saw the @mattijn also reported in https://github.com/vega/vega-lite/pull/9535#issuecomment-2927816763. 

I made the references to the `curr` data sets more robust so that time-encoded marks never reference a missing data source when filters are expression-based. It also seems like we needed to expose a signal to make comparisons other than the default param lookup/equality, e.g <, >, so that the lines can be built up cumulatively instead of just showing a single fragment in each time step. I'm still not happy with the special naming here, but it's a bit clearer than the previous internal `anim_value` that also caused a cyclic data flow, but I will try to follow up with a PR that improves this.

As part of this change I also enabled animation for facet-backed pathmarks since this was required to make grouped lines work. @jonathanzong had already written this code, so I just needed to comment it out with a small adjustment. @jonathanzong do you have time to review this PR and see if the approach here makes sense and let me know if you were already planning to implement this functionality in a different manner (I'm happy to close this PR if that is the case)?

![recording-2026-04-14_08 37 20-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0e457098-5734-422b-9cae-1347c87e411d)
(I believe that the nudging of the legend to the right is due to https://github.com/vega/vega/issues/4267)

```json

{
  "data": {
    "values": [
      {"z": "a", "x": 0, "y": 0},
      {"z": "a", "x": 1, "y": 0.2},
      {"z": "a", "x": 2, "y": 0.39},
      {"z": "a", "x": 3, "y": 0.56},
      {"z": "a", "x": 4, "y": 0.72},
      {"z": "a", "x": 5, "y": 0.84},
      {"z": "a", "x": 6, "y": 0.93},
      {"z": "a", "x": 7, "y": 0.98},
      {"z": "b", "x": 7, "y": 1.0},
      {"z": "b", "x": 6, "y": 0.97},
      {"z": "b", "x": 5, "y": 0.91},
      {"z": "b", "x": 4, "y": 0.81},
      {"z": "b", "x": 3, "y": 0.68},
      {"z": "b", "x": 2, "y": 0.52},
      {"z": "b", "x": 1, "y": 0.33},
      {"z": "b", "x": 0, "y": 0.14}
    ]
  },
  "params": [
    {
      "name": "ANIM",
      "select": {"type": "point", "fields": ["x"], "on": "timer"}
    }
  ],
  "transform": [
    {"filter": "datum.x <= ANIM_value"}
  ],
  "mark": {"type": "trail"},
  "encoding": {
    "x": {"field": "x", "type": "quantitative"},
    "y": {"field": "y", "type": "quantitative"},
    "color": {"field": "z"},
    "time": {"field": "x", "type": "quantitative"},
    "size": {"field": "y", "type": "quantitative"}
  }
}
```

I left documentation out of this PR as that needs to be resolved separately in https://github.com/vega/vega-lite/pull/9535 first.

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
