### PR TITLE
refactor: simplify isDiscrete and isContinuous

### DIFF
--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -868,6 +868,7 @@ export function vgField(
 }
 
 export function isDiscrete(def: TypedFieldDef<Field> | DatumDef<any, any>) {
+  if (!def.type) return false;
   switch (def.type) {
     case 'nominal':
     case 'ordinal':
@@ -879,6 +880,10 @@ export function isDiscrete(def: TypedFieldDef<Field> | DatumDef<any, any>) {
       return false;
   }
   throw new Error(log.message.invalidFieldType(def.type));
+}
+
+export function isContinuous(def: TypedFieldDef<Field> | DatumDef<any, any>) {
+  return !!def.type && !isDiscrete(def);
 }
 
 export function isDiscretizing(def: TypedFieldDef<Field> | DatumDef<any, any>) {

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -31,6 +31,7 @@ import {
 import {
   getBandPosition,
   getFieldOrDatumDef,
+  isDiscrete,
   isFieldDef,
   isFieldOrDatumDef,
   ScaleDatumDef,
@@ -54,7 +55,6 @@ import {
   Scheme,
 } from '../../scale.js';
 import {getStepFor, isStep, LayoutSizeMixins, Step} from '../../spec/base.js';
-import {isDiscrete} from '../../type.js';
 import * as util from '../../util.js';
 import {isSignalRef, VgRange} from '../../vega.schema.js';
 import {exprFromSignalRefOrValue, signalOrStringValue} from '../common.js';
@@ -366,7 +366,7 @@ function getPositionStep(step: Step, model: UnitModel, channel: PositionScaleCha
   const mergedScaleCmpt = model.getScaleComponent(channel);
   const offsetChannel = getOffsetScaleChannel(channel);
   const offsetDef = encoding[offsetChannel];
-  const stepFor = getStepFor({step, offsetIsDiscrete: isFieldOrDatumDef(offsetDef) && isDiscrete(offsetDef.type)});
+  const stepFor = getStepFor({step, offsetIsDiscrete: isFieldOrDatumDef(offsetDef) && isDiscrete(offsetDef)});
 
   if (stepFor === 'offset' && channelHasFieldOrDatum(encoding, offsetChannel)) {
     const offsetScaleCmpt = model.getScaleComponent(offsetChannel);

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -63,7 +63,9 @@ import {
   initChannelDef,
   initFieldDef,
   isConditionalDef,
+  isContinuous,
   isDatumDef,
+  isDiscrete,
   isFieldDef,
   isOrderOnlyDef,
   isTypedFieldDef,
@@ -94,7 +96,7 @@ import * as log from './log/index.js';
 import {Mark} from './mark.js';
 import {EncodingFacetMapping} from './spec/facet.js';
 import {AggregatedFieldDef, BinTransform, TimeUnitTransform} from './transform.js';
-import {isContinuous, isDiscrete, QUANTITATIVE, TEMPORAL} from './type.js';
+import {QUANTITATIVE, TEMPORAL} from './type.js';
 import {keys, some} from './util.js';
 import {isSignalRef} from './vega.schema.js';
 import {isBinnedTimeUnit} from './timeunit.js';
@@ -371,7 +373,7 @@ export function channelHasNestedOffsetScale<F extends Field>(
     const fieldDef = encoding[channel];
     if (
       (isFieldDef(fieldDef) || isDatumDef(fieldDef)) &&
-      (isDiscrete(fieldDef.type) || (isFieldDef(fieldDef) && fieldDef.timeUnit))
+      (isDiscrete(fieldDef) || (isFieldDef(fieldDef) && fieldDef.timeUnit))
     ) {
       const offsetChannel = getOffsetScaleChannel(channel);
       return channelHasFieldOrDatum(encoding, offsetChannel);
@@ -554,7 +556,7 @@ export function initEncoding(
 
       const positionDef = normalizedEncoding[mainChannel];
       if (isFieldDef(positionDef)) {
-        if (isContinuous(positionDef.type)) {
+        if (isContinuous(positionDef)) {
           if (isFieldDef(channelDef) && !positionDef.timeUnit) {
             // TODO: nesting continuous field instead continuous field should
             // behave like offsetting the data in data domain

--- a/src/type.ts
+++ b/src/type.ts
@@ -18,9 +18,11 @@ export function isType(t: any): t is Type {
   return hasOwnProperty(Type, t);
 }
 
-export function isContinuous(type: Type): type is 'quantitative' | 'temporal' {
-  return type === 'quantitative' || type === 'temporal';
-}
+/**
+ * Type-only discrete check (does not consider binning).
+ * For a field-aware version that treats binned quantitative as discrete,
+ * use `isDiscrete` from `./channeldef.js`.
+ */
 export function isDiscrete(type: Type): type is 'ordinal' | 'nominal' {
   return type === 'ordinal' || type === 'nominal';
 }

--- a/test/channeldef.test.ts
+++ b/test/channeldef.test.ts
@@ -7,6 +7,8 @@ import {
   defaultType,
   functionalTitleFormatter,
   initChannelDef,
+  isContinuous,
+  isDiscrete,
   TypedFieldDef,
   vgField,
 } from '../src/channeldef.js';
@@ -344,5 +346,81 @@ describe('fieldDef', () => {
       const fieldDef = {field: 'f', type: TEMPORAL};
       expect(defaultTitle(fieldDef, {})).toBe('f');
     });
+  });
+});
+
+describe('isDiscrete()', () => {
+  it('returns true for nominal field def', () => {
+    expect(isDiscrete({field: 'f', type: 'nominal'})).toBe(true);
+  });
+
+  it('returns true for ordinal field def', () => {
+    expect(isDiscrete({field: 'f', type: 'ordinal'})).toBe(true);
+  });
+
+  it('returns true for geojson field def', () => {
+    expect(isDiscrete({field: 'f', type: 'geojson'})).toBe(true);
+  });
+
+  it('returns false for temporal field def', () => {
+    expect(isDiscrete({field: 'f', type: 'temporal'})).toBe(false);
+  });
+
+  it('returns false for unbinned quantitative field def', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative'})).toBe(false);
+  });
+
+  it('returns true for binned quantitative field def (bin: true)', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative', bin: true})).toBe(true);
+  });
+
+  it('returns true for pre-binned quantitative field def (bin: "binned")', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative', bin: 'binned'})).toBe(true);
+  });
+
+  it('returns true for quantitative field def with bin params', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative', bin: {maxbins: 10}})).toBe(true);
+  });
+
+  it('returns false for quantitative datum def (datum defs cannot be binned)', () => {
+    expect(isDiscrete({datum: 1, type: 'quantitative'})).toBe(false);
+  });
+
+  it('returns true for nominal datum def', () => {
+    expect(isDiscrete({datum: 'a', type: 'nominal'})).toBe(true);
+  });
+
+  it('returns false for datum def without explicit type', () => {
+    expect(isDiscrete({datum: 1} as any)).toBe(false);
+  });
+});
+
+describe('isContinuous()', () => {
+  it('returns true for unbinned quantitative field def', () => {
+    expect(isContinuous({field: 'f', type: 'quantitative'})).toBe(true);
+  });
+
+  it('returns true for temporal field def', () => {
+    expect(isContinuous({field: 'f', type: 'temporal'})).toBe(true);
+  });
+
+  it('returns false for binned quantitative field def', () => {
+    expect(isContinuous({field: 'f', type: 'quantitative', bin: true})).toBe(false);
+  });
+
+  it('returns false for nominal field def', () => {
+    expect(isContinuous({field: 'f', type: 'nominal'})).toBe(false);
+  });
+
+  it('returns false for ordinal field def', () => {
+    expect(isContinuous({field: 'f', type: 'ordinal'})).toBe(false);
+  });
+
+  it('returns false for geojson field def', () => {
+    expect(isContinuous({field: 'f', type: 'geojson'})).toBe(false);
+  });
+
+  it('returns false for datum def without explicit type', () => {
+    expect(isContinuous({datum: 1} as any)).toBe(false);
   });
 });

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -13,6 +13,7 @@ import {
 import {isPositionFieldOrDatumDef} from '../src/channeldef.js';
 import {defaultConfig} from '../src/config.js';
 import {
+  channelHasNestedOffsetScale,
   Encoding,
   extractTransformsFromEncoding,
   fieldDefs,
@@ -122,6 +123,20 @@ describe('encoding', () => {
         x: {field: 'a', type: 'temporal', timeUnit: {unit: 'year'}},
         xOffset: {field: 'b', type: 'nominal'},
       });
+    });
+
+    it('does not drop xOffset if x is binned quantitative (treated as discrete)', () => {
+      const encoding = initEncoding(
+        {
+          x: {field: 'a', type: 'quantitative', bin: true},
+          xOffset: {field: 'b', type: 'nominal'},
+        },
+        'point',
+        false,
+        defaultConfig,
+      );
+
+      expect(encoding.xOffset).toBeDefined();
     });
   });
 
@@ -559,6 +574,69 @@ describe('encoding', () => {
         {field: 'foo', type: 'quantitative'},
         {field: 'bar', test: 'datum.val > 12', type: 'quantitative'},
       ]);
+    });
+  });
+
+  describe('channelHasNestedOffsetScale', () => {
+    it('returns true for nominal x with xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'nominal'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for ordinal x with xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'ordinal'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for binned quantitative x with xOffset (treated as discrete)', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'quantitative', bin: true}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for unbinned quantitative x with xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'quantitative'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false when offset channel is missing', () => {
+      expect(channelHasNestedOffsetScale<string>({x: {field: 'a', type: 'nominal'}}, 'x')).toBe(false);
+    });
+
+    it('returns true for temporal x with timeUnit and xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'temporal', timeUnit: 'year'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
+    });
+
+    it('treats geojson x as discrete with xOffset (rarely used on position channels)', () => {
+      // geojson is not typically used as a position channel; this asserts that
+      // the field-aware isDiscrete migration treats it consistently with how
+      // channeldef.isDiscrete classifies it (true).
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'geojson'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Closes #9596.

## Summary

Migrate three callsites from the type-only `isDiscrete` / `isContinuous` in `src/type.ts` to the field-aware `isDiscrete` (binning-aware) plus a new mirror `isContinuous` in `src/channeldef.ts`:

- `channelHasNestedOffsetScale` (`src/encoding.ts`)
- `initEncoding` continuous-position warning (`src/encoding.ts`)
- `getPositionStep` `offsetIsDiscrete` (`src/compile/scale/range.ts`)

`tooltipRefForEncoding` (`src/compile/mark/encode/tooltip.ts`) keeps the type-only `isDiscrete` because it wants the bin-range tooltip format for binned quantitative fields, not the discrete array-join format (an existing tooltip test caught this when a full migration was attempted).

Added `if (!def.type) return false` guard to `channeldef.isDiscrete` so a `DatumDef` without an explicit type returns `false` silently (matching the prior type-only behavior) instead of throwing.

## Notable behavior changes

For the three migrated callsites:
- **Binned quantitative** fields are now classified as discrete. This affects how `channelHasNestedOffsetScale`, the continuous-position warning, and `getPositionStep` treat e.g. `x: {type: 'quantitative', bin: true}` with an offset. Covered by new tests.
- **`geojson`** is now classified as discrete in those callsites (vs neither under the type-only version). `geojson` is not used on position/offset channels in practice, but the change is documented and covered by a `channelHasNestedOffsetScale` test.

## Test plan

- 11 progression cases for `isDiscrete` (FieldDef/DatumDef × all 5 types × binning variants) in `test/channeldef.test.ts`
- 7 cases for the new `isContinuous` mirror
- 7 direct cases for `channelHasNestedOffsetScale` (ordinal, nominal, binned-quantitative, unbinned-quantitative, missing offset, temporal+timeUnit, geojson)
- 1 case asserting `xOffset` is preserved when `x` is binned quantitative
- Full suite: 3264 unit + 3253 examples passing locally; lint + schema clean