### PR TITLE
docs: fix documentation for heatmap default color scheme

### DIFF
--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -163,7 +163,7 @@ By default, Vega-Lite assigns different [default color schemes](#range-config) b
 
 <div class="vl-example" data-name="point_color_ordinal"></div>
 
-- _Quantitative_ and _temporal_ fields use the [pre-defined named color range](#range-config) `"heatmap"` (the [`"viridis"`](https://vega.github.io/vega/docs/schemes/#viridis) scheme by default) for rect marks and `"ramp"` (the [`"blues"`](https://vega.github.io/vega/docs/schemes/#blues) scheme by default) for other marks.
+- _Quantitative_ and _temporal_ fields use the [pre-defined named color range](#range-config) `"heatmap"` (the [`"yellowgreenblue"`](https://vega.github.io/vega/docs/schemes/#yellowgreenblue) scheme by default) for rect marks and `"ramp"` (the [`"blues"`](https://vega.github.io/vega/docs/schemes/#blues) scheme by default) for other marks.
 
 <div class="vl-example" data-name="rect_heatmap"></div>
 


### PR DESCRIPTION
This PR fixes the incorrect claim in the docs that `"viridis"` is used for the `"heatmap"` color scheme.

### Exhibit 1:

Screenshot from https://vega.github.io/vega-lite/docs/scale.html#range-config. It doesn't look like viridis but something like `"yellowgreenblue"`.

<img width="1620" height="604" alt="image" src="https://github.com/user-attachments/assets/2dd02258-5a5e-4380-8cd6-e194220fcec7" />

### Exhibit 2:

Vega-Lite delegates the actual scheme selection to Vega, which defaults to "yellowgreenblue".

https://github.com/vega/vega/blob/f436c6727018c7bfb41dce846b5746f7a494f7cd/packages/vega-parser/src/config.js#L222-L224

