### PR TITLE
feat: add wordcloud composite mark and transform

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -5209,6 +5209,9 @@
         },
         {
           "$ref": "#/definitions/ErrorBand"
+        },
+        {
+          "$ref": "#/definitions/WordCloud"
         }
       ]
     },
@@ -5222,6 +5225,9 @@
         },
         {
           "$ref": "#/definitions/ErrorBandDef"
+        },
+        {
+          "$ref": "#/definitions/WordcloudDef"
         }
       ]
     },
@@ -7839,6 +7845,10 @@
         "view": {
           "$ref": "#/definitions/ViewConfig",
           "description": "Default properties for [single view plots](https://vega.github.io/vega-lite/docs/spec.html#single)."
+        },
+        "wordcloud": {
+          "$ref": "#/definitions/WordcloudConfig",
+          "description": "Wordcloud Config"
         }
       },
       "type": "object"
@@ -31330,6 +31340,9 @@
         },
         {
           "$ref": "#/definitions/PivotTransform"
+        },
+        {
+          "$ref": "#/definitions/WordcloudTransform"
         }
       ]
     },
@@ -32452,6 +32465,293 @@
       },
       "required": [
         "window"
+      ],
+      "type": "object"
+    },
+    "WordCloud": {
+      "const": "wordcloud",
+      "type": "string"
+    },
+    "WordcloudConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "font": {
+          "description": "The font family for words. __Default value:__ `\"sans-serif\"`",
+          "type": "string"
+        },
+        "fontSizeRange": {
+          "description": "The [min, max] range of font sizes for scaling word sizes. __Default value:__ `[10, 56]`",
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "fontStyle": {
+          "description": "The font style. __Default value:__ `\"normal\"`",
+          "type": "string"
+        },
+        "fontWeight": {
+          "description": "The font weight. __Default value:__ `\"normal\"`",
+          "type": "string"
+        },
+        "padding": {
+          "description": "Padding in pixels between words. __Default value:__ `1`",
+          "type": "number"
+        },
+        "spiral": {
+          "description": "The spiral layout algorithm: `\"archimedean\"` or `\"rectangular\"`. __Default value:__ `\"archimedean\"`",
+          "enum": [
+            "archimedean",
+            "rectangular"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "WordcloudDef": {
+      "additionalProperties": false,
+      "properties": {
+        "clip": {
+          "description": "Whether a composite mark be clipped to the enclosing group’s width and height.",
+          "type": "boolean"
+        },
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/Gradient"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Default color.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__\n- This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).\n- The `fill` and `stroke` properties have higher precedence than `color` and will override `color`."
+        },
+        "font": {
+          "description": "The font family for words. __Default value:__ `\"sans-serif\"`",
+          "type": "string"
+        },
+        "fontSize": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "A fixed font size for all words. When omitted, font sizes are scaled from the `size` encoding channel using `fontSizeRange`."
+        },
+        "fontSizeRange": {
+          "description": "The [min, max] range of font sizes for scaling word sizes. __Default value:__ `[10, 56]`",
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "fontStyle": {
+          "description": "The font style. __Default value:__ `\"normal\"`",
+          "type": "string"
+        },
+        "fontWeight": {
+          "description": "The font weight. __Default value:__ `\"normal\"`",
+          "type": "string"
+        },
+        "opacity": {
+          "description": "The opacity (value between [0,1]) of the mark.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "padding": {
+          "description": "Padding in pixels between words. __Default value:__ `1`",
+          "type": "number"
+        },
+        "rotate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Rotation angle for all words in degrees, or an expression. If the `angle` encoding channel is specified, it overrides this setting. __Default value:__ `0`"
+        },
+        "spiral": {
+          "description": "The spiral layout algorithm: `\"archimedean\"` or `\"rectangular\"`. __Default value:__ `\"archimedean\"`",
+          "enum": [
+            "archimedean",
+            "rectangular"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/WordCloud",
+          "description": "The mark type. This could a primitive mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`, `\"area\"`, `\"point\"`, `\"geoshape\"`, `\"rule\"`, and `\"text\"`) or a composite mark type (`\"boxplot\"`, `\"errorband\"`, `\"errorbar\"`)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "WordcloudTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output field names for the wordcloud transform as `[x, y, font, fontSize, fontStyle, fontWeight, angle]`. __Default value:__ `[\"x\", \"y\", \"font\", \"fontSize\", \"fontStyle\", \"fontWeight\", \"angle\"]`",
+          "items": {
+            "$ref": "#/definitions/FieldName"
+          },
+          "maxItems": 7,
+          "minItems": 7,
+          "type": "array"
+        },
+        "font": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The font family for the words. __Default value:__ `\"sans-serif\"`"
+        },
+        "fontSize": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "field": {
+                  "$ref": "#/definitions/FieldName"
+                }
+              },
+              "required": [
+                "field"
+              ],
+              "type": "object"
+            }
+          ],
+          "description": "A fixed font size for all words. When omitted, font size is determined by the data using `fontSizeRange`. Use `{field: \"fieldName\"}` to derive font size from a data field."
+        },
+        "fontSizeRange": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The [min, max] font size range for scaling when font size is data-driven. __Default value:__ `[10, 56]`"
+        },
+        "fontStyle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The font style. __Default value:__ `\"normal\"`"
+        },
+        "fontWeight": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The font weight. __Default value:__ `\"normal\"`"
+        },
+        "padding": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Padding between words in pixels. __Default value:__ `1`"
+        },
+        "rotate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "field": {
+                  "$ref": "#/definitions/FieldName"
+                }
+              },
+              "required": [
+                "field"
+              ],
+              "type": "object"
+            }
+          ],
+          "description": "Rotation angle for words in degrees. Use a number for a fixed angle, or `{field: \"fieldName\"}` for per-word rotation. __Default value:__ `0`"
+        },
+        "size": {
+          "description": "The layout size as [width, height] in pixels. Defaults to the view's width and height signals.",
+          "items": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/definitions/ExprRef"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "spiral": {
+          "description": "The layout spiral algorithm. __Default value:__ `\"archimedean\"`",
+          "enum": [
+            "archimedean",
+            "rectangular"
+          ],
+          "type": "string"
+        },
+        "wordcloud": {
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field containing the words to display."
+        }
+      },
+      "required": [
+        "wordcloud"
       ],
       "type": "object"
     }

--- a/examples/specs/wordcloud_basic.vl.json
+++ b/examples/specs/wordcloud_basic.vl.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+  "description": "A word cloud showing word frequencies. Font size encodes frequency and color distinguishes words.",
+  "width": 500,
+  "height": 300,
+  "data": {
+    "values": [
+      {"word": "vega", "count": 90},
+      {"word": "data", "count": 75},
+      {"word": "visualization", "count": 60},
+      {"word": "chart", "count": 55},
+      {"word": "grammar", "count": 50},
+      {"word": "mark", "count": 45},
+      {"word": "encoding", "count": 40},
+      {"word": "scale", "count": 38},
+      {"word": "transform", "count": 35},
+      {"word": "layer", "count": 30},
+      {"word": "field", "count": 28},
+      {"word": "type", "count": 25},
+      {"word": "color", "count": 22},
+      {"word": "axis", "count": 20},
+      {"word": "legend", "count": 18},
+      {"word": "tooltip", "count": 15},
+      {"word": "filter", "count": 12},
+      {"word": "aggregate", "count": 10},
+      {"word": "bin", "count": 8},
+      {"word": "facet", "count": 7}
+    ]
+  },
+  "mark": "wordcloud",
+  "encoding": {
+    "text": {"field": "word", "type": "nominal"},
+    "size": {"field": "count", "type": "quantitative"},
+    "color": {"field": "word", "type": "nominal"}
+  }
+}

--- a/examples/specs/wordcloud_custom.vl.json
+++ b/examples/specs/wordcloud_custom.vl.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+  "description": "A word cloud with custom configuration: rectangular spiral, custom font size range, and fixed rotation.",
+  "width": 600,
+  "height": 350,
+  "data": {
+    "values": [
+      {"word": "machine", "freq": 100},
+      {"word": "learning", "freq": 95},
+      {"word": "neural", "freq": 80},
+      {"word": "network", "freq": 75},
+      {"word": "deep", "freq": 70},
+      {"word": "model", "freq": 65},
+      {"word": "training", "freq": 60},
+      {"word": "prediction", "freq": 55},
+      {"word": "classification", "freq": 50},
+      {"word": "regression", "freq": 45},
+      {"word": "feature", "freq": 40},
+      {"word": "accuracy", "freq": 35},
+      {"word": "loss", "freq": 30},
+      {"word": "gradient", "freq": 25},
+      {"word": "epoch", "freq": 20}
+    ]
+  },
+  "mark": {
+    "type": "wordcloud",
+    "fontSizeRange": [14, 64],
+    "spiral": "rectangular",
+    "padding": 3,
+    "font": "Georgia"
+  },
+  "encoding": {
+    "text": {"field": "word", "type": "nominal"},
+    "size": {"field": "freq", "type": "quantitative"},
+    "color": {"field": "word", "type": "nominal"}
+  }
+}

--- a/site/docs/mark/mark.md
+++ b/site/docs/mark/mark.md
@@ -36,7 +36,7 @@ The `mark` property of a [single view specification](spec.html#single) can eithe
 
 Vega-Lite supports the following primitive `mark` types: [`"area"`](area.html), [`"bar"`](bar.html), [`"circle"`](circle.html), [`"line"`](line.html), [`"point"`](point.html), [`"rect"`](rect.html), [`"rule"`](rule.html), [`"square"`](square.html), [`"text"`](text.html), [`"tick"`](tick.html), and [`"geoshape"`](geoshape.html). In general, one mark instance is generated per input data element. However, line and area marks represent multiple data elements as a contiguous line or shape.
 
-In addition to primitive marks, Vega-Lite also support composite marks, which are "macros" for complex layered graphics that contain multiple primitive marks. Supported composite mark types include [`"boxplot"`](boxplot.html), [`"errorband"`](errorband.html), [`"errorbar"`](errorbar.html).
+In addition to primitive marks, Vega-Lite also support composite marks, which are "macros" for complex layered graphics that contain multiple primitive marks. Supported composite mark types include [`"boxplot"`](boxplot.html), [`"errorband"`](errorband.html), [`"errorbar"`](errorbar.html), and [`"wordcloud"`](wordcloud.html).
 
 For example, a bar chart has `mark` as a simple string `"bar"`.
 

--- a/site/docs/mark/wordcloud.md
+++ b/site/docs/mark/wordcloud.md
@@ -1,0 +1,84 @@
+---
+layout: docs
+menu: docs
+title: Word Cloud
+permalink: /docs/wordcloud.html
+---
+
+```js
+// Single View Specification
+{
+  "data": ... ,
+  "mark": "wordcloud",
+  "encoding": ... ,
+  ...
+}
+```
+
+A word cloud visualizes a collection of words where the size of each word reflects its frequency or importance. To create a word cloud, set `mark` to `"wordcloud"`.
+
+Vega-Lite's wordcloud mark uses [Vega's built-in wordcloud layout engine](https://vega.github.io/vega/docs/transforms/wordcloud/), which places words without overlap using a spiral placement algorithm.
+
+<!--prettier-ignore-start-->
+## Documentation Overview
+{:.no_toc}
+
+- TOC
+{:toc}
+
+<!--prettier-ignore-end-->
+
+{:#properties}
+
+## Word Cloud Mark Properties
+
+A wordcloud's mark definition contains the following properties:
+
+{% include table.html props="type,font,fontStyle,fontWeight,fontSize,fontSizeRange,rotate,padding,spiral,color,opacity" source="WordcloudDef" %}
+
+{:#encoding}
+
+## Encoding Channels
+
+| Channel   | Description                                                                     |
+| --------- | ------------------------------------------------------------------------------- |
+| `text`    | **Required.** The data field containing the words to display.                   |
+| `size`    | A quantitative field whose values are scaled to font sizes via `fontSizeRange`. |
+| `color`   | Color of each word. Can be a field or a fixed value.                            |
+| `opacity` | Opacity of each word.                                                           |
+| `angle`   | Per-word rotation. Can be a quantitative field or a fixed value (in degrees).   |
+
+{:#basic}
+
+## Basic Word Cloud
+
+A minimal word cloud requires only a `text` encoding. Word sizes are uniform unless a `size` channel is also provided.
+
+<div class="vl-example" data-name="wordcloud_basic"></div>
+
+{:#custom}
+
+## Customizing the Word Cloud
+
+Use the mark definition object to control font, size range, spiral algorithm, and padding.
+
+<div class="vl-example" data-name="wordcloud_custom"></div>
+
+{:#config}
+
+## Word Cloud Config
+
+```js
+// Top-level View Specification
+{
+  "config": {
+    "wordcloud": {
+      "fontSizeRange": [10, 56],  // default font size range
+      "padding": 1,               // default padding between words
+      "spiral": "archimedean"     // default spiral algorithm
+    }
+  }
+}
+```
+
+{% include table.html props="font,fontStyle,fontWeight,fontSizeRange,padding,spiral" source="WordcloudConfig" %}

--- a/site/docs/transform/transform.md
+++ b/site/docs/transform/transform.md
@@ -43,3 +43,4 @@ The View-level `transform` object is an array of objects describing transformati
 - [Stack](stack.html)
 - [Time Unit](timeunit.html#transform)
 - [Window](window.html)
+- [Wordcloud](wordcloud-transform.html)

--- a/site/docs/transform/wordcloud.md
+++ b/site/docs/transform/wordcloud.md
@@ -1,0 +1,74 @@
+---
+layout: docs
+menu: docs
+title: Wordcloud Transform
+permalink: /docs/wordcloud-transform.html
+---
+
+The wordcloud transform computes a non-overlapping word layout using a spiral placement algorithm, adding position, font size, and rotation fields to each data object.
+
+```js
+// Any View Specification
+{
+  ...
+  "transform": [
+    {"wordcloud": "fieldName", ...}  // Wordcloud Transform
+  ],
+  ...
+}
+```
+
+> **Tip:** For most use cases, the [`"wordcloud"` composite mark](wordcloud.html) is simpler — it handles the transform and text mark automatically. Use this transform directly when you need full control over the mark encoding.
+
+## Wordcloud Transform Definition
+
+{% include table.html props="wordcloud,size,font,fontStyle,fontWeight,fontSize,fontSizeRange,rotate,padding,spiral,as" source="WordcloudTransform" %}
+
+## Output Fields
+
+By default, the transform adds the following fields to each datum (configurable via `as`):
+
+| Default field | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `x`           | Computed x position in pixels (centered on layout width / 2)  |
+| `y`           | Computed y position in pixels (centered on layout height / 2) |
+| `font`        | Font family used for the word                                 |
+| `fontSize`    | Computed font size in pixels                                  |
+| `fontStyle`   | Font style                                                    |
+| `fontWeight`  | Font weight                                                   |
+| `angle`       | Rotation angle in degrees                                     |
+
+## Usage
+
+```json
+{
+  "transform": [
+    {
+      "wordcloud": "word",
+      "fontSize": {"field": "count"},
+      "fontSizeRange": [12, 56],
+      "padding": 2,
+      "spiral": "archimedean"
+    }
+  ]
+}
+```
+
+Then use a `text` mark with `x`/`y` value encodings to render the result:
+
+```json
+{
+  "mark": "text",
+  "encoding": {
+    "x": {"value": {"expr": "datum.x"}},
+    "y": {"value": {"expr": "datum.y"}},
+    "text": {"field": "word"},
+    "size": {"value": {"expr": "datum.fontSize"}},
+    "color": {"field": "category", "type": "nominal"}
+  }
+}
+```
+
+### Example: Basic Word Cloud via Transform
+
+<div class="vl-example" data-name="wordcloud_basic"></div>

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -30,6 +30,7 @@ import {SourceNode} from './source.js';
 import {StackNode} from './stack.js';
 import {TimeUnitNode} from './timeunit.js';
 import {WindowTransformNode} from './window.js';
+import {WordcloudTransformNode} from './wordcloud.js';
 import {DataComponent} from './index.js';
 
 function makeWalkTree(data: VgData[]) {
@@ -108,7 +109,8 @@ function makeWalkTree(data: VgData[]) {
       node instanceof IdentifierNode ||
       node instanceof SampleTransformNode ||
       node instanceof PivotTransformNode ||
-      node instanceof ExtentTransformNode
+      node instanceof ExtentTransformNode ||
+      node instanceof WordcloudTransformNode
     ) {
       dataSource.transform.push(node.assemble());
     }

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -33,6 +33,7 @@ import {
   isStack,
   isTimeUnit,
   isWindow,
+  isWordcloud,
 } from '../../transform.js';
 import {deepEqual, mergeDeep} from '../../util.js';
 import {getMarkPropOrConfig} from '../common.js';
@@ -74,6 +75,7 @@ import {SourceNode} from './source.js';
 import {StackNode} from './stack.js';
 import {TimeUnitNode} from './timeunit.js';
 import {WindowTransformNode} from './window.js';
+import {WordcloudTransformNode} from './wordcloud.js';
 
 export function findSource(data: Data, sources: SourceNode[]) {
   for (const other of sources) {
@@ -233,6 +235,9 @@ export function parseTransformArray(head: DataFlowNode, model: Model, ancestorPa
       derivedType = 'derived';
     } else if (isLoess(t)) {
       transformNode = head = new LoessTransformNode(head, t);
+      derivedType = 'derived';
+    } else if (isWordcloud(t)) {
+      transformNode = head = new WordcloudTransformNode(head, t);
       derivedType = 'derived';
     } else {
       log.warn(log.message.invalidTransformIgnored(t));

--- a/src/compile/data/wordcloud.ts
+++ b/src/compile/data/wordcloud.ts
@@ -1,0 +1,73 @@
+import {WordcloudTransform as VgWordcloudTransform} from 'vega';
+import {WordcloudTransform} from '../../transform.js';
+import {duplicate, hash} from '../../util.js';
+import {DataFlowNode} from './dataflow.js';
+
+const WC_DEFAULT_OUTPUT = ['x', 'y', 'font', 'fontSize', 'fontStyle', 'fontWeight', 'angle'] as const;
+
+export class WordcloudTransformNode extends DataFlowNode {
+  public clone() {
+    return new WordcloudTransformNode(null, duplicate(this.transform));
+  }
+
+  constructor(
+    parent: DataFlowNode,
+    private transform: WordcloudTransform,
+  ) {
+    super(parent);
+    this.transform = duplicate(transform);
+    if (!this.transform.as) {
+      this.transform.as = [...WC_DEFAULT_OUTPUT] as [string, string, string, string, string, string, string];
+    }
+  }
+
+  public dependentFields() {
+    const fields = new Set([this.transform.wordcloud]);
+    const {fontSize, rotate} = this.transform;
+    if (typeof fontSize === 'object' && 'field' in fontSize) {
+      fields.add((fontSize as {field: string}).field);
+    }
+    if (typeof rotate === 'object' && 'field' in rotate) {
+      fields.add((rotate as {field: string}).field);
+    }
+    return fields;
+  }
+
+  public producedFields() {
+    return new Set(this.transform.as);
+  }
+
+  public hash() {
+    return `WordcloudTransform ${hash(this.transform)}`;
+  }
+
+  public assemble(): VgWordcloudTransform {
+    const {wordcloud, size, fontSize, rotate, as, ...rest} = this.transform;
+
+    const vgFontSize =
+      fontSize !== undefined
+        ? typeof fontSize === 'object' && 'field' in fontSize
+          ? {field: (fontSize as {field: string}).field}
+          : (fontSize as any)
+        : undefined;
+
+    const vgRotate =
+      rotate !== undefined
+        ? typeof rotate === 'object' && 'field' in rotate
+          ? {field: (rotate as {field: string}).field}
+          : (rotate as any)
+        : undefined;
+
+    const vgSize: any = size ?? [{signal: 'width'}, {signal: 'height'}];
+
+    return {
+      type: 'wordcloud',
+      text: {field: wordcloud},
+      size: vgSize,
+      ...(vgFontSize !== undefined ? {fontSize: vgFontSize} : {}),
+      ...(vgRotate !== undefined ? {rotate: vgRotate} : {}),
+      as: as as any,
+      ...(rest as any),
+    } as VgWordcloudTransform;
+  }
+}

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -272,8 +272,8 @@ export function compositeMarkOrient<M extends CompositeMark>(
   const {mark, encoding} = spec;
   const {x, y} = encoding;
 
-  if (isMarkDef(mark) && mark.orient) {
-    return mark.orient;
+  if (isMarkDef(mark) && 'orient' in mark && (mark as any).orient) {
+    return (mark as any).orient;
   }
 
   if (isContinuousFieldOrDatumDef(x)) {

--- a/src/compositemark/index.ts
+++ b/src/compositemark/index.ts
@@ -24,15 +24,26 @@ import {
   ErrorExtraEncoding,
   normalizeErrorBar,
 } from './errorbar.js';
+import {
+  WORDCLOUD,
+  WordCloud,
+  WordcloudConfigMixins,
+  WordcloudDef,
+  WORDCLOUD_PARTS,
+  normalizeWordcloud,
+} from './wordcloud.js';
 
 export type {BoxPlotConfig} from './boxplot.js';
 export type {ErrorBandConfigMixins} from './errorband.js';
 export type {ErrorBarConfigMixins} from './errorbar.js';
+export type {WordcloudConfigMixins, WordcloudConfig} from './wordcloud.js';
 
 export type CompositeMarkNormalizerRun = (
   spec: GenericUnitSpec<any, any>,
   params: NormalizerParams,
 ) => NormalizedLayerSpec | NormalizedUnitSpec;
+
+export type {WordCloud, WordcloudDef} from './wordcloud.js';
 
 /**
  * Registry index for all composite mark's normalizer
@@ -66,18 +77,20 @@ export type SharedCompositeEncoding<F extends Field> = PartialIndex<
 
 export type FacetedCompositeEncoding<F extends Field> = Encoding<F> & ErrorExtraEncoding<F> & EncodingFacetMapping<F>;
 
-export type CompositeMark = BoxPlot | ErrorBar | ErrorBand;
+export type CompositeMark = BoxPlot | ErrorBar | ErrorBand | WordCloud;
 
 export function getAllCompositeMarks() {
   return keys(compositeMarkRegistry);
 }
 
-export type CompositeMarkDef = BoxPlotDef | ErrorBarDef | ErrorBandDef;
+export type CompositeMarkDef = BoxPlotDef | ErrorBarDef | ErrorBandDef | WordcloudDef;
 
 export type CompositeAggregate = BoxPlot | ErrorBar | ErrorBand;
 
-export interface CompositeMarkConfigMixins extends BoxPlotConfigMixins, ErrorBarConfigMixins, ErrorBandConfigMixins {}
+export interface CompositeMarkConfigMixins
+  extends BoxPlotConfigMixins, ErrorBarConfigMixins, ErrorBandConfigMixins, WordcloudConfigMixins {}
 
 add(BOXPLOT, normalizeBoxPlot, BOXPLOT_PARTS);
 add(ERRORBAR, normalizeErrorBar, ERRORBAR_PARTS);
 add(ERRORBAND, normalizeErrorBand, ERRORBAND_PARTS);
+add(WORDCLOUD, normalizeWordcloud as any, WORDCLOUD_PARTS);

--- a/src/compositemark/wordcloud.ts
+++ b/src/compositemark/wordcloud.ts
@@ -1,0 +1,208 @@
+import {isFieldDef, isValueDef} from '../channeldef.js';
+import {Encoding} from '../encoding.js';
+import {ExprRef} from '../expr.js';
+import {NormalizerParams} from '../normalize/index.js';
+import {GenericUnitSpec, NormalizedUnitSpec} from '../spec/index.js';
+import {WordcloudTransform} from '../transform.js';
+import {CompositeMarkNormalizer} from './base.js';
+import {GenericCompositeMarkDef} from './common.js';
+
+export const WORDCLOUD = 'wordcloud' as const;
+export type WordCloud = typeof WORDCLOUD;
+
+export const WORDCLOUD_PARTS = [] as const;
+
+export interface WordcloudConfig {
+  /**
+   * The font family for words.
+   * __Default value:__ `"sans-serif"`
+   */
+  font?: string;
+
+  /**
+   * The font style.
+   * __Default value:__ `"normal"`
+   */
+  fontStyle?: string;
+
+  /**
+   * The font weight.
+   * __Default value:__ `"normal"`
+   */
+  fontWeight?: string;
+
+  /**
+   * The [min, max] range of font sizes for scaling word sizes.
+   * __Default value:__ `[10, 56]`
+   */
+  fontSizeRange?: [number, number];
+
+  /**
+   * Padding in pixels between words.
+   * __Default value:__ `1`
+   */
+  padding?: number;
+
+  /**
+   * The spiral layout algorithm: `"archimedean"` or `"rectangular"`.
+   * __Default value:__ `"archimedean"`
+   */
+  spiral?: 'archimedean' | 'rectangular';
+}
+
+export type WordcloudDef = GenericCompositeMarkDef<WordCloud> &
+  WordcloudConfig & {
+    /**
+     * Type of the mark. For word clouds, this should always be `"wordcloud"`.
+     */
+    type: WordCloud;
+
+    /**
+     * A fixed font size for all words. When omitted, font sizes are scaled from
+     * the `size` encoding channel using `fontSizeRange`.
+     */
+    fontSize?: number | ExprRef;
+
+    /**
+     * Rotation angle for all words in degrees, or an expression.
+     * If the `angle` encoding channel is specified, it overrides this setting.
+     * __Default value:__ `0`
+     */
+    rotate?: number | ExprRef;
+  };
+
+export interface WordcloudConfigMixins {
+  /**
+   * Wordcloud Config
+   */
+  wordcloud?: WordcloudConfig;
+}
+
+// Internal field name prefix to avoid collision with user data fields
+const WC_PREFIX = '__wc_';
+const WC_FIELDS = {
+  x: `${WC_PREFIX}x`,
+  y: `${WC_PREFIX}y`,
+  font: `${WC_PREFIX}font`,
+  fontSize: `${WC_PREFIX}fontSize`,
+  fontStyle: `${WC_PREFIX}fontStyle`,
+  fontWeight: `${WC_PREFIX}fontWeight`,
+  angle: `${WC_PREFIX}angle`,
+} as const;
+
+const WC_AS: [string, string, string, string, string, string, string] = [
+  WC_FIELDS.x,
+  WC_FIELDS.y,
+  WC_FIELDS.font,
+  WC_FIELDS.fontSize,
+  WC_FIELDS.fontStyle,
+  WC_FIELDS.fontWeight,
+  WC_FIELDS.angle,
+];
+
+export const wordcloudNormalizer = new CompositeMarkNormalizer(WORDCLOUD, normalizeWordcloud);
+
+export function normalizeWordcloud(
+  spec: GenericUnitSpec<Encoding<string>, WordCloud | WordcloudDef>,
+  {config}: NormalizerParams,
+): NormalizedUnitSpec {
+  const {mark, encoding = {}, params, ...outerSpec} = spec;
+  const markDef: WordcloudDef = typeof mark === 'string' ? {type: mark} : mark;
+
+  const wcConfig: WordcloudConfig = config?.wordcloud ?? {};
+
+  // Extract the text field (required for wordcloud)
+  const textEncoding = encoding.text;
+  const textField = textEncoding && isFieldDef(textEncoding) ? textEncoding.field : undefined;
+
+  // Build the wordcloud transform
+  const wcTransform: WordcloudTransform = {
+    wordcloud: textField ?? 'text',
+    as: WC_AS,
+    font: markDef.font ?? wcConfig.font,
+    fontStyle: markDef.fontStyle ?? wcConfig.fontStyle,
+    fontWeight: markDef.fontWeight ?? wcConfig.fontWeight,
+    padding: markDef.padding ?? wcConfig.padding,
+    spiral: markDef.spiral ?? wcConfig.spiral,
+  };
+
+  // Handle fontSize: from size encoding field, markDef, or config
+  const sizeEncoding = encoding.size;
+  if (sizeEncoding && isFieldDef(sizeEncoding) && sizeEncoding.field) {
+    wcTransform.fontSize = {field: sizeEncoding.field as string};
+    wcTransform.fontSizeRange = markDef.fontSizeRange ?? wcConfig.fontSizeRange ?? [10, 56];
+  } else if (markDef.fontSize !== undefined) {
+    wcTransform.fontSize = markDef.fontSize as any;
+  }
+
+  // Handle rotation: from angle encoding or markDef
+  const angleEncoding = encoding.angle;
+  if (angleEncoding && isFieldDef(angleEncoding) && angleEncoding.field) {
+    wcTransform.rotate = {field: angleEncoding.field as string};
+  } else if (angleEncoding && isValueDef(angleEncoding)) {
+    wcTransform.rotate = angleEncoding.value as number;
+  } else if (markDef.rotate !== undefined) {
+    wcTransform.rotate = markDef.rotate as any;
+  }
+
+  // Clean up undefined properties
+  for (const key of Object.keys(wcTransform) as (keyof WordcloudTransform)[]) {
+    if (wcTransform[key] === undefined) {
+      delete wcTransform[key];
+    }
+  }
+
+  // Build the output encoding for the text mark.
+  // x and y use ExprRef values to bypass vega-lite's scale system — the
+  // wordcloud transform already outputs pixel positions.  Using a field
+  // encoding would apply a linear scale that distorts positions and inverts y.
+  const outputEncoding: Encoding<string> = {
+    x: {value: {expr: `datum["${WC_FIELDS.x}"]`} as ExprRef},
+    y: {value: {expr: `datum["${WC_FIELDS.y}"]`} as ExprRef},
+    // Re-use the text field from the original encoding
+    text: textEncoding ?? {field: 'text', type: 'nominal'},
+    // Font size from transform output via ExprRef to bypass size scale
+    size: {value: {expr: `datum["${WC_FIELDS.fontSize}"]`} as ExprRef},
+  };
+
+  // Propagate color encoding if present
+  if (encoding.color) {
+    outputEncoding.color = encoding.color;
+  } else if (markDef.color) {
+    outputEncoding.color = {value: markDef.color} as any;
+  }
+
+  // Propagate opacity encoding if present
+  if (encoding.opacity) {
+    outputEncoding.opacity = encoding.opacity;
+  }
+
+  // Propagate tooltip encoding if present
+  if (encoding.tooltip) {
+    outputEncoding.tooltip = encoding.tooltip;
+  }
+
+  // Propagate href encoding if present
+  if (encoding.href) {
+    outputEncoding.href = encoding.href;
+  }
+
+  // Existing transforms in the spec are prepended; wordcloud runs first
+  const transforms = [wcTransform, ...(outerSpec.transform ?? [])];
+
+  const normalizedSpec: NormalizedUnitSpec = {
+    ...outerSpec,
+    transform: transforms,
+    mark: {
+      type: 'text',
+      align: 'center',
+      baseline: 'alphabetic',
+      ...(markDef.clip !== undefined ? {clip: markDef.clip} : {}),
+      ...(markDef.opacity !== undefined ? {opacity: markDef.opacity} : {}),
+    },
+    encoding: outputEncoding,
+    ...(params ? {params} : {}),
+  };
+
+  return normalizedSpec;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -350,6 +350,12 @@ export const defaultConfig: Config<SignalRef> = {
     borders: false,
   },
 
+  wordcloud: {
+    fontSizeRange: [10, 56],
+    padding: 1,
+    spiral: 'archimedean',
+  },
+
   scale: defaultScaleConfig,
 
   projection: {},

--- a/src/normalize/core.ts
+++ b/src/normalize/core.ts
@@ -6,6 +6,7 @@ import {SharedCompositeEncoding} from '../compositemark/index.js';
 import {boxPlotNormalizer} from '../compositemark/boxplot.js';
 import {errorBandNormalizer} from '../compositemark/errorband.js';
 import {errorBarNormalizer} from '../compositemark/errorbar.js';
+import {wordcloudNormalizer} from '../compositemark/wordcloud.js';
 import {channelHasField, Encoding} from '../encoding.js';
 import {ExprRef} from '../expr.js';
 import * as log from '../log/index.js';
@@ -38,6 +39,7 @@ export class CoreNormalizer extends SpecMapper<NormalizerParams, FacetedUnitSpec
     boxPlotNormalizer,
     errorBarNormalizer,
     errorBandNormalizer,
+    wordcloudNormalizer,
     new PathOverlayNormalizer(),
     new RuleForRangedLineNormalizer(),
   ];

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,6 +2,7 @@ import type {AggregateOp} from 'vega';
 import {BinParams} from './bin.js';
 import {FieldName} from './channeldef.js';
 import {Data} from './data.js';
+import {ExprRef} from './expr.js';
 import {ImputeParams} from './impute.js';
 import {LogicalComposition, normalizeLogicalComposition} from './logical.js';
 import {ParameterName} from './parameter.js';
@@ -681,6 +682,80 @@ export function isFold(t: Transform): t is FoldTransform {
 export function isExtent(t: Transform): t is ExtentTransform {
   return hasProperty(t, 'extent') && !hasProperty(t, 'density') && !hasProperty(t, 'regression');
 }
+
+export interface WordcloudTransform {
+  /**
+   * The data field containing the words to display.
+   */
+  wordcloud: FieldName;
+
+  /**
+   * The layout size as [width, height] in pixels. Defaults to the view's width and height signals.
+   */
+  size?: [number | ExprRef, number | ExprRef];
+
+  /**
+   * The font family for the words.
+   * __Default value:__ `"sans-serif"`
+   */
+  font?: string | ExprRef;
+
+  /**
+   * The font style.
+   * __Default value:__ `"normal"`
+   */
+  fontStyle?: string | ExprRef;
+
+  /**
+   * The font weight.
+   * __Default value:__ `"normal"`
+   */
+  fontWeight?: string | ExprRef;
+
+  /**
+   * A fixed font size for all words.
+   * When omitted, font size is determined by the data using `fontSizeRange`.
+   * Use `{field: "fieldName"}` to derive font size from a data field.
+   */
+  fontSize?: number | ExprRef | {field: FieldName};
+
+  /**
+   * The [min, max] font size range for scaling when font size is data-driven.
+   * __Default value:__ `[10, 56]`
+   */
+  fontSizeRange?: [number, number] | null;
+
+  /**
+   * Rotation angle for words in degrees.
+   * Use a number for a fixed angle, or `{field: "fieldName"}` for per-word rotation.
+   * __Default value:__ `0`
+   */
+  rotate?: number | ExprRef | {field: FieldName};
+
+  /**
+   * Padding between words in pixels.
+   * __Default value:__ `1`
+   */
+  padding?: number | ExprRef;
+
+  /**
+   * The layout spiral algorithm.
+   * __Default value:__ `"archimedean"`
+   */
+  spiral?: 'archimedean' | 'rectangular';
+
+  /**
+   * The output field names for the wordcloud transform as
+   * `[x, y, font, fontSize, fontStyle, fontWeight, angle]`.
+   * __Default value:__ `["x", "y", "font", "fontSize", "fontStyle", "fontWeight", "angle"]`
+   */
+  as?: [FieldName, FieldName, FieldName, FieldName, FieldName, FieldName, FieldName];
+}
+
+export function isWordcloud(t: Transform): t is WordcloudTransform {
+  return hasProperty(t, 'wordcloud');
+}
+
 export type Transform =
   | AggregateTransform
   | BinTransform
@@ -700,7 +775,8 @@ export type Transform =
   | SampleTransform
   | StackTransform
   | WindowTransform
-  | PivotTransform;
+  | PivotTransform
+  | WordcloudTransform;
 
 export function normalizeTransform(transform: Transform[]) {
   return transform.map((t) => {

--- a/test/compositemark/wordcloud.test.ts
+++ b/test/compositemark/wordcloud.test.ts
@@ -1,0 +1,310 @@
+import {compile} from '../../src/compile/compile.js';
+import {normalize} from '../../src/normalize/index.js';
+import {defaultConfig} from '../../src/config.js';
+
+describe('wordcloud composite mark', () => {
+  describe('normalizeWordcloud', () => {
+    it('normalizes mark string "wordcloud" to a text mark unit spec', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            size: {field: 'count', type: 'quantitative'},
+          },
+        },
+        defaultConfig,
+      );
+
+      expect((output as any).mark.type).toBe('text');
+    });
+
+    it('normalizes mark object {type: "wordcloud"} to a text mark unit spec', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: {type: 'wordcloud'},
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      );
+
+      expect((output as any).mark.type).toBe('text');
+    });
+
+    it('prepends a wordcloud transform using the text encoding field', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            size: {field: 'count', type: 'quantitative'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      const wcTransform = output.transform?.[0];
+      expect(wcTransform).toBeDefined();
+      expect(wcTransform.wordcloud).toBe('word');
+    });
+
+    it('maps size encoding field to wordcloud fontSize parameter', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            size: {field: 'count', type: 'quantitative'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      const wcTransform = output.transform?.[0];
+      expect(wcTransform.fontSize).toEqual({field: 'count'});
+    });
+
+    it('applies default fontSizeRange from config', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            size: {field: 'count', type: 'quantitative'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      const wcTransform = output.transform?.[0];
+      expect(wcTransform.fontSizeRange).toEqual([10, 56]);
+    });
+
+    it('uses custom fontSizeRange from mark def', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: {type: 'wordcloud', fontSizeRange: [8, 80]},
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            size: {field: 'count', type: 'quantitative'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.transform?.[0].fontSizeRange).toEqual([8, 80]);
+    });
+
+    it('uses custom spiral from mark def', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: {type: 'wordcloud', spiral: 'rectangular'},
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.transform?.[0].spiral).toBe('rectangular');
+    });
+
+    it('uses custom font from mark def', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: {type: 'wordcloud', font: 'Georgia'},
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.transform?.[0].font).toBe('Georgia');
+    });
+
+    it('maps angle encoding field to wordcloud rotate parameter', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10, rotation: 45}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            angle: {field: 'rotation', type: 'quantitative'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.transform?.[0].rotate).toEqual({field: 'rotation'});
+    });
+
+    it('maps fixed angle value to wordcloud rotate parameter', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            angle: {value: 45},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.transform?.[0].rotate).toBe(45);
+    });
+
+    it('propagates color encoding to the output spec', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+            color: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.encoding?.color).toEqual({field: 'word', type: 'nominal'});
+    });
+
+    it('encodes x and y as ExprRef values to bypass scale system', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.encoding?.x?.value?.expr).toContain('__wc_x');
+      expect(output.encoding?.y?.value?.expr).toContain('__wc_y');
+    });
+
+    it('encodes size as ExprRef to use raw computed font size', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.encoding?.size?.value?.expr).toContain('__wc_fontSize');
+    });
+
+    it('preserves existing transforms, placing wordcloud first', () => {
+      const output = normalize(
+        {
+          data: {values: [{word: 'hello', count: 10}]},
+          mark: 'wordcloud',
+          transform: [{filter: 'datum.count > 5'}],
+          encoding: {
+            text: {field: 'word', type: 'nominal'},
+          },
+        },
+        defaultConfig,
+      ) as any;
+
+      expect(output.transform?.[0].wordcloud).toBeDefined();
+      expect(output.transform?.[1]).toEqual({filter: 'datum.count > 5'});
+    });
+  });
+
+  describe('compile wordcloud', () => {
+    it('compiles to a Vega spec with a wordcloud data transform', () => {
+      const result = compile({
+        data: {values: [{word: 'hello', count: 10}]},
+        mark: 'wordcloud',
+        encoding: {
+          text: {field: 'word', type: 'nominal'},
+          size: {field: 'count', type: 'quantitative'},
+        },
+      });
+
+      const vgSpec = result.spec;
+      const wcTransform = vgSpec.data
+        ?.find((d: any) => d.transform?.some((t: any) => t.type === 'wordcloud'))
+        ?.transform?.find((t: any) => t.type === 'wordcloud');
+
+      expect(wcTransform).toBeDefined();
+      expect(wcTransform.type).toBe('wordcloud');
+      expect(wcTransform.text).toEqual({field: 'word'});
+      expect(wcTransform.fontSize).toEqual({field: 'count'});
+    });
+
+    it('compiled Vega spec uses signal expressions for x/y (no positional scales)', () => {
+      const result = compile({
+        data: {values: [{word: 'hello', count: 10}]},
+        mark: 'wordcloud',
+        encoding: {
+          text: {field: 'word', type: 'nominal'},
+          size: {field: 'count', type: 'quantitative'},
+        },
+      });
+
+      const vgSpec = result.spec;
+      const mark = vgSpec.marks?.[0] as any;
+
+      expect(mark.encode.update.x.signal).toContain('__wc_x');
+      expect(mark.encode.update.y.signal).toContain('__wc_y');
+      expect(mark.encode.update.fontSize.signal).toContain('__wc_fontSize');
+
+      // No x or y positional scales should be present
+      const scaleNames = vgSpec.scales?.map((s: any) => s.name) ?? [];
+      expect(scaleNames).not.toContain('x');
+      expect(scaleNames).not.toContain('y');
+    });
+
+    it('compiled Vega wordcloud transform uses view width/height signals by default', () => {
+      const result = compile({
+        width: 600,
+        height: 400,
+        data: {values: [{word: 'hello', count: 10}]},
+        mark: 'wordcloud',
+        encoding: {
+          text: {field: 'word', type: 'nominal'},
+        },
+      });
+
+      const vgSpec = result.spec;
+      const wcTransform = vgSpec.data
+        ?.find((d: any) => d.transform?.some((t: any) => t.type === 'wordcloud'))
+        ?.transform?.find((t: any) => t.type === 'wordcloud');
+
+      expect(wcTransform.size).toEqual([{signal: 'width'}, {signal: 'height'}]);
+    });
+
+    it('compiled Vega spec text mark has center alignment', () => {
+      const result = compile({
+        data: {values: [{word: 'hello', count: 10}]},
+        mark: 'wordcloud',
+        encoding: {
+          text: {field: 'word', type: 'nominal'},
+        },
+      });
+
+      const mark = result.spec.marks?.[0] as any;
+      expect(mark.encode.update.align?.value).toBe('center');
+    });
+  });
+});


### PR DESCRIPTION
<html><head></head><body><h2>feat: add wordcloud composite mark and transform</h2><h3>Summary</h3><p>This PR adds native <strong>word cloud support</strong> to Vega-Lite through:</p><ol><li><p>A new <strong><code inline="">wordcloud</code> composite mark</strong> (recommended API)</p></li><li><p>A standalone <strong><code inline="">wordcloud</code> data transform</strong> for advanced customization</p></li></ol><p>The implementation leverages Vega’s built-in <code inline="">vega-wordcloud</code> layout engine, which already exists as a peer dependency, so no additional runtime dependency is introduced.</p><hr><h2>Motivation</h2><p>Word clouds are a widely adopted visualization for representing text frequency and prominence.</p><p>Although libraries such as Python’s <code inline="">wordcloud</code> have popularized this chart type, Vega-Lite currently lacks native support. Since Vega already bundles <code inline="">vega-wordcloud</code>, this change exposes that capability through a high-level Vega-Lite interface while remaining consistent with existing Vega-Lite architecture.</p><hr><h2>Usage</h2><h3>Composite mark (recommended)</h3><pre><code class="language-json">{
  "mark": "wordcloud",
  "encoding": {
    "text": {"field": "word"},
    "size": {"field": "count", "type": "quantitative"},
    "color": {"field": "word", "type": "nominal"}
  }
}
</code></pre><h3>Composite mark with configuration</h3><pre><code class="language-json">{
  "mark": {
    "type": "wordcloud",
    "fontSizeRange": [14, 64],
    "spiral": "rectangular",
    "padding": 3,
    "font": "Georgia"
  },
  "encoding": {
    "text": {"field": "word"},
    "size": {"field": "count", "type": "quantitative"}
  }
}
</code></pre><h3>Standalone transform (advanced usage)</h3><pre><code class="language-json">{
  "transform": [
    {
      "wordcloud": "word",
      "fontSize": {"field": "count"},
      "fontSizeRange": [10, 56],
      "spiral": "archimedean"
    }
  ],
  "mark": "text",
  "encoding": {
    "x": {"value": {"expr": "datum.x"}},
    "y": {"value": {"expr": "datum.y"}},
    "text": {"field": "word"},
    "size": {"value": {"expr": "datum.fontSize"}}
  }
}

<h2>Supported Encoding Channels</h2>
Channel | Description
-- | --
text | Required. Field containing words to display
size | Quantitative field mapped to font sizes via fontSizeRange
color | Word color (field or fixed value)
opacity | Word opacity
angle | Per-word rotation (field or fixed degrees)

<html><head></head><body><p>Use proper GitHub Markdown formatting like this:</p><h2>Supported Mark Definition Options</h2><ul><li><p><code inline="">fontSizeRange</code></p></li><li><p><code inline="">spiral</code> (<code inline="">archimedean</code> | <code inline="">rectangular</code>)</p></li><li><p><code inline="">padding</code></p></li><li><p><code inline="">font</code></p></li><li><p><code inline="">fontStyle</code></p></li><li><p><code inline="">fontWeight</code></p></li><li><p><code inline="">fontSize</code></p></li><li><p><code inline="">rotate</code></p></li></ul><hr><h2>Implementation Notes</h2><ul><li><p>Follows the existing composite mark architecture used by <code inline="">boxplot</code>, <code inline="">errorbar</code>, and <code inline="">errorband</code>.</p></li><li><p>Normalizes into a standard text mark unit spec before standard compilation.</p></li><li><p>Uses Vega’s native <code inline="">wordcloud</code> transform for layout generation.</p></li><li><p>Word positions are already produced in pixel space, so normalization emits:</p></li></ul><pre><code class="language-js">{ value: { expr: "datum.__wc_x" } }
</code></pre><p>for <code inline="">x/y</code> positioning to bypass Vega-Lite scales and avoid position distortion and y-axis inversion.</p><ul><li><p>Layout size defaults to:</p></li></ul><pre><code class="language-js">[{ signal: "width" }, { signal: "height" }]
</code></pre><p>to allow responsive rendering at any view size.</p><ul><li><p>Internal generated fields are prefixed with 

<code inline="">__wc_</code> to avoid collisions with user data.</p></li></ul><hr><h2>Files Changed</h2>

File | Description
-- | --
src/transform.ts | Add WordcloudTransform interface and isWordcloud() type guard
src/compile/data/wordcloud.ts | Add WordcloudTransformNode
src/compile/data/assemble.ts | Register transform node
src/compile/data/parse.ts | Parse wordcloud transform
src/compositemark/wordcloud.ts | Composite mark definition and normalizer
src/compositemark/index.ts | Register composite mark
src/normalize/core.ts | Add wordcloud normalizer
src/config.ts | Add default configuration
src/compositemark/common.ts | Fix orient guard for non-oriented composite marks
test/compositemark/wordcloud.test.ts | Add unit tests
site/docs/mark/wordcloud.md | Add mark documentation
site/docs/transform/wordcloud.md | Add transform documentation
site/docs/mark/mark.md | Update mark documentation
site/docs/transform/transform.md | Update transform documentation
examples/specs/wordcloud_basic.vl.json | Add basic example
examples/specs/wordcloud_custom.vl.json | Add custom configuration example


<hr><h2>Validation Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> PR is atomic and scoped to a single feature</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Uses semantic commit title</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> <code inline="">npm test</code> passes</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Includes unit tests</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Includes documentation</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Includes usage examples</p></li></ul></body></html>