### PR TITLE
feat: Enable scale binding (pan and zoom) for geoshape marks

### DIFF
--- a/src/compile/projection/assemble.ts
+++ b/src/compile/projection/assemble.ts
@@ -2,6 +2,7 @@ import {Projection as VgProjection, SignalRef} from 'vega';
 import {contains} from '../../util.js';
 import {isSignalRef} from '../../vega.schema.js';
 import {isConcatModel, isLayerModel, Model} from '../model.js';
+import {projectionFitName, projectionScaleName, projectionTranslateName} from '../selection/scales.js';
 
 export function assembleProjections(model: Model): VgProjection[] {
   if (isLayerModel(model) || isConcatModel(model)) {
@@ -25,6 +26,7 @@ export function assembleProjectionForModel(model: Model): VgProjection[] {
 
   const projection = component.combine();
   const {name} = projection; // we need to extract name so that it is always present in the output and pass TS type validation
+  const selectionName = component.interactiveSelection;
 
   if (!component.data) {
     // generate custom projection, no automatic fitting
@@ -35,6 +37,12 @@ export function assembleProjectionForModel(model: Model): VgProjection[] {
         translate: {signal: '[width / 2, height / 2]'},
         // parameters, overwrite default translate if specified
         ...projection,
+        ...(selectionName
+          ? {
+              scale: {signal: projectionScaleName(selectionName)},
+              translate: {signal: projectionTranslateName(selectionName)},
+            }
+          : {}),
       },
     ];
   } else {
@@ -60,10 +68,20 @@ export function assembleProjectionForModel(model: Model): VgProjection[] {
       {
         name,
         size,
-        fit: {
-          signal: fits.length > 1 ? `[${fits.join(', ')}]` : fits[0],
-        },
+        fit: selectionName
+          ? {
+              signal: projectionFitName(selectionName),
+            }
+          : {
+              signal: fits.length > 1 ? `[${fits.join(', ')}]` : fits[0],
+            },
         ...projection,
+        ...(selectionName
+          ? {
+              scale: {signal: projectionScaleName(selectionName)},
+              translate: {signal: projectionTranslateName(selectionName)},
+            }
+          : {}),
       },
     ];
   }

--- a/src/compile/projection/component.ts
+++ b/src/compile/projection/component.ts
@@ -10,6 +10,7 @@ export class ProjectionComponent extends Split<VgProjection> {
     public specifiedProjection: Projection<SignalRef>,
     public size: SignalRef[],
     public data: (string | SignalRef)[],
+    public interactiveSelection?: string,
   ) {
     super(
       {...specifiedProjection}, // all explicit properties of projection

--- a/src/compile/projection/parse.ts
+++ b/src/compile/projection/parse.ts
@@ -6,10 +6,11 @@ import {DataSourceType} from '../../data.js';
 import {replaceExprRef} from '../../expr.js';
 import {PROJECTION_PROPERTIES} from '../../projection.js';
 import {GEOJSON} from '../../type.js';
-import {deepEqual, duplicate, every} from '../../util.js';
+import {deepEqual, duplicate, every, vals} from '../../util.js';
 import {isUnitModel, Model} from '../model.js';
 import {UnitModel} from '../unit.js';
 import {ProjectionComponent} from './component.js';
+import scales from '../selection/scales.js';
 
 export function parseProjection(model: Model) {
   model.component.projection = isUnitModel(model) ? parseUnitProjection(model) : parseNonUnitProjections(model);
@@ -22,6 +23,10 @@ function parseUnitProjection(model: UnitModel): ProjectionComponent {
     const size = fit ? [model.getSizeSignalRef('width'), model.getSizeSignalRef('height')] : undefined;
     const data = fit ? gatherFitData(model) : undefined;
 
+    const interactiveSelection = vals(model.component.selection ?? {}).find(
+      (selCmpt) => scales.defined(selCmpt) && model.hasProjection,
+    )?.name;
+
     const projComp = new ProjectionComponent(
       model.projectionName(true),
       {
@@ -30,6 +35,7 @@ function parseUnitProjection(model: UnitModel): ProjectionComponent {
       },
       size,
       data,
+      interactiveSelection,
     );
 
     if (!projComp.get('type')) {

--- a/src/compile/selection/clear.ts
+++ b/src/compile/selection/clear.ts
@@ -6,6 +6,15 @@ import {varName} from '../../util.js';
 import inputBindings from './inputs.js';
 import toggle, {TOGGLE} from './toggle.js';
 import {SelectionCompiler} from './index.js';
+import {
+  isProjectionBoundInterval,
+  projectionFitExpr,
+  projectionFitName,
+  projectionScaleName,
+  projectionTranslateName,
+} from './scales.js';
+import {UnitModel} from '../unit.js';
+import {stringValue} from 'vega-util';
 
 const clear: SelectionCompiler = {
   defined: (selCmpt) => {
@@ -33,13 +42,32 @@ const clear: SelectionCompiler = {
 
   signals: (model, selCmpt, signals) => {
     function addClear(idx: number, update: Update) {
-      if (idx !== -1 && signals[idx].on) {
-        signals[idx].on.push({events: selCmpt.clear, update});
+      if (idx !== -1) {
+        (signals[idx].on ??= []).push({events: selCmpt.clear, update});
       }
     }
 
     // Be as minimalist as possible when adding clear triggers to minimize dataflow execution.
     if (selCmpt.type === 'interval') {
+      if (isProjectionBoundInterval(model as UnitModel, selCmpt as any)) {
+        const unit = model as UnitModel;
+        const fitExpr = projectionFitExpr(model as UnitModel);
+        const scaleIdx = signals.findIndex((n) => n.name === projectionScaleName(selCmpt.name));
+        const translateIdx = signals.findIndex((n) => n.name === projectionTranslateName(selCmpt.name));
+        const projection = stringValue(unit.projectionName());
+
+        addClear(scaleIdx, `geoScale(${projection})`);
+        addClear(
+          translateIdx,
+          `[${unit.getSizeSignalRef('width').signal} / 2, ${unit.getSizeSignalRef('height').signal} / 2]`,
+        );
+
+        if (fitExpr) {
+          const fitIdx = signals.findIndex((n) => n.name === projectionFitName(selCmpt.name));
+          addClear(fitIdx, fitExpr);
+        }
+      }
+
       for (const proj of selCmpt.project.items) {
         const vIdx = signals.findIndex((n) => n.name === proj.signals.visual);
         addClear(vIdx, '[0, 0]');

--- a/src/compile/selection/clear.ts
+++ b/src/compile/selection/clear.ts
@@ -14,7 +14,6 @@ import {
   projectionTranslateName,
 } from './scales.js';
 import {UnitModel} from '../unit.js';
-import {stringValue} from 'vega-util';
 
 const clear: SelectionCompiler = {
   defined: (selCmpt) => {
@@ -50,20 +49,18 @@ const clear: SelectionCompiler = {
     // Be as minimalist as possible when adding clear triggers to minimize dataflow execution.
     if (selCmpt.type === 'interval') {
       if (isProjectionBoundInterval(model as UnitModel, selCmpt as any)) {
-        const unit = model as UnitModel;
         const fitExpr = projectionFitExpr(model as UnitModel);
-        const scaleIdx = signals.findIndex((n) => n.name === projectionScaleName(selCmpt.name));
-        const translateIdx = signals.findIndex((n) => n.name === projectionTranslateName(selCmpt.name));
-        const projection = stringValue(unit.projectionName());
-
-        addClear(scaleIdx, `geoScale(${projection})`);
-        addClear(
-          translateIdx,
-          `[${unit.getSizeSignalRef('width').signal} / 2, ${unit.getSizeSignalRef('height').signal} / 2]`,
-        );
 
         if (fitExpr) {
-          const fitIdx = signals.findIndex((n) => n.name === projectionFitName(selCmpt.name));
+          const scaleName = projectionScaleName(selCmpt.name);
+          const translateName = projectionTranslateName(selCmpt.name);
+          const fitName = projectionFitName(selCmpt.name);
+          const scaleIdx = signals.findIndex((n) => n.name === scaleName);
+          const translateIdx = signals.findIndex((n) => n.name === translateName);
+          const fitIdx = signals.findIndex((n) => n.name === fitName);
+
+          addClear(scaleIdx, '1');
+          addClear(translateIdx, '[0, 0]');
           addClear(fitIdx, fitExpr);
         }
       }

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -31,8 +31,14 @@ const interval: SelectionCompiler<'interval'> = {
       const def: IntervalSelectionConfigWithField = {...(isObject(selDef.select) ? selDef.select : {})};
       def.fields = [SELECTION_ID];
       if (!def.encodings) {
-        // Remap default x/y projection
-        def.encodings = selDef.value ? (keys(selDef.value) as GeoPositionChannel[]) : [LONGITUDE, LATITUDE];
+        // Remap default x/y projection. Only include channels that the model
+        // actually has field definitions for (geoshape specs may have no
+        // longitude/latitude encoding, so projection-bound interactions work
+        // purely through scale/translate signals).
+        const candidates: GeoPositionChannel[] = selDef.value
+          ? (keys(selDef.value) as GeoPositionChannel[])
+          : [LONGITUDE, LATITUDE];
+        def.encodings = candidates.filter((ch) => model.fieldDef(ch));
       }
 
       selDef.select = {type: 'interval', ...def};

--- a/src/compile/selection/scales.ts
+++ b/src/compile/selection/scales.ts
@@ -149,7 +149,7 @@ function isTopLevelLayer(model: Model): boolean {
   return model.parent && isLayerModel(model.parent) && (!model.parent.parent || isTopLevelLayer(model.parent.parent));
 }
 
-function projectionFitExpr(model: UnitModel) {
+export function projectionFitExpr(model: UnitModel) {
   const projection = model.component.projection;
   if (!projection?.data) {
     return null;

--- a/src/compile/selection/scales.ts
+++ b/src/compile/selection/scales.ts
@@ -3,12 +3,17 @@ import {VL_SELECTION_RESOLVE} from './index.js';
 import {isScaleChannel, ScaleChannel} from '../../channel.js';
 import * as log from '../../log/index.js';
 import {hasContinuousDomain} from '../../scale.js';
+import {contains} from '../../util.js';
 import {isLayerModel, Model} from '../model.js';
 import {UnitModel} from '../unit.js';
 import {SelectionProjection} from './project.js';
-import {SelectionCompiler} from './index.js';
+import {SelectionCompiler, SelectionComponent} from './index.js';
 import {replacePathInField} from '../../util.js';
 import {NewSignal} from 'vega';
+
+const PROJECTION_SCALE = '_projection_scale';
+const PROJECTION_TRANSLATE = '_projection_translate';
+const PROJECTION_FIT = '_projection_fit';
 
 const scaleBindings: SelectionCompiler<'interval'> = {
   defined: (selCmpt) => {
@@ -16,6 +21,11 @@ const scaleBindings: SelectionCompiler<'interval'> = {
   },
 
   parse: (model, selCmpt) => {
+    if (model.hasProjection) {
+      selCmpt.scales = [];
+      return;
+    }
+
     const bound: SelectionProjection[] = (selCmpt.scales = []);
 
     for (const proj of selCmpt.project.items) {
@@ -77,6 +87,27 @@ const scaleBindings: SelectionCompiler<'interval'> = {
   },
 
   signals: (model, selCmpt, signals) => {
+    if (isProjectionBoundInterval(model, selCmpt)) {
+      const scaleSg = projectionScaleName(selCmpt.name);
+      const translateSg = projectionTranslateName(selCmpt.name);
+      const fitSg = projectionFitName(selCmpt.name);
+      const width = model.getSizeSignalRef('width').signal;
+      const height = model.getSizeSignalRef('height').signal;
+      const fitExpr = projectionFitExpr(model);
+
+      if (!signals.some((s) => s.name === scaleSg)) {
+        signals.push({name: scaleSg, value: 1});
+      }
+
+      if (!signals.some((s) => s.name === translateSg)) {
+        signals.push({name: translateSg, value: [0, 0], update: `[${width} / 2, ${height} / 2]`});
+      }
+
+      if (fitExpr && !signals.some((s) => s.name === fitSg)) {
+        signals.push({name: fitSg, init: fitExpr});
+      }
+    }
+
     // Nested signals need only push to top-level signals with multiview displays.
     if (model.parent && !isTopLevelLayer(model)) {
       for (const proj of selCmpt.scales) {
@@ -98,6 +129,43 @@ export function domain(model: UnitModel, channel: ScaleChannel) {
   return `domain(${scale})`;
 }
 
+export function isProjectionBoundInterval(model: UnitModel, selCmpt: SelectionComponent<'interval'>) {
+  return model.hasProjection && scaleBindings.defined(selCmpt);
+}
+
+export function projectionScaleName(name: string) {
+  return name + PROJECTION_SCALE;
+}
+
+export function projectionTranslateName(name: string) {
+  return name + PROJECTION_TRANSLATE;
+}
+
+export function projectionFitName(name: string) {
+  return name + PROJECTION_FIT;
+}
+
 function isTopLevelLayer(model: Model): boolean {
   return model.parent && isLayerModel(model.parent) && (!model.parent.parent || isTopLevelLayer(model.parent.parent));
+}
+
+function projectionFitExpr(model: UnitModel) {
+  const projection = model.component.projection;
+  if (!projection?.data) {
+    return null;
+  }
+
+  const fits: string[] = projection.data.reduce((sources, data) => {
+    const source = typeof data === 'string' ? `data(${stringValue(model.lookupDataSource(data))})` : data.signal;
+    if (!contains(sources, source)) {
+      sources.push(source);
+    }
+    return sources;
+  }, [] as string[]);
+
+  if (fits.length === 0) {
+    return null;
+  }
+
+  return fits.length > 1 ? `[${fits.join(', ')}]` : fits[0];
 }

--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -5,8 +5,15 @@ import {ScaleChannel, X, Y} from '../../channel.js';
 import {UnitModel} from '../unit.js';
 import {BRUSH as INTERVAL_BRUSH} from './interval.js';
 import {SelectionProjection} from './project.js';
-import scalesCompiler, {domain} from './scales.js';
+import scalesCompiler, {
+  domain,
+  isProjectionBoundInterval,
+  projectionFitName,
+  projectionScaleName,
+  projectionTranslateName,
+} from './scales.js';
 import {SelectionCompiler} from './index.js';
+import {stringValue} from 'vega-util';
 
 const ANCHOR = '_translate_anchor';
 const DELTA = '_translate_delta';
@@ -19,6 +26,7 @@ const translate: SelectionCompiler<'interval'> = {
   signals: (model, selCmpt, signals) => {
     const name = selCmpt.name;
     const boundScales = scalesCompiler.defined(selCmpt);
+    const projectionBound = isProjectionBoundInterval(model, selCmpt);
     const anchor = name + ANCHOR;
     const {x, y} = selCmpt.project.hasChannel;
     let events = parseSelector(selCmpt.translate, 'scope');
@@ -34,9 +42,11 @@ const translate: SelectionCompiler<'interval'> = {
         on: [
           {
             events: events.map((e) => e.between[0]),
-            update: `{x: x(unit), y: y(unit)${
-              x !== undefined ? `, extent_x: ${boundScales ? domain(model, X) : `slice(${x.signals.visual})`}` : ''
-            }${y !== undefined ? `, extent_y: ${boundScales ? domain(model, Y) : `slice(${y.signals.visual})`}` : ''}}`,
+            update: projectionBound
+              ? `{x: x(unit), y: y(unit), translate: ${projectionTranslateName(name)}}`
+              : `{x: x(unit), y: y(unit)${
+                  x !== undefined ? `, extent_x: ${boundScales ? domain(model, X) : `slice(${x.signals.visual})`}` : ''
+                }${y !== undefined ? `, extent_y: ${boundScales ? domain(model, Y) : `slice(${y.signals.visual})`}` : ''}}`,
           },
         ],
       },
@@ -51,6 +61,45 @@ const translate: SelectionCompiler<'interval'> = {
         ],
       },
     );
+
+    if (projectionBound) {
+      const anchorSg: any = signals.find((s) => s.name === anchor);
+      const scaleSg = signals.find((s) => s.name === projectionScaleName(name));
+      const translateSg = signals.find((s) => s.name === projectionTranslateName(name));
+      const fitSg = signals.find((s) => s.name === projectionFitName(name));
+      const projection = stringValue(model.projectionName());
+
+      anchorSg.value = {x: 0, y: 0, translate: [0, 0]};
+      scaleSg.on ??= [];
+      translateSg.on ??= [];
+
+      scaleSg.on.push({
+        events: events.map((e) => e.between[0]),
+        update: `geoScale(${projection})`,
+      });
+
+      translateSg.on.push({
+        events: events.map((e) => e.between[0]),
+        update: `${anchor}.translate`,
+      });
+
+      translateSg.on.push({
+        events: {signal: name + DELTA},
+        update: `[${anchor}.translate[0] - ${name + DELTA}.x, ${anchor}.translate[1] - ${name + DELTA}.y]`,
+      });
+
+      if (fitSg) {
+        fitSg.on = [
+          ...(fitSg.on ?? []),
+          {
+            events: events.map((e) => e.between[0]),
+            update: 'null',
+          },
+        ];
+      }
+
+      return signals;
+    }
 
     if (x !== undefined) {
       onDelta(model, selCmpt, x, 'width', signals);

--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -79,11 +79,6 @@ const translate: SelectionCompiler<'interval'> = {
       });
 
       translateSg.on.push({
-        events: events.map((e) => e.between[0]),
-        update: `${anchor}.translate`,
-      });
-
-      translateSg.on.push({
         events: {signal: name + DELTA},
         update: `[${anchor}.translate[0] - ${name + DELTA}.x, ${anchor}.translate[1] - ${name + DELTA}.y]`,
       });
@@ -92,7 +87,7 @@ const translate: SelectionCompiler<'interval'> = {
         fitSg.on = [
           ...(fitSg.on ?? []),
           {
-            events: events.map((e) => e.between[0]),
+            events: {signal: name + DELTA},
             update: 'null',
           },
         ];

--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -80,6 +80,7 @@ const translate: SelectionCompiler<'interval'> = {
 
       translateSg.on.push({
         events: {signal: name + DELTA},
+        force: true,
         update: `[${anchor}.translate[0] - ${name + DELTA}.x, ${anchor}.translate[1] - ${name + DELTA}.y]`,
       });
 

--- a/src/compile/selection/translate.ts
+++ b/src/compile/selection/translate.ts
@@ -43,7 +43,7 @@ const translate: SelectionCompiler<'interval'> = {
           {
             events: events.map((e) => e.between[0]),
             update: projectionBound
-              ? `{x: x(unit), y: y(unit), translate: ${projectionTranslateName(name)}}`
+              ? `{x: x(unit), y: y(unit), translate: geoTranslate(${stringValue(model.projectionName())})}`
               : `{x: x(unit), y: y(unit)${
                   x !== undefined ? `, extent_x: ${boundScales ? domain(model, X) : `slice(${x.signals.visual})`}` : ''
                 }${y !== undefined ? `, extent_y: ${boundScales ? domain(model, Y) : `slice(${y.signals.visual})`}` : ''}}`,

--- a/src/compile/selection/zoom.ts
+++ b/src/compile/selection/zoom.ts
@@ -6,7 +6,14 @@ import {ScaleChannel, X, Y} from '../../channel.js';
 import {UnitModel} from '../unit.js';
 import {BRUSH as INTERVAL_BRUSH} from './interval.js';
 import {SelectionProjection} from './project.js';
-import {default as scalesCompiler, domain} from './scales.js';
+import {
+  default as scalesCompiler,
+  domain,
+  isProjectionBoundInterval,
+  projectionFitName,
+  projectionScaleName,
+  projectionTranslateName,
+} from './scales.js';
 import {SelectionCompiler} from './index.js';
 
 const ANCHOR = '_zoom_anchor';
@@ -20,6 +27,7 @@ const zoom: SelectionCompiler<'interval'> = {
   signals: (model, selCmpt, signals) => {
     const name = selCmpt.name;
     const boundScales = scalesCompiler.defined(selCmpt);
+    const projectionBound = isProjectionBoundInterval(model, selCmpt);
     const delta = name + DELTA;
     const {x, y} = selCmpt.project.hasChannel;
     const sx = stringValue(model.scaleName(X));
@@ -36,11 +44,13 @@ const zoom: SelectionCompiler<'interval'> = {
         on: [
           {
             events,
-            update: !boundScales
-              ? `{x: x(unit), y: y(unit)}`
-              : `{${[sx ? `x: invert(${sx}, x(unit))` : '', sy ? `y: invert(${sy}, y(unit))` : '']
-                  .filter((expr) => expr)
-                  .join(', ')}}`,
+            update: projectionBound
+              ? `{x: x(unit), y: y(unit), scale: ${projectionScaleName(name)}, translate: ${projectionTranslateName(name)}}`
+              : !boundScales
+                ? `{x: x(unit), y: y(unit)}`
+                : `{${[sx ? `x: invert(${sx}, x(unit))` : '', sy ? `y: invert(${sy}, y(unit))` : '']
+                    .filter((expr) => expr)
+                    .join(', ')}}`,
           },
         ],
       },
@@ -55,6 +65,40 @@ const zoom: SelectionCompiler<'interval'> = {
         ],
       },
     );
+
+    if (projectionBound) {
+      const anchorSignal: any = signals.find((s) => s.name === name + ANCHOR);
+      const scaleSg = signals.find((s) => s.name === projectionScaleName(name));
+      const translateSg = signals.find((s) => s.name === projectionTranslateName(name));
+      const fitSg = signals.find((s) => s.name === projectionFitName(name));
+      const anchorSg = `${name}${ANCHOR}`;
+
+      anchorSignal.value = {x: 0, y: 0, scale: 1, translate: [0, 0]};
+      scaleSg.on ??= [];
+      translateSg.on ??= [];
+
+      scaleSg.on.push({
+        events: {signal: delta},
+        update: `${anchorSg}.scale / ${delta}`,
+      });
+
+      translateSg.on.push({
+        events: {signal: delta},
+        update: `[${anchorSg}.x + (${anchorSg}.translate[0] - ${anchorSg}.x) / ${delta}, ${anchorSg}.y + (${anchorSg}.translate[1] - ${anchorSg}.y) / ${delta}]`,
+      });
+
+      if (fitSg) {
+        fitSg.on = [
+          ...(fitSg.on ?? []),
+          {
+            events,
+            update: 'null',
+          },
+        ];
+      }
+
+      return signals;
+    }
 
     if (x !== undefined) {
       onDelta(model, selCmpt, x, 'width', signals);

--- a/src/compile/selection/zoom.ts
+++ b/src/compile/selection/zoom.ts
@@ -45,7 +45,9 @@ const zoom: SelectionCompiler<'interval'> = {
           {
             events,
             update: projectionBound
-              ? `{x: x(unit), y: y(unit), scale: ${projectionScaleName(name)}, translate: ${projectionTranslateName(name)}}`
+              ? `{x: x(unit), y: y(unit), scale: geoScale(${stringValue(model.projectionName())}), translate: ${projectionTranslateName(
+                  name,
+                )}}`
               : !boundScales
                 ? `{x: x(unit), y: y(unit)}`
                 : `{${[sx ? `x: invert(${sx}, x(unit))` : '', sy ? `y: invert(${sy}, y(unit))` : '']
@@ -72,10 +74,16 @@ const zoom: SelectionCompiler<'interval'> = {
       const translateSg = signals.find((s) => s.name === projectionTranslateName(name));
       const fitSg = signals.find((s) => s.name === projectionFitName(name));
       const anchorSg = `${name}${ANCHOR}`;
+      const projection = stringValue(model.projectionName());
 
       anchorSignal.value = {x: 0, y: 0, scale: 1, translate: [0, 0]};
       scaleSg.on ??= [];
       translateSg.on ??= [];
+
+      scaleSg.on.push({
+        events,
+        update: `geoScale(${projection})`,
+      });
 
       scaleSg.on.push({
         events: {signal: delta},

--- a/src/compile/selection/zoom.ts
+++ b/src/compile/selection/zoom.ts
@@ -45,9 +45,9 @@ const zoom: SelectionCompiler<'interval'> = {
           {
             events,
             update: projectionBound
-              ? `{x: x(unit), y: y(unit), scale: geoScale(${stringValue(model.projectionName())}), translate: ${projectionTranslateName(
-                  name,
-                )}}`
+              ? `{x: x(unit), y: y(unit), scale: geoScale(${stringValue(model.projectionName())}), translate: geoTranslate(${stringValue(
+                  model.projectionName(),
+                )})}`
               : !boundScales
                 ? `{x: x(unit), y: y(unit)}`
                 : `{${[sx ? `x: invert(${sx}, x(unit))` : '', sy ? `y: invert(${sy}, y(unit))` : '']
@@ -99,7 +99,7 @@ const zoom: SelectionCompiler<'interval'> = {
         fitSg.on = [
           ...(fitSg.on ?? []),
           {
-            events,
+            events: {signal: delta},
             update: 'null',
           },
         ];

--- a/src/compile/selection/zoom.ts
+++ b/src/compile/selection/zoom.ts
@@ -74,24 +74,20 @@ const zoom: SelectionCompiler<'interval'> = {
       const translateSg = signals.find((s) => s.name === projectionTranslateName(name));
       const fitSg = signals.find((s) => s.name === projectionFitName(name));
       const anchorSg = `${name}${ANCHOR}`;
-      const projection = stringValue(model.projectionName());
 
       anchorSignal.value = {x: 0, y: 0, scale: 1, translate: [0, 0]};
       scaleSg.on ??= [];
       translateSg.on ??= [];
 
       scaleSg.on.push({
-        events,
-        update: `geoScale(${projection})`,
-      });
-
-      scaleSg.on.push({
         events: {signal: delta},
+        force: true,
         update: `${anchorSg}.scale / ${delta}`,
       });
 
       translateSg.on.push({
         events: {signal: delta},
+        force: true,
         update: `[${anchorSg}.x + (${anchorSg}.translate[0] - ${anchorSg}.x) / ${delta}, ${anchorSg}.y + (${anchorSg}.translate[1] - ${anchorSg}.y) / ${delta}]`,
       });
 

--- a/test/compile/projection/assemble.test.ts
+++ b/test/compile/projection/assemble.test.ts
@@ -104,4 +104,25 @@ describe('compile/projection/assemble', () => {
       expect(projection.fit).toBeUndefined();
     });
   });
+
+  describe('assembleInteractiveProjectionForModel', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/airports.csv'},
+      mark: 'circle',
+      projection: {type: 'albersUsa'},
+      params: [{name: 'geo', select: {type: 'interval'}, bind: 'scales'}],
+      encoding: {
+        longitude: {field: 'longitude', type: 'quantitative'},
+        latitude: {field: 'latitude', type: 'quantitative'},
+      },
+    });
+    model.parse();
+
+    it('uses projection parameter signals', () => {
+      const projection = assembleProjectionForModel(model)[0];
+      expect(projection.scale).toEqual({signal: 'geo_projection_scale'});
+      expect(projection.translate).toEqual({signal: 'geo_projection_translate'});
+      expect(projection.fit).toEqual({signal: 'geo_projection_fit'});
+    });
+  });
 });

--- a/test/compile/selection/clear.test.ts
+++ b/test/compile/selection/clear.test.ts
@@ -1,5 +1,5 @@
 import {parseSelector} from 'vega-event-selector';
-import {assembleTopLevelSignals} from '../../../src/compile/selection/assemble.js';
+import {assembleTopLevelSignals, assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble.js';
 import interval from '../../../src/compile/selection/interval.js';
 import point from '../../../src/compile/selection/point.js';
 import {parseUnitSelection} from '../../../src/compile/selection/parse.js';
@@ -238,6 +238,67 @@ describe('Clear selection transform, interval type', () => {
               update: '[0, 0]',
             },
           ],
+        },
+      ]),
+    );
+  });
+});
+
+describe('Clear selection transform, projection-bound interval', () => {
+  const model = parseUnitModel({
+    data: {url: 'data/airports.csv'},
+    mark: 'circle',
+    projection: {type: 'albersUsa'},
+    encoding: {
+      longitude: {field: 'longitude', type: 'quantitative'},
+      latitude: {field: 'latitude', type: 'quantitative'},
+    },
+  });
+
+  model.parseScale();
+  model.component.selection = parseUnitSelection(model, [
+    {
+      name: 'geo',
+      select: {type: 'interval'},
+      bind: 'scales',
+    },
+  ]);
+  model.parseProjection();
+
+  it('resets projection fit on clear', () => {
+    const signals = assembleUnitSelectionSignals(model, []);
+
+    const scale: any = signals.find((s) => s.name === 'geo_projection_scale');
+    expect(scale.on).toEqual(
+      expect.arrayContaining([
+        {
+          events: parseSelector('dblclick', 'view'),
+          update: 'geoScale("projection")',
+        },
+      ]),
+    );
+
+    const translate: any = signals.find((s) => s.name === 'geo_projection_translate');
+    expect(translate.on).toEqual(
+      expect.arrayContaining([
+        {
+          events: parseSelector('dblclick', 'view'),
+          update: '[width / 2, height / 2]',
+        },
+      ]),
+    );
+
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'geo_projection_fit',
+          init: 'geojson_0',
+          on: expect.arrayContaining([
+            {
+              events: parseSelector('dblclick', 'view'),
+              update: 'geojson_0',
+            },
+          ]),
         },
       ]),
     );

--- a/test/compile/selection/clear.test.ts
+++ b/test/compile/selection/clear.test.ts
@@ -273,7 +273,7 @@ describe('Clear selection transform, projection-bound interval', () => {
       expect.arrayContaining([
         {
           events: parseSelector('dblclick', 'view'),
-          update: 'geoScale("projection")',
+          update: '1',
         },
       ]),
     );
@@ -283,7 +283,7 @@ describe('Clear selection transform, projection-bound interval', () => {
       expect.arrayContaining([
         {
           events: parseSelector('dblclick', 'view'),
-          update: '[width / 2, height / 2]',
+          update: '[0, 0]',
         },
       ]),
     );

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -345,10 +345,6 @@ describe('Translate Selection Transform', () => {
       expect(projTranslate.on).toEqual(
         expect.arrayContaining([
           {
-            events: parseSelector('pointerdown', 'scope'),
-            update: 'geo_translate_anchor.translate',
-          },
-          {
             events: {signal: 'geo_translate_delta'},
             update:
               '[geo_translate_anchor.translate[0] - geo_translate_delta.x, geo_translate_anchor.translate[1] - geo_translate_delta.y]',
@@ -361,7 +357,7 @@ describe('Translate Selection Transform', () => {
       expect(fit.on).toEqual(
         expect.arrayContaining([
           {
-            events: parseSelector('pointerdown', 'scope'),
+            events: {signal: 'geo_translate_delta'},
             update: 'null',
           },
         ]),

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -297,4 +297,75 @@ describe('Translate Selection Transform', () => {
       });
     });
   });
+
+  describe('projection-bound intervals', () => {
+    it('builds projection translate/scale updates', () => {
+      const model = parseUnitModel({
+        mark: 'circle',
+        projection: {type: 'albersUsa'},
+        encoding: {
+          longitude: {field: 'longitude', type: 'quantitative'},
+          latitude: {field: 'latitude', type: 'quantitative'},
+        },
+        params: [{name: 'geo', select: {type: 'interval'}, bind: 'scales'}],
+      });
+
+      model.parseScale();
+      model.component.selection = parseUnitSelection(model, model.selection);
+      model.parseProjection();
+
+      const signals = assembleUnitSelectionSignals(model, []);
+      const anchor: any = signals.find((s) => s.name === 'geo_translate_anchor');
+      expect(anchor).toEqual(
+        expect.objectContaining({
+          value: {x: 0, y: 0, translate: [0, 0]},
+          on: [
+            {
+              events: parseSelector('pointerdown', 'scope'),
+              update: '{x: x(unit), y: y(unit), translate: geo_projection_translate}',
+            },
+          ],
+        }),
+      );
+
+      const scale: any = signals.find((s) => s.name === 'geo_projection_scale');
+      expect(scale.value).toBe(1);
+      expect(scale.on).toEqual(
+        expect.arrayContaining([
+          {
+            events: parseSelector('pointerdown', 'scope'),
+            update: 'geoScale("projection")',
+          },
+        ]),
+      );
+
+      const projTranslate: any = signals.find((s) => s.name === 'geo_projection_translate');
+      expect(projTranslate.value).toEqual([0, 0]);
+      expect(projTranslate.update).toBe('[width / 2, height / 2]');
+      expect(projTranslate.on).toEqual(
+        expect.arrayContaining([
+          {
+            events: parseSelector('pointerdown', 'scope'),
+            update: 'geo_translate_anchor.translate',
+          },
+          {
+            events: {signal: 'geo_translate_delta'},
+            update:
+              '[geo_translate_anchor.translate[0] - geo_translate_delta.x, geo_translate_anchor.translate[1] - geo_translate_delta.y]',
+          },
+        ]),
+      );
+
+      const fit: any = signals.find((s) => s.name === 'geo_projection_fit');
+      expect(fit.init).toBe('geojson_0');
+      expect(fit.on).toEqual(
+        expect.arrayContaining([
+          {
+            events: parseSelector('pointerdown', 'scope'),
+            update: 'null',
+          },
+        ]),
+      );
+    });
+  });
 });

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -322,7 +322,7 @@ describe('Translate Selection Transform', () => {
           on: [
             {
               events: parseSelector('pointerdown', 'scope'),
-              update: '{x: x(unit), y: y(unit), translate: geo_projection_translate}',
+              update: '{x: x(unit), y: y(unit), translate: geoTranslate("projection")}',
             },
           ],
         }),

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -346,6 +346,7 @@ describe('Translate Selection Transform', () => {
         expect.arrayContaining([
           {
             events: {signal: 'geo_translate_delta'},
+            force: true,
             update:
               '[geo_translate_anchor.translate[0] - geo_translate_delta.x, geo_translate_anchor.translate[1] - geo_translate_delta.y]',
           },

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -276,7 +276,7 @@ describe('Zoom Selection Transform', () => {
       expect(anchor.on).toEqual([
         {
           events: parseSelector('wheel!', 'scope'),
-          update: '{x: x(unit), y: y(unit), scale: geo_projection_scale, translate: geo_projection_translate}',
+          update: '{x: x(unit), y: y(unit), scale: geoScale("projection"), translate: geo_projection_translate}',
         },
       ]);
 

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -253,4 +253,67 @@ describe('Zoom Selection Transform', () => {
       });
     });
   });
+
+  describe('projection-bound intervals', () => {
+    it('builds projection zoom updates', () => {
+      const model = parseUnitModel({
+        mark: 'circle',
+        projection: {type: 'albersUsa'},
+        encoding: {
+          longitude: {field: 'longitude', type: 'quantitative'},
+          latitude: {field: 'latitude', type: 'quantitative'},
+        },
+        params: [{name: 'geo', select: {type: 'interval'}, bind: 'scales'}],
+      });
+
+      model.parseScale();
+      model.component.selection = parseUnitSelection(model, model.selection);
+      model.parseProjection();
+
+      const signals = assembleUnitSelectionSignals(model, []);
+      const anchor: any = signals.find((s) => s.name === 'geo_zoom_anchor');
+      expect(anchor.value).toEqual({x: 0, y: 0, scale: 1, translate: [0, 0]});
+      expect(anchor.on).toEqual([
+        {
+          events: parseSelector('wheel!', 'scope'),
+          update: '{x: x(unit), y: y(unit), scale: geo_projection_scale, translate: geo_projection_translate}',
+        },
+      ]);
+
+      const scale: any = signals.find((s) => s.name === 'geo_projection_scale');
+      expect(scale.value).toBe(1);
+      expect(scale.on).toEqual(
+        expect.arrayContaining([
+          {
+            events: {signal: 'geo_zoom_delta'},
+            update: 'geo_zoom_anchor.scale / geo_zoom_delta',
+          },
+        ]),
+      );
+
+      const translate: any = signals.find((s) => s.name === 'geo_projection_translate');
+      expect(translate.value).toEqual([0, 0]);
+      expect(translate.update).toBe('[width / 2, height / 2]');
+      expect(translate.on).toEqual(
+        expect.arrayContaining([
+          {
+            events: {signal: 'geo_zoom_delta'},
+            update:
+              '[geo_zoom_anchor.x + (geo_zoom_anchor.translate[0] - geo_zoom_anchor.x) / geo_zoom_delta, geo_zoom_anchor.y + (geo_zoom_anchor.translate[1] - geo_zoom_anchor.y) / geo_zoom_delta]',
+          },
+        ]),
+      );
+
+      const fit: any = signals.find((s) => s.name === 'geo_projection_fit');
+      expect(fit.init).toBe('geojson_0');
+      expect(fit.on).toEqual(
+        expect.arrayContaining([
+          {
+            events: parseSelector('wheel!', 'scope'),
+            update: 'null',
+          },
+        ]),
+      );
+    });
+  });
 });

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -282,10 +282,15 @@ describe('Zoom Selection Transform', () => {
 
       const scale: any = signals.find((s) => s.name === 'geo_projection_scale');
       expect(scale.value).toBe(1);
+      expect(scale.on).not.toContainEqual({
+        events: parseSelector('wheel!', 'scope'),
+        update: 'geoScale("projection")',
+      });
       expect(scale.on).toEqual(
         expect.arrayContaining([
           {
             events: {signal: 'geo_zoom_delta'},
+            force: true,
             update: 'geo_zoom_anchor.scale / geo_zoom_delta',
           },
         ]),
@@ -298,6 +303,7 @@ describe('Zoom Selection Transform', () => {
         expect.arrayContaining([
           {
             events: {signal: 'geo_zoom_delta'},
+            force: true,
             update:
               '[geo_zoom_anchor.x + (geo_zoom_anchor.translate[0] - geo_zoom_anchor.x) / geo_zoom_delta, geo_zoom_anchor.y + (geo_zoom_anchor.translate[1] - geo_zoom_anchor.y) / geo_zoom_delta]',
           },

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -276,7 +276,7 @@ describe('Zoom Selection Transform', () => {
       expect(anchor.on).toEqual([
         {
           events: parseSelector('wheel!', 'scope'),
-          update: '{x: x(unit), y: y(unit), scale: geoScale("projection"), translate: geo_projection_translate}',
+          update: '{x: x(unit), y: y(unit), scale: geoScale("projection"), translate: geoTranslate("projection")}',
         },
       ]);
 
@@ -309,7 +309,7 @@ describe('Zoom Selection Transform', () => {
       expect(fit.on).toEqual(
         expect.arrayContaining([
           {
-            events: parseSelector('wheel!', 'scope'),
+            events: {signal: 'geo_zoom_delta'},
             update: 'null',
           },
         ]),


### PR DESCRIPTION
close #3306

This enables `bind: "scales"` (pan and zoom via `interval` selection) for geographic/cartographic projections, so viewers can drag to pan and scroll to zoom on projected maps just like they can with regular scatter plots.

Previously, using `params: [{name: "mapNav", select: {type: "interval"}, bind: "scales"}]` on a view with a `projection` and `longitude`/`latitude` (or `geoshape`) encodings would produce a runtime error (`Unrecognized signal name: "mapNav_projection_fit"`) because the necessary Vega signals were never generated for projected views.

This currently does not support layering of another marks or multiviews. There are also some projections that should probably have panning mapped to rotation instead of the current default. I intentionally wanted to keep this PR as simple as possible to get feedback on the behavior and the implementation; all the remaining functionality could come in follow up PRs.

One behavioral issue I see currently is that I'm not sure is that for some projections, there is a small "jump" when starting to either pan or zoom from the initial position (or from reset after doubleclick). It seems like the signals responsible for the panning are updating to the correct values, so the issue lies elsewhere and I can't figure out where it is coming from. You can see an example in the animation below when I switch to the mercator projection. When I'm dragging with the pointer upwards, there is first a small "jump" downwards:

<img width="778" height="674" alt="recording-2026-04-18_12 23 40-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/beccc2a4-2982-411c-9c9c-a408222cfb68" />

In the animation below, you can also see that when zooming close to the edge there is sometimes an initial step of panning only with no zoom so the view gets closer to the mouse pointer. That's not as disruptive as the "pan in the wrong direction" mentioned above, but still seems like a bug and there should at least be some zoom in the initial step (and I don't see this when panning charts without geoshape marks). It happens for both projections in the clip:

<img width="778" height="674" alt="recording-2026-04-18_12 26 04-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/fc016ac7-f5ed-4cde-9875-2427170e1731" />

```json

{
  "width": 600,
  "height": 250,
  "params": [
    {
      "name": "projection",
      "value": "equalEarth",
      "bind": {
        "input": "select",
        "options": [
          "albers",
          "albersUsa",
          "azimuthalEqualArea",
          "azimuthalEquidistant",
          "conicConformal",
          "conicEqualArea",
          "conicEquidistant",
          "equalEarth",
          "equirectangular",
          "gnomonic",
          "mercator",
          "naturalEarth1",
          "orthographic",
          "stereographic",
          "transverseMercator"
        ]
      }
    },
    { "name": "geo", "select": { "type": "interval" }, "bind": "scales" }
  ],
  "data": {
    "url": "data/world-110m.json",
    "format": {"type": "topojson", "feature": "countries"}
  },
  "projection": {"type": {"expr": "projection"}},
  "mark": {"type": "geoshape", "fill": "lightgray", "stroke": "gray"}
}
```
One limitation is that some views lend themselves best to rotation rather than panning, e.g. the orthographic/sphere, but that is outside scope for this PR. A follow up could maybe include something like this to indicate what type of panning should be executed:

```json
{
  "name": "nav",
  "select": {
    "type": "interval",
    "pan": "rotate"
  },
  "bind": "scales"
}
```
