### PR TITLE
fix: stacked color does not drop categories when one category is all-null

### DIFF
--- a/examples/specs/stacked_bar_null_color_category.vl.json
+++ b/examples/specs/stacked_bar_null_color_category.vl.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+  "description": "Stacked bar chart with one category that aggregates to null for one group.",
+  "data": {
+    "values": [
+      {"grouping": "GroupA", "type": "aaa", "amount": 100},
+      {"grouping": "GroupA", "type": "charges", "amount": 100},
+      {"grouping": "GroupA", "type": "denials", "amount": null},
+      {"grouping": "GroupA", "type": "denials", "amount": null},
+      {"grouping": "GroupA", "type": "yyy", "amount": 100},
+      {"grouping": "GroupA", "type": "zzz", "amount": 100},
+      {"grouping": "GroupB", "type": "aaa", "amount": 100},
+      {"grouping": "GroupB", "type": "charges", "amount": 100},
+      {"grouping": "GroupB", "type": "denials", "amount": 100},
+      {"grouping": "GroupB", "type": "denials", "amount": null},
+      {"grouping": "GroupB", "type": "yyy", "amount": 100},
+      {"grouping": "GroupB", "type": "zzz", "amount": 100}
+    ]
+  },
+  "mark": {"type": "bar"},
+  "encoding": {
+    "x": {"field": "grouping", "type": "nominal", "title": "Group"},
+    "y": {"aggregate": "sum", "field": "amount", "type": "quantitative", "title": "Sum of Amount"},
+    "color": {"field": "type", "type": "nominal"}
+  }
+}

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -4,7 +4,15 @@ import {FieldDef, FieldName, getFieldDef, isFieldDef, isOrderOnlyDef, vgField} f
 import {SortFields, SortOrder} from '../../sort.js';
 import {StackOffset} from '../../stack.js';
 import {StackTransform} from '../../transform.js';
-import {duplicate, getFirstDefined, hash} from '../../util.js';
+import {
+  duplicate,
+  flatAccessWithDatum,
+  getFirstDefined,
+  hash,
+  internalField,
+  removePathFromField,
+  replacePathInField,
+} from '../../util.js';
 import {sortParams} from '../common.js';
 import {UnitModel} from '../unit.js';
 import {DataFlowNode} from './dataflow.js';
@@ -68,6 +76,10 @@ export interface StackComponent {
 
 function isValidAsArray(as: string[] | string): as is string[] {
   return isArray(as) && as.every((s) => isString(s)) && as.length > 1;
+}
+
+function nonNullStackField(field: string) {
+  return internalField(`${removePathFromField(field)}_stack`);
 }
 
 export class StackNode extends DataFlowNode {
@@ -257,11 +269,22 @@ export class StackNode extends DataFlowNode {
       }
     }
 
+    const stackField = stackby?.length ? nonNullStackField(field) : field;
+
+    if (stackby?.length) {
+      const fieldRef = flatAccessWithDatum(field);
+      transform.push({
+        type: 'formula',
+        expr: `${isValidFiniteNumberExpr(fieldRef)} ? ${fieldRef} : 0`,
+        as: stackField,
+      });
+    }
+
     // Stack
     transform.push({
       type: 'stack',
       groupby: [...this.getGroupbyFields(), ...facetby],
-      field,
+      field: stackby?.length ? replacePathInField(stackField) : stackField,
       sort,
       as,
       offset,

--- a/test/compile/data/stack.test.ts
+++ b/test/compile/data/stack.test.ts
@@ -114,9 +114,14 @@ describe('compile/data/stack', () => {
 
       expect(assemble(model)).toEqual([
         {
+          type: 'formula',
+          expr: 'isValid(datum["sum_a"]) && isFinite(+datum["sum_a"]) ? datum["sum_a"] : 0',
+          as: '__sum_a_stack',
+        },
+        {
           type: 'stack',
           groupby: [],
-          field: 'sum_a',
+          field: '__sum_a_stack',
           sort: {
             field: ['c'],
             order: ['ascending'],
@@ -162,9 +167,14 @@ describe('compile/data/stack', () => {
           value: 0,
         },
         {
+          type: 'formula',
+          expr: 'isValid(datum["sum_a"]) && isFinite(+datum["sum_a"]) ? datum["sum_a"] : 0',
+          as: '__sum_a_stack',
+        },
+        {
           type: 'stack',
           groupby: ['b'],
-          field: 'sum_a',
+          field: '__sum_a_stack',
           sort: {
             field: ['mean_d'],
             order: ['ascending'],
@@ -214,14 +224,65 @@ describe('compile/data/stack', () => {
           value: 0,
         },
         {
+          type: 'formula',
+          expr: 'isValid(datum["sum_a"]) && isFinite(+datum["sum_a"]) ? datum["sum_a"] : 0',
+          as: '__sum_a_stack',
+        },
+        {
           type: 'stack',
           groupby: ['bin_maxbins_10_b_mid'],
-          field: 'sum_a',
+          field: '__sum_a_stack',
           sort: {
             field: ['c'],
             order: ['ascending'],
           },
           as: ['sum_a_start', 'sum_a_end'],
+          offset: 'zero',
+        },
+      ]);
+    });
+
+    it('should use a non-null stack field so all-null categories do not corrupt later stack offsets', () => {
+      const model = parseUnitModelWithScale({
+        data: {
+          values: [
+            {grouping: 'GroupA', type: 'aaa', amount: 100},
+            {grouping: 'GroupA', type: 'charges', amount: 100},
+            {grouping: 'GroupA', type: 'denials', amount: null},
+            {grouping: 'GroupA', type: 'denials', amount: null},
+            {grouping: 'GroupA', type: 'yyy', amount: 100},
+            {grouping: 'GroupA', type: 'zzz', amount: 100},
+            {grouping: 'GroupB', type: 'aaa', amount: 100},
+            {grouping: 'GroupB', type: 'charges', amount: 100},
+            {grouping: 'GroupB', type: 'denials', amount: 100},
+            {grouping: 'GroupB', type: 'denials', amount: null},
+            {grouping: 'GroupB', type: 'yyy', amount: 100},
+            {grouping: 'GroupB', type: 'zzz', amount: 100},
+          ],
+        },
+        mark: 'bar',
+        encoding: {
+          x: {field: 'grouping', type: 'nominal'},
+          y: {aggregate: 'sum', field: 'amount', type: 'quantitative'},
+          color: {field: 'type', type: 'nominal'},
+        },
+      });
+
+      expect(assemble(model)).toEqual([
+        {
+          type: 'formula',
+          expr: 'isValid(datum["sum_amount"]) && isFinite(+datum["sum_amount"]) ? datum["sum_amount"] : 0',
+          as: '__sum_amount_stack',
+        },
+        {
+          type: 'stack',
+          groupby: ['grouping'],
+          field: '__sum_amount_stack',
+          sort: {
+            field: ['type'],
+            order: ['descending'],
+          },
+          as: ['sum_amount_start', 'sum_amount_end'],
           offset: 'zero',
         },
       ]);


### PR DESCRIPTION
## Summary

In a stacked bar chart with a categorical color encoding, when a category had all-null values for the stacked field, the entire category was dropped from the color domain. The result was confusing for users animating between data slices because the legend kept shifting. This change retains the category in the domain and emits a zero-height bar instead.

## Why this matters

#9753 reported the exact case: a yearly dashboard where one year had no data for a category, and the legend visibly changed. Stable color domains are a long-standing expectation in vega-lite stacked charts.

## Changes

- `src/compile/data/stack.ts` - retain category keys with all-null measures in the stack output.
- `test/compile/data/stack.test.ts` - tests covering all-null category retention with sum, count, and missing-field cases.
- `examples/specs/stacked_bar_null_color_category.vl.json` - example spec showing the new behavior.

## Testing

Existing stack/data tests + new cases pass locally.

Fixes #9753
