### PR TITLE
docs: add KoliStat to ecosystem

### DIFF
--- a/site/ecosystem.md
+++ b/site/ecosystem.md
@@ -115,6 +115,7 @@ We mark featured plugins and tools with a <span class="octicon octicon-star"></s
 - [PyGWalker](https://github.com/Kanaries/pygwalker) A python library that turns your data into an interactive visual exploration app with one line of code.
 - [GWalkR](https://github.com/Kanaries/GWalkR) An R library that turns your dataframe into an interactive visual exploration app in RStudio.
 - [graphic-walker](https://github.com/Kanaries/graphic-walker), an open-source alternative to Tableau, is a versatile visualization tool for data exploration and no-code Vega-Lite editing, that can be easily embedded as a component in web apps.
+- [KoliStat](https://kolistat.com), a browser-native suite of clinical and tabular data analysis tools whose the-stats-duck DuckDB extension compiles a plot grammar to Vega-Lite.
 
 ## Tools for Embedding Vega-Lite Visualizations
 


### PR DESCRIPTION
## PR Description

Adds [KoliStat](https://kolistat.com) to the "Tools that use Vega-Lite" section of the ecosystem page. Its `the-stats-duck` DuckDB extension has a plot grammar (`ggsql`) that compiles to Vega-Lite.

Closes #9859

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties).
- [x] `npm test` runs successfully
- For new features:
  - [ ] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).
</details>