### PR TITLE
fix: Avoid cyclic reference when using frozen/unreactive domains

### DIFF
--- a/examples/compiled/point_constant_legend_domain.vg.json
+++ b/examples/compiled/point_constant_legend_domain.vg.json
@@ -67,8 +67,12 @@
       "name": "color_selection",
       "update": "vlSelectionResolve(\"color_selection_store\", \"union\", true, true)"
     },
-    {"name": "computed_domain", "update": "domain('color')"},
-    {"name": "color_domain", "react": false, "update": "computed_domain"},
+    {"name": "computed_domain", "update": "domain('__color_domain_source')"},
+    {
+      "name": "color_domain",
+      "value": {"__vl_color_domain_sentinel": true},
+      "update": "color_domain && color_domain.__vl_color_domain_sentinel ? (computed_domain) : color_domain"
+    },
     {
       "name": "color_selection_tuple",
       "update": "color_selection_Origin_legend !== null ? {fields: color_selection_tuple_fields, values: [color_selection_Origin_legend]} : null"
@@ -140,6 +144,11 @@
       "type": "ordinal",
       "domain": {"signal": "color_domain"},
       "range": "category"
+    },
+    {
+      "name": "__color_domain_source",
+      "type": "ordinal",
+      "domain": {"data": "source_0", "field": "Origin"}
     }
   ],
   "axes": [

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -6,6 +6,7 @@ import {Config, initConfig, stripAndRedirectConfig} from '../config.js';
 import * as log from '../log/index.js';
 import {normalize} from '../normalize/index.js';
 import {assembleParameterSignals} from '../parameter.js';
+import {isSelectionParameter} from '../selection.js';
 import {LayoutSizeMixins, TopLevel, TopLevelSpec} from '../spec/index.js';
 import {
   AutoSizeParams,
@@ -222,6 +223,17 @@ function assembleTopLevelModel(
   });
 
   const {params, ...otherTopLevelProps} = topLevelProperties;
+  const group = model.assembleGroup([
+    ...layoutSignals,
+    ...model.assembleSelectionTopLevelSignals([]),
+    ...assembleParameterSignals(params),
+  ]);
+
+  const parameterSignalNames = new Set(
+    (params || []).filter((param) => !isSelectionParameter(param)).map((param) => param.name),
+  );
+
+  rewriteSignalDomainRefs(group, parameterSignalNames);
 
   return {
     $schema: 'https://vega.github.io/schema/vega/v6.json',
@@ -232,12 +244,85 @@ function assembleTopLevelModel(
     ...(encodeEntry ? {encode: {update: encodeEntry}} : {}),
     data,
     ...(projections.length > 0 ? {projections} : {}),
-    ...model.assembleGroup([
-      ...layoutSignals,
-      ...model.assembleSelectionTopLevelSignals([]),
-      ...assembleParameterSignals(params),
-    ]),
+    ...group,
     ...(vgConfig ? {config: vgConfig} : {}),
     ...(usermeta ? {usermeta} : {}),
   };
+}
+
+function rewriteSignalDomainRefs(group: any, parameterSignalNames: Set<string>) {
+  if (!group?.signals || !group?.scales) return;
+
+  const helperScaleName = new Map<string, string>();
+
+  for (const signal of group.signals) {
+    if (!parameterSignalNames.has(signal.name)) continue;
+
+    for (const key of ['init', 'update']) {
+      const expr = signal[key];
+      if (!isString(expr) || expr.indexOf('domain(') < 0) continue;
+
+      signal[key] = expr.replace(/domain\((['"])([^'"]+)\1\)/g, (match: string, _quote: string, scaleName: string) => {
+        const helper = helperScaleFor(scaleName, group, helperScaleName, parameterSignalNames);
+        return helper ? `domain('${helper}')` : match;
+      });
+    }
+  }
+}
+
+function helperScaleFor(
+  scaleName: string,
+  group: any,
+  helperScaleName: Map<string, string>,
+  parameterSignalNames: Set<string>,
+) {
+  if (helperScaleName.has(scaleName)) {
+    return helperScaleName.get(scaleName);
+  }
+
+  const scale = (group.scales as any[]).find((s) => s.name === scaleName);
+  if (!scale || !scale.domain || !scale.domain.signal) return null;
+  if (!parameterSignalNames.has(scale.domain.signal)) return null;
+
+  const ref = findScaleFieldRef(group.marks, scaleName, undefined);
+  if (!ref) return null;
+
+  const helper = `__${scaleName}_domain_source`;
+  if (!(group.scales as any[]).some((s) => s.name === helper)) {
+    group.scales.push({
+      name: helper,
+      type: scale.type,
+      domain: {data: ref.data, field: ref.field},
+    });
+  }
+
+  helperScaleName.set(scaleName, helper);
+  return helper;
+}
+
+type ScaleFieldRef = {data: string; field: string} | null;
+
+function findScaleFieldRef(marks: any[], scaleName: string, inheritedData: string): ScaleFieldRef {
+  for (const mark of marks || []) {
+    const dataName = mark.from?.data || inheritedData;
+    const found = findScaleFieldInEncode(mark.encode, scaleName, dataName);
+    if (found) return found;
+
+    const nested = findScaleFieldRef(mark.marks, scaleName, dataName);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function findScaleFieldInEncode(encode: any, scaleName: string, dataName: string): ScaleFieldRef {
+  for (const blockName of keys(encode || {})) {
+    const block = encode[blockName] || {};
+    for (const key of keys(block)) {
+      const value = block[key];
+      if (value?.scale === scaleName && isString(value.field) && dataName) {
+        return {data: dataName, field: value.field};
+      }
+    }
+  }
+  return null;
 }

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -304,11 +304,13 @@ type ScaleFieldRef = {data: string; field: string} | null;
 
 function findScaleFieldRef(marks: any[], scaleName: string, inheritedData: string): ScaleFieldRef {
   for (const mark of marks || []) {
-    const dataName = mark.from?.data || inheritedData;
+    const facetDataName = mark.from?.facet?.data;
+    const fromDataName = mark.from?.data;
+    const dataName = fromDataName === 'facet' ? inheritedData : fromDataName || facetDataName || inheritedData;
     const found = findScaleFieldInEncode(mark.encode, scaleName, dataName);
     if (found) return found;
 
-    const nested = findScaleFieldRef(mark.marks, scaleName, dataName);
+    const nested = findScaleFieldRef(mark.marks, scaleName, facetDataName || dataName);
     if (nested) return nested;
   }
   return null;

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -40,9 +40,9 @@ export function assembleParameterSignals(params: (VariableParameter | TopLevelSe
     // Selection parameters are handled separately via assembleSelectionTopLevelSignals
     // and assembleSignals methods registered on the Model.
     if (isSelectionParameter(param)) continue;
-    const {expr, bind, ...rest} = param;
+    const {expr, bind, react, ...rest} = param;
 
-    if (bind && expr) {
+    if (expr && bind) {
       // Vega's InitSignal -- apply expr to "init"
       const signal: InitSignal = {
         ...rest,
@@ -50,11 +50,20 @@ export function assembleParameterSignals(params: (VariableParameter | TopLevelSe
         init: expr,
       };
       signals.push(signal);
+    } else if (expr && react === false) {
+      const sentinelKey = `__vl_${param.name}_sentinel`;
+      const signal: NewSignal = {
+        ...rest,
+        value: {[sentinelKey]: true},
+        update: `${param.name} && ${param.name}.${sentinelKey} ? (${expr}) : ${param.name}`,
+      };
+      signals.push(signal);
     } else {
       const signal: NewSignal = {
         ...rest,
         ...(expr ? {update: expr} : {}),
         ...(bind ? {bind} : {}),
+        ...(react === false ? {react} : {}),
       };
       signals.push(signal);
     }

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -222,6 +222,109 @@ describe('compile/compile', () => {
     expect(spec.autosize).toEqual({type: 'fit', contains: 'content'});
   });
 
+  it('should rewrite sorted domain expressions to use helper scales', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b'},
+          {x: 2, y: 2, c: 'a'},
+          {x: 3, y: 3, c: 'c'},
+        ],
+      },
+      params: [
+        {name: 'computed_domain', expr: "sort(domain('color'))"},
+        {name: 'color_domain', react: false, expr: 'computed_domain'},
+      ],
+      mark: 'point',
+      encoding: {
+        color: {
+          field: 'c',
+          type: 'nominal',
+          scale: {domain: {expr: 'color_domain'}},
+        },
+        x: {field: 'x', type: 'quantitative'},
+        y: {field: 'y', type: 'quantitative'},
+      },
+    });
+
+    expect(spec.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'computed_domain',
+          update: "sort(domain('__color_domain_source'))",
+        }),
+      ]),
+    );
+
+    expect(spec.scales).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: '__color_domain_source',
+          type: 'ordinal',
+          domain: {data: 'data_0', field: 'c'},
+        }),
+      ]),
+    );
+  });
+
+  it('should rewrite parameter domain expressions even without sort', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b'},
+          {x: 2, y: 2, c: 'a'},
+        ],
+      },
+      params: [
+        {name: 'computed_domain', expr: "sort(domain('color'))"},
+        {name: 'color_domain', react: false, expr: 'computed_domain'},
+        {name: 'domain_len', expr: "domain('color').length"},
+      ],
+      mark: 'point',
+      encoding: {
+        color: {
+          field: 'c',
+          type: 'nominal',
+          scale: {domain: {expr: 'color_domain'}},
+        },
+        x: {field: 'x', type: 'quantitative'},
+        y: {field: 'y', type: 'quantitative'},
+      },
+    });
+
+    expect(spec.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'domain_len',
+          update: "domain('__color_domain_source').length",
+        }),
+      ]),
+    );
+  });
+
+  it('should compile non-reactive parameter references to one-time updates', () => {
+    const {spec} = compile({
+      data: {values: [{x: 1}]},
+      mark: 'point',
+      encoding: {x: {field: 'x', type: 'quantitative'}},
+      params: [
+        {name: 'a', expr: '5'},
+        {name: 'b', expr: 'a', react: false},
+      ],
+    });
+
+    expect(spec.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'a', update: '5'}),
+        expect.objectContaining({
+          name: 'b',
+          value: {__vl_b_sentinel: true},
+          update: 'b && b.__vl_b_sentinel ? (a) : b',
+        }),
+      ]),
+    );
+  });
+
   it('should set autosize to fit if requested', () => {
     const {spec} = compile({
       autosize: 'fit',

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -1,4 +1,4 @@
-import {AggregateTransform} from 'vega';
+import {AggregateTransform, parse, View} from 'vega';
 import {compile} from '../../src/compile/compile.js';
 import * as log from '../../src/log/index.js';
 
@@ -302,6 +302,112 @@ describe('compile/compile', () => {
     );
   });
 
+  it('should rewrite domain references for layered specs', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b'},
+          {x: 2, y: 2, c: 'a'},
+        ],
+      },
+      params: [
+        {name: 'computed_domain', expr: "sort(domain('color'))"},
+        {name: 'color_domain', react: false, expr: 'computed_domain'},
+      ],
+      layer: [
+        {
+          mark: 'point',
+          encoding: {
+            color: {field: 'c', type: 'nominal', scale: {domain: {expr: 'color_domain'}}},
+            x: {field: 'x', type: 'quantitative'},
+            y: {field: 'y', type: 'quantitative'},
+          },
+        },
+      ],
+    });
+
+    expect(spec.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'computed_domain', update: "sort(domain('__color_domain_source'))"}),
+      ]),
+    );
+    expect(spec.scales).toEqual(expect.arrayContaining([expect.objectContaining({name: '__color_domain_source'})]));
+  });
+
+  it('should rewrite domain references for faceted specs', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b', g: 'u'},
+          {x: 2, y: 2, c: 'a', g: 'v'},
+        ],
+      },
+      params: [
+        {name: 'computed_domain', expr: "sort(domain('color'))"},
+        {name: 'color_domain', react: false, expr: 'computed_domain'},
+      ],
+      facet: {field: 'g', type: 'nominal'},
+      spec: {
+        mark: 'point',
+        encoding: {
+          color: {field: 'c', type: 'nominal', scale: {domain: {expr: 'color_domain'}}},
+          x: {field: 'x', type: 'quantitative'},
+          y: {field: 'y', type: 'quantitative'},
+        },
+      },
+    });
+
+    expect(spec.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'computed_domain', update: "sort(domain('__color_domain_source'))"}),
+      ]),
+    );
+    expect(spec.scales).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: '__color_domain_source', domain: {data: 'data_0', field: 'c'}}),
+      ]),
+    );
+  });
+
+  it('should rewrite domain references for concatenated specs', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b'},
+          {x: 2, y: 2, c: 'a'},
+        ],
+      },
+      params: [
+        {name: 'computed_domain', expr: "sort(domain('color'))"},
+        {name: 'color_domain', react: false, expr: 'computed_domain'},
+      ],
+      hconcat: [
+        {
+          mark: 'point',
+          encoding: {
+            color: {field: 'c', type: 'nominal', scale: {domain: {expr: 'color_domain'}}},
+            x: {field: 'x', type: 'quantitative'},
+            y: {field: 'y', type: 'quantitative'},
+          },
+        },
+        {
+          mark: 'point',
+          encoding: {
+            x: {field: 'x', type: 'quantitative'},
+            y: {field: 'y', type: 'quantitative'},
+          },
+        },
+      ],
+    });
+
+    expect(spec.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'computed_domain', update: "sort(domain('__color_domain_source'))"}),
+      ]),
+    );
+    expect(spec.scales).toEqual(expect.arrayContaining([expect.objectContaining({name: '__color_domain_source'})]));
+  });
+
   it('should compile non-reactive parameter references to one-time updates', () => {
     const {spec} = compile({
       data: {values: [{x: 1}]},
@@ -323,6 +429,131 @@ describe('compile/compile', () => {
         }),
       ]),
     );
+  });
+
+  it('should keep sorted frozen color domain for layered specs at runtime', async () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b'},
+          {x: 2, y: 2, c: 'a'},
+          {x: 3, y: 3, c: 'c'},
+        ],
+      },
+      params: [
+        {name: 'legend_click', select: {type: 'point', encodings: ['color']}, bind: 'legend'},
+        {name: 'frozen_domain', expr: "sort(domain('color'))", react: false},
+      ],
+      layer: [
+        {
+          mark: 'point',
+          transform: [{filter: {param: 'legend_click'}}],
+          encoding: {
+            color: {field: 'c', type: 'nominal', scale: {domain: {expr: 'frozen_domain'}}},
+            x: {field: 'x', type: 'quantitative'},
+            y: {field: 'y', type: 'quantitative'},
+          },
+        },
+      ],
+    });
+
+    const view = new View(parse(spec), {renderer: 'none'});
+    await view.runAsync();
+    expect(view.scale('color').domain()).toEqual(['a', 'b', 'c']);
+
+    const legendSignal = spec.signals.find((s) => s.name.includes('legend_click_c_legend')).name;
+    view.signal(legendSignal, 'a');
+    await view.runAsync();
+
+    expect(view.data('data_0').map((d: any) => d.c)).toEqual(['a']);
+    expect(view.scale('color').domain()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should keep sorted frozen color domain for faceted specs at runtime', async () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b', g: 'u'},
+          {x: 2, y: 2, c: 'a', g: 'u'},
+          {x: 3, y: 3, c: 'c', g: 'v'},
+        ],
+      },
+      params: [
+        {name: 'legend_click', select: {type: 'point', encodings: ['color']}, bind: 'legend'},
+        {name: 'frozen_domain', expr: "sort(domain('color'))", react: false},
+      ],
+      facet: {column: {field: 'g', type: 'nominal'}},
+      spec: {
+        mark: 'point',
+        transform: [{filter: {param: 'legend_click'}}],
+        encoding: {
+          color: {field: 'c', type: 'nominal', scale: {domain: {expr: 'frozen_domain'}}},
+          x: {field: 'x', type: 'quantitative'},
+          y: {field: 'y', type: 'quantitative'},
+        },
+      },
+    });
+
+    const view = new View(parse(spec), {renderer: 'none'});
+    await view.runAsync();
+    expect(view.scale('color').domain()).toEqual(['a', 'b', 'c']);
+
+    const legendSignal = spec.signals.find((s) => s.name.includes('legend_click_c_legend')).name;
+    view.signal(legendSignal, 'a');
+    await view.runAsync();
+
+    expect(view.data('data_0').map((d: any) => d.c)).toEqual(['a']);
+    expect(view.scale('color').domain()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should keep sorted frozen color domain for concatenated specs at runtime', async () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {x: 1, y: 1, c: 'b'},
+          {x: 2, y: 2, c: 'a'},
+          {x: 3, y: 3, c: 'c'},
+        ],
+      },
+      params: [
+        {name: 'legend_click', select: {type: 'point', encodings: ['color']}, bind: 'legend'},
+        {name: 'frozen_domain', expr: "sort(domain('color'))", react: false},
+      ],
+      hconcat: [
+        {
+          mark: 'point',
+          transform: [{filter: {param: 'legend_click'}}],
+          encoding: {
+            color: {field: 'c', type: 'nominal', scale: {domain: {expr: 'frozen_domain'}}},
+            x: {field: 'x', type: 'quantitative'},
+            y: {field: 'y', type: 'quantitative'},
+          },
+        },
+        {
+          mark: 'bar',
+          transform: [
+            {filter: {param: 'legend_click'}},
+            {bin: {maxbins: 8}, field: 'x', as: 'x_binned'},
+            {aggregate: [{op: 'count', as: 'count'}], groupby: ['x_binned']},
+          ],
+          encoding: {
+            y: {field: 'x_binned', type: 'ordinal'},
+            x: {field: 'count', type: 'quantitative'},
+          },
+        },
+      ],
+    });
+
+    const view = new View(parse(spec), {renderer: 'none'});
+    await view.runAsync();
+    expect(view.scale('color').domain()).toEqual(['a', 'b', 'c']);
+
+    const legendSignal = spec.signals.find((s) => s.name.includes('legend_click_c_legend')).name;
+    view.signal(legendSignal, 'a');
+    await view.runAsync();
+
+    expect(view.data('data_0').map((d: any) => d.c)).toEqual(['a']);
+    expect(view.scale('color').domain()).toEqual(['a', 'b', 'c']);
   });
 
   it('should set autosize to fit if requested', () => {


### PR DESCRIPTION
This PR fixes unstable frozen legend domains when users define parameter expressions like `sort(domain("color"))` and then freeze with `react: false`. In some specs, this pattern effectively referenced a signal-driven scale domain from the same parameter pipeline, which could lead to initialization-order issues (empty/unsorted domains, composition fragility, facet edge cases).

Currently a domain cannot be set to a fixed sequence of values unless one knows the sequence up front, ie there is no way to retrieve the values from the data. This leads to issues when creating e.g. a legend that allows for filtering of the data, because the color domain is recomputed at each click on the legend so that the color changes for that category. We also have to click outside the legend to bring back the the full range of colors and there is no way to shift click to select multiple categories:

<img width="444" height="520" alt="recording-2026-04-17_12 36 51-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/c9f6ac42-536d-433a-817a-fab474ef57f7" />

[Open the Chart in the Vega Editor](https://vega.github.io/editor/#/url/vega-lite/N4IgJghgLhIFygK4CcA28QAspQA4Gc4B6IgYzADsA6AK3zAFNUBLAN2SooaiItwFsirBgHMIAWkgx83fAAFWARioAmAJxUADESkQyEZPlr4A9hRABfADQhcBiP3zwA2qAoOGGVKIYUwAfVIWUgBrEBsZb1IoeFAoAE9cTzhbE2YKGJsAM2YmMCc4ZxAAYXiWPwZDEABdaxAAI3SwLx8-S2qbVlIzUmgXUH4DMIQQBKSMXDSMyxsoZAgKfCyTZH5+kBzUKErY23s1lO8RXwCg5lDLCw6QX26wdJFd7tQV3Zy8jFLyxirZxOSQBQTPx0hB0HUAB5vXKoZopAASKxkkwA7js-uMUgBHRALKDMGD44QzEDxaEfFIAWWY3nw-iSyH8AHEwS9zBiATi8QToGxPBYBVZQJgGMwRNh4IpNJobINkMM4v8MPUDCS5gslisDq4NjTtshdnZ5gcQEcToFgmEBddbiZ7hRHiMoSN3rCMIjDAxUeiGul4HNEAw6mSRhARCJkKJoADuohpgKrhYgA)

After this PR, we can use a parameter with `react: false` to initialize and sort the color domain, making sure that all the categorical levels in the original data are always visible in the legend, so that each category is constantly linked to the same color even as the data is filter and so that shift-clicking to select multiple categories work as desired:

<img width="442" height="526" alt="recording-2026-04-17_15 10 02-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/228d19c4-e40e-4be5-b2c8-21925d076420" />

This diff for this compared to the spec above is relatively small:

```diff
{
  "data": {
    "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/cars.json"
  },
  "params": [
    {
      "name": "legend_click",
      "select": {"type": "point", "fields": ["Cylinders"]},
      "bind": "legend"
    },
+   {"name": "frozen_domain", "expr": "sort(domain('color'))", "react": false}
  ],
  "vconcat": [
    {
      "mark": {"type": "point"},
      "transform": [{"filter": {"param": "legend_click"}}],
      "encoding": {
        "color": {
          "field": "Cylinders",
          "type": "nominal",
+         "scale": {"domain": {"expr": "frozen_domain"}}
        },
        "x": {"field": "Horsepower", "type": "quantitative"},
        "y": {"field": "Miles_per_Gallon", "type": "quantitative"}
      }
    },
    {
      "height": 100,
      "mark": {"type": "bar"},
      "transform": [
        {"filter": {"param": "legend_click"}}
      ],
      "encoding": {
        "x": {"field": "Horsepower", "bin": true},
        "y": {"aggregate": "count"}
      }
    }
  ]
}
```

An additional motivation for this PR is to unblock https://github.com/vega/altair/pull/3394. While some of the code in this fix feels a bit "patchy" (like the regex match), the desired behavior more closely matches what one would expect from `react: false`, ie it retrieves a value at chart initialization that does not later change/react to any subsequent updates to the chart. Previously,`sort(domain("color"))` + `react:false` could freeze too early or depend on fragile scale-domain evaluation order.

### Detailed changes

1. **Rewrite parameter `domain('<scale>')` refs to helper source-domain scales**  
   In compiled Vega, parameter signal expressions that reference `domain('color')` now get rewritten to a helper scale (for example `__color_domain_source`) when the referenced scale domain is parameter-driven.
   - This avoids self-referential scale-domain dependency patterns.
   - Applied at compile time in `src/compile/compile.ts`.
2. **Generalize `react: false` parameter freezing behavior**  
   `expr + react:false` parameters compile to one-time/latching updates so the first evaluated value is captured and held stable during interaction.
   - This preserves frozen legend domain behavior under filtering and selection updates.
   - Implemented in `src/parameter.ts`.
3. **Fix helper-scale source inference for composed specs (especially facet)**  
   Helper-scale data-source inference now correctly resolves through composed mark structures and facet wrappers, instead of accidentally using the synthetic `facet` placeholder source.
   - Implemented in `src/compile/compile.ts`.
4. **Expanded tests**  
   Added/updated compile + runtime-focused tests to cover:
   - sorted/frozen parameter domain rewrites,
   - non-sort domain expressions,
   - `react:false` freezing behavior,
   - layered / faceted / concatenated specs.


<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [x] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>
