### PR TITLE
fix: apply cornerRadiusEnd to the rendered value end of bars

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3141,7 +3141,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "- For vertical bars, top-left and top-right corner radius.\n\n- For horizontal bars, top-right and bottom-right corner radius."
+          "description": "Corner radius of the value-end side."
         },
         "cornerRadiusTopLeft": {
           "anyOf": [
@@ -16812,7 +16812,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "- For vertical bars, top-left and top-right corner radius.\n\n- For horizontal bars, top-right and bottom-right corner radius."
+          "description": "Corner radius of the value-end side."
         },
         "cornerRadiusTopLeft": {
           "anyOf": [

--- a/examples/compiled/bar_axis_space_saving.vg.json
+++ b/examples/compiled/bar_axis_space_saving.vg.json
@@ -33,8 +33,6 @@
       "from": {"data": "source_0"},
       "encode": {
         "update": {
-          "cornerRadiusTopRight": {"value": 2},
-          "cornerRadiusBottomRight": {"value": 2},
           "fill": {"value": "#4c78a8"},
           "ariaRoleDescription": {"value": "bar"},
           "description": {
@@ -43,7 +41,35 @@
           "x": {"scale": "x", "field": "__count"},
           "x2": {"scale": "x", "value": 0},
           "y": {"scale": "y", "field": "Origin", "offset": 5, "band": 0.25},
-          "height": {"signal": "max(0.25, 0.5 * bandwidth('y'))"}
+          "height": {"signal": "max(0.25, 0.5 * bandwidth('y'))"},
+          "cornerRadiusTopRight": [
+            {
+              "test": "scale(\"x\", datum[\"__count\"]) > scale(\"x\", 0)",
+              "value": 2
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusBottomRight": [
+            {
+              "test": "scale(\"x\", datum[\"__count\"]) > scale(\"x\", 0)",
+              "value": 2
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusTopLeft": [
+            {
+              "test": "scale(\"x\", datum[\"__count\"]) < scale(\"x\", 0)",
+              "value": 2
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusBottomLeft": [
+            {
+              "test": "scale(\"x\", datum[\"__count\"]) < scale(\"x\", 0)",
+              "value": 2
+            },
+            {"value": 0}
+          ]
         }
       }
     }

--- a/examples/compiled/bar_corner_radius_end.vg.json
+++ b/examples/compiled/bar_corner_radius_end.vg.json
@@ -71,8 +71,34 @@
             "signal": "max(scale('y',datum[\"min_b_start\"]),scale('y',datum[\"max_b_start\"]),scale('y',datum[\"min_b_end\"]),scale('y',datum[\"max_b_end\"]))"
           },
           "clip": {"value": true},
-          "cornerRadiusTopLeft": {"value": 4},
-          "cornerRadiusTopRight": {"value": 4}
+          "cornerRadiusTopLeft": [
+            {
+              "test": "scale(\"y\", datum[\"max_b_end\"]) < scale(\"y\", datum[\"max_b_start\"])",
+              "value": 4
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusTopRight": [
+            {
+              "test": "scale(\"y\", datum[\"max_b_end\"]) < scale(\"y\", datum[\"max_b_start\"])",
+              "value": 4
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusBottomLeft": [
+            {
+              "test": "scale(\"y\", datum[\"min_b_end\"]) > scale(\"y\", datum[\"min_b_start\"])",
+              "value": 4
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusBottomRight": [
+            {
+              "test": "scale(\"y\", datum[\"min_b_end\"]) > scale(\"y\", datum[\"min_b_start\"])",
+              "value": 4
+            },
+            {"value": 0}
+          ]
         }
       },
       "marks": [

--- a/examples/compiled/histogram_nonlinear.vg.json
+++ b/examples/compiled/histogram_nonlinear.vg.json
@@ -54,8 +54,6 @@
       "from": {"data": "data_0"},
       "encode": {
         "update": {
-          "cornerRadiusTopLeft": {"value": 0},
-          "cornerRadiusTopRight": {"value": 0},
           "fill": {"value": "#4c78a8"},
           "ariaRoleDescription": {"value": "bar"},
           "description": {
@@ -64,7 +62,35 @@
           "x": {"scale": "x", "field": "startTime"},
           "x2": {"scale": "x", "field": "endTime"},
           "y": {"scale": "y", "field": "residency_end"},
-          "y2": {"scale": "y", "field": "residency_start"}
+          "y2": {"scale": "y", "field": "residency_start"},
+          "cornerRadiusTopLeft": [
+            {
+              "test": "scale(\"y\", datum[\"residency_end\"]) < scale(\"y\", datum[\"residency_start\"])",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusTopRight": [
+            {
+              "test": "scale(\"y\", datum[\"residency_end\"]) < scale(\"y\", datum[\"residency_start\"])",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusBottomLeft": [
+            {
+              "test": "scale(\"y\", datum[\"residency_end\"]) > scale(\"y\", datum[\"residency_start\"])",
+              "value": 0
+            },
+            {"value": 0}
+          ],
+          "cornerRadiusBottomRight": [
+            {
+              "test": "scale(\"y\", datum[\"residency_end\"]) > scale(\"y\", datum[\"residency_start\"])",
+              "value": 0
+            },
+            {"value": 0}
+          ]
         }
       }
     }

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -5,7 +5,7 @@ import * as encode from './encode/index.js';
 export const bar: MarkCompiler = {
   vgMark: 'rect',
   encodeEntry: (model: UnitModel) => {
-    return {
+    const encodeEntry = {
       ...encode.baseEncodeEntry(model, {
         align: 'ignore',
         baseline: 'ignore',
@@ -16,6 +16,11 @@ export const bar: MarkCompiler = {
       }),
       ...encode.rectPosition(model, 'x'),
       ...encode.rectPosition(model, 'y'),
+    };
+
+    return {
+      ...encodeEntry,
+      ...encode.cornerRadiusEnd(model, encodeEntry),
     };
   },
 };

--- a/src/compile/mark/encode/corner-radius.ts
+++ b/src/compile/mark/encode/corner-radius.ts
@@ -1,0 +1,158 @@
+import type {SignalRef} from 'vega';
+import {stringValue} from 'vega-util';
+import type {Mark, MarkDef} from '../../../mark.js';
+import {flatAccessWithDatum} from '../../../util.js';
+import {VgEncodeEntry, VgValueRef} from '../../../vega.schema.js';
+import {getMarkPropOrConfig, signalOrValueRef} from '../../common.js';
+import {UnitModel} from '../../unit.js';
+
+type CornerRadius =
+  | 'cornerRadiusTopLeft'
+  | 'cornerRadiusTopRight'
+  | 'cornerRadiusBottomLeft'
+  | 'cornerRadiusBottomRight';
+type CornerRadiusEnd = NonNullable<MarkDef<Mark, SignalRef>['cornerRadiusEnd']>;
+
+interface StackedBarCornerRadiusFields {
+  minStart: string;
+  maxStart: string;
+  minEnd: string;
+  maxEnd: string;
+}
+
+export function cornerRadiusEnd(model: UnitModel, encodeEntry: VgEncodeEntry): VgEncodeEntry {
+  const {markDef, config} = model;
+  const radius = getMarkPropOrConfig('cornerRadiusEnd', markDef, config);
+  // Check the original encoding because non-ranged bars also compile to x/x2 or y/y2 endpoints.
+  const isRanged =
+    (markDef.orient === 'horizontal' && model.encoding.x2) || (markDef.orient === 'vertical' && model.encoding.y2);
+  if (markDef.type !== 'bar' || radius === undefined || !markDef.orient || isRanged) {
+    return {};
+  }
+
+  // Compare rendered positions so negative values and reversed scales round the correct end.
+  if (markDef.orient === 'horizontal') {
+    const x = positionRefToExpr(encodeEntry.x);
+    const x2 = positionRefToExpr(encodeEntry.x2);
+    return x && x2 ? horizontalCornerRadius(radius, `${x} > ${x2}`, `${x} < ${x2}`) : {};
+  } else {
+    const y = positionRefToExpr(encodeEntry.y);
+    const y2 = positionRefToExpr(encodeEntry.y2);
+    // Vega's y coordinates increase downward, so the top end has the smaller position.
+    return y && y2 ? verticalCornerRadius(radius, `${y} < ${y2}`, `${y} > ${y2}`) : {};
+  }
+}
+
+export function cornerRadiusEndForStackedBar(
+  model: UnitModel,
+  scaleName: string,
+  fields: StackedBarCornerRadiusFields,
+): VgEncodeEntry {
+  const radius = getMarkPropOrConfig('cornerRadiusEnd', model.markDef, model.config);
+  if (radius === undefined) {
+    return {};
+  }
+
+  // Rounded stacks use generated min/max fields for the outer negative and positive boundaries.
+  const minStart = scaledFieldExpr(scaleName, fields.minStart);
+  const maxStart = scaledFieldExpr(scaleName, fields.maxStart);
+  const minEnd = scaledFieldExpr(scaleName, fields.minEnd);
+  const maxEnd = scaledFieldExpr(scaleName, fields.maxEnd);
+
+  if (model.stack.fieldChannel === 'x') {
+    return horizontalCornerRadius(radius, `${maxEnd} > ${maxStart}`, `${minEnd} < ${minStart}`);
+  } else {
+    return verticalCornerRadius(radius, `${maxEnd} < ${maxStart}`, `${minEnd} > ${minStart}`);
+  }
+}
+
+function horizontalCornerRadius(radius: CornerRadiusEnd, rightEndTest: string, leftEndTest: string): VgEncodeEntry {
+  return {
+    ...conditionalCornerRadius(['cornerRadiusTopRight', 'cornerRadiusBottomRight'], rightEndTest, radius),
+    ...conditionalCornerRadius(['cornerRadiusTopLeft', 'cornerRadiusBottomLeft'], leftEndTest, radius),
+  };
+}
+
+function verticalCornerRadius(radius: CornerRadiusEnd, topEndTest: string, bottomEndTest: string): VgEncodeEntry {
+  return {
+    ...conditionalCornerRadius(['cornerRadiusTopLeft', 'cornerRadiusTopRight'], topEndTest, radius),
+    ...conditionalCornerRadius(['cornerRadiusBottomLeft', 'cornerRadiusBottomRight'], bottomEndTest, radius),
+  };
+}
+
+function conditionalCornerRadius(corners: CornerRadius[], test: string, radius: CornerRadiusEnd): VgEncodeEntry {
+  const valueRef = signalOrValueRef(radius);
+  return corners.reduce<VgEncodeEntry>((encode, corner) => {
+    encode[corner] = [{test, ...valueRef}, {value: 0}];
+    return encode;
+  }, {});
+}
+
+function positionRefToExpr(ref: VgEncodeEntry['x']): string | undefined {
+  if (Array.isArray(ref)) {
+    // Conditional position encodings keep their unconditional fallback last.
+    ref = ref[ref.length - 1];
+  }
+  return ref ? valueRefToExpr(ref) : undefined;
+}
+
+function valueRefToExpr(ref: VgValueRef): string | undefined {
+  let expr: string | undefined;
+
+  if (ref.scale) {
+    const scaledValue = scaledValueRefToExpr(ref);
+    if (scaledValue === undefined) {
+      return undefined;
+    }
+    expr = `scale(${stringValue(ref.scale)}, ${scaledValue})`;
+  } else if (ref.signal) {
+    expr = `(${ref.signal})`;
+  } else if (ref.field !== undefined) {
+    expr = fieldRefToExpr(ref.field);
+  } else if (ref.value !== undefined) {
+    expr = stringValue(ref.value);
+  }
+
+  if (expr === undefined) {
+    return undefined;
+  }
+
+  if (ref.mult !== undefined) {
+    expr = `${ref.mult} * (${expr})`;
+  }
+
+  if (ref.offset !== undefined) {
+    const offset = typeof ref.offset === 'number' ? stringValue(ref.offset) : valueRefToExpr(ref.offset);
+    if (offset) {
+      expr = `${expr} + ${offset}`;
+    }
+  }
+
+  return expr;
+}
+
+function scaledValueRefToExpr(ref: VgValueRef): string | undefined {
+  if (ref.signal) {
+    return ref.signal;
+  } else if (ref.field !== undefined) {
+    return fieldRefToExpr(ref.field);
+  } else if (ref.value !== undefined) {
+    return stringValue(ref.value);
+  }
+  return undefined;
+}
+
+function fieldRefToExpr(field: NonNullable<VgValueRef['field']>): string | undefined {
+  if (typeof field === 'string') {
+    return flatAccessWithDatum(field);
+  } else if (field.datum) {
+    return flatAccessWithDatum(field.datum, 'datum');
+  } else if (field.parent) {
+    return flatAccessWithDatum(field.parent, 'parent');
+  }
+  return undefined;
+}
+
+function scaledFieldExpr(scaleName: string, field: string): string {
+  return `scale(${stringValue(scaleName)}, ${flatAccessWithDatum(field)})`;
+}

--- a/src/compile/mark/encode/corner-radius.ts
+++ b/src/compile/mark/encode/corner-radius.ts
@@ -11,7 +11,7 @@ type CornerRadius =
   | 'cornerRadiusTopRight'
   | 'cornerRadiusBottomLeft'
   | 'cornerRadiusBottomRight';
-type CornerRadiusEnd = NonNullable<MarkDef<Mark, SignalRef>['cornerRadiusEnd']>;
+export type CornerRadiusEnd = NonNullable<MarkDef<Mark, SignalRef>['cornerRadiusEnd']>;
 
 interface StackedBarCornerRadiusFields {
   minStart: string;
@@ -21,34 +21,42 @@ interface StackedBarCornerRadiusFields {
 }
 
 export function cornerRadiusEnd(model: UnitModel, encodeEntry: VgEncodeEntry): VgEncodeEntry {
-  const {markDef, config} = model;
+  const {markDef, config, encoding} = model;
   const radius = getMarkPropOrConfig('cornerRadiusEnd', markDef, config);
-  // Check the original encoding because non-ranged bars also compile to x/x2 or y/y2 endpoints.
-  const isRanged =
-    (markDef.orient === 'horizontal' && model.encoding.x2) || (markDef.orient === 'vertical' && model.encoding.y2);
-  if (markDef.type !== 'bar' || radius === undefined || !markDef.orient || isRanged) {
+  if (markDef.type !== 'bar' || radius === undefined || !markDef.orient) {
     return {};
+  }
+
+  // Check the original encoding because non-ranged bars also compile to x/x2 or y/y2 endpoints.
+  const isRanged = markDef.orient === 'horizontal' ? encoding.x2 : encoding.y2;
+  if (isRanged) {
+    // Both ends of a ranged bar cap a value, so round every corner —
+    // unless a mark-level cornerRadius beats a config-level cornerRadiusEnd.
+    if (markDef.cornerRadiusEnd === undefined && markDef.cornerRadius !== undefined) {
+      return {};
+    }
+    return {cornerRadius: signalOrValueRef(radius)};
   }
 
   // Compare rendered positions so negative values and reversed scales round the correct end.
   if (markDef.orient === 'horizontal') {
     const x = positionRefToExpr(encodeEntry.x);
     const x2 = positionRefToExpr(encodeEntry.x2);
-    return x && x2 ? horizontalCornerRadius(radius, `${x} > ${x2}`, `${x} < ${x2}`) : {};
+    return x && x2 ? horizontalCornerRadius(model, radius, `${x} > ${x2}`, `${x} < ${x2}`) : {};
   } else {
     const y = positionRefToExpr(encodeEntry.y);
     const y2 = positionRefToExpr(encodeEntry.y2);
     // Vega's y coordinates increase downward, so the top end has the smaller position.
-    return y && y2 ? verticalCornerRadius(radius, `${y} < ${y2}`, `${y} > ${y2}`) : {};
+    return y && y2 ? verticalCornerRadius(model, radius, `${y} < ${y2}`, `${y} > ${y2}`) : {};
   }
 }
 
 export function cornerRadiusEndForStackedBar(
   model: UnitModel,
+  radius: CornerRadiusEnd | undefined,
   scaleName: string,
   fields: StackedBarCornerRadiusFields,
 ): VgEncodeEntry {
-  const radius = getMarkPropOrConfig('cornerRadiusEnd', model.markDef, model.config);
   if (radius === undefined) {
     return {};
   }
@@ -60,30 +68,55 @@ export function cornerRadiusEndForStackedBar(
   const maxEnd = scaledFieldExpr(scaleName, fields.maxEnd);
 
   if (model.stack.fieldChannel === 'x') {
-    return horizontalCornerRadius(radius, `${maxEnd} > ${maxStart}`, `${minEnd} < ${minStart}`);
+    return horizontalCornerRadius(model, radius, `${maxEnd} > ${maxStart}`, `${minEnd} < ${minStart}`);
   } else {
-    return verticalCornerRadius(radius, `${maxEnd} < ${maxStart}`, `${minEnd} > ${minStart}`);
+    return verticalCornerRadius(model, radius, `${maxEnd} < ${maxStart}`, `${minEnd} > ${minStart}`);
   }
 }
 
-function horizontalCornerRadius(radius: CornerRadiusEnd, rightEndTest: string, leftEndTest: string): VgEncodeEntry {
+function horizontalCornerRadius(
+  model: UnitModel,
+  radius: CornerRadiusEnd,
+  rightEndTest: string,
+  leftEndTest: string,
+): VgEncodeEntry {
   return {
-    ...conditionalCornerRadius(['cornerRadiusTopRight', 'cornerRadiusBottomRight'], rightEndTest, radius),
-    ...conditionalCornerRadius(['cornerRadiusTopLeft', 'cornerRadiusBottomLeft'], leftEndTest, radius),
+    ...conditionalCornerRadius(model, ['cornerRadiusTopRight', 'cornerRadiusBottomRight'], rightEndTest, radius),
+    ...conditionalCornerRadius(model, ['cornerRadiusTopLeft', 'cornerRadiusBottomLeft'], leftEndTest, radius),
   };
 }
 
-function verticalCornerRadius(radius: CornerRadiusEnd, topEndTest: string, bottomEndTest: string): VgEncodeEntry {
+function verticalCornerRadius(
+  model: UnitModel,
+  radius: CornerRadiusEnd,
+  topEndTest: string,
+  bottomEndTest: string,
+): VgEncodeEntry {
   return {
-    ...conditionalCornerRadius(['cornerRadiusTopLeft', 'cornerRadiusTopRight'], topEndTest, radius),
-    ...conditionalCornerRadius(['cornerRadiusBottomLeft', 'cornerRadiusBottomRight'], bottomEndTest, radius),
+    ...conditionalCornerRadius(model, ['cornerRadiusTopLeft', 'cornerRadiusTopRight'], topEndTest, radius),
+    ...conditionalCornerRadius(model, ['cornerRadiusBottomLeft', 'cornerRadiusBottomRight'], bottomEndTest, radius),
   };
 }
 
-function conditionalCornerRadius(corners: CornerRadius[], test: string, radius: CornerRadiusEnd): VgEncodeEntry {
+function conditionalCornerRadius(
+  model: UnitModel,
+  corners: CornerRadius[],
+  test: string,
+  radius: CornerRadiusEnd,
+): VgEncodeEntry {
+  const {markDef, config} = model;
   const valueRef = signalOrValueRef(radius);
+  // Mark properties beat config properties, so a config-level cornerRadiusEnd
+  // must not override corner radii from the mark definition.
+  const specifiedEnd = markDef.cornerRadiusEnd !== undefined;
   return corners.reduce<VgEncodeEntry>((encode, corner) => {
-    encode[corner] = [{test, ...valueRef}, {value: 0}];
+    if (!specifiedEnd && (markDef[corner] !== undefined || markDef.cornerRadius !== undefined)) {
+      return encode;
+    }
+    // At the non-value end, fall back to the corner's own radius so cornerRadiusEnd only overrides the value end.
+    const fallback =
+      getMarkPropOrConfig(corner, markDef, config) ?? getMarkPropOrConfig('cornerRadius', markDef, config) ?? 0;
+    encode[corner] = [{test, ...valueRef}, signalOrValueRef(fallback)];
     return encode;
   }, {});
 }

--- a/src/compile/mark/encode/index.ts
+++ b/src/compile/mark/encode/index.ts
@@ -1,6 +1,7 @@
 export {aria} from './aria.js';
 export {baseEncodeEntry} from './base.js';
 export {color} from './color.js';
+export {cornerRadiusEnd, cornerRadiusEndForStackedBar} from './corner-radius.js';
 export {defined, valueIfDefined} from './defined.js';
 export {nonPosition} from './nonposition.js';
 export {pointPosition} from './position-point.js';

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -10,22 +10,7 @@ import {Config} from '../../config.js';
 import {Encoding, isAggregate} from '../../encoding.js';
 import {replaceExprRef} from '../../expr.js';
 import * as log from '../../log/index.js';
-import {
-  AREA,
-  BAR,
-  BAR_CORNER_RADIUS_INDEX as BAR_CORNER_RADIUS_END_INDEX,
-  CIRCLE,
-  IMAGE,
-  LINE,
-  Mark,
-  MarkDef,
-  POINT,
-  RECT,
-  RULE,
-  SQUARE,
-  TEXT,
-  TICK,
-} from '../../mark.js';
+import {AREA, BAR, CIRCLE, IMAGE, LINE, Mark, MarkDef, POINT, RECT, RULE, SQUARE, TEXT, TICK} from '../../mark.js';
 import {QUANTITATIVE, TEMPORAL} from '../../type.js';
 import {contains, getFirstDefined} from '../../util.js';
 import {getMarkConfig, getMarkPropOrConfig} from '../common.js';
@@ -43,16 +28,11 @@ export function initMarkdef(originalMarkDef: MarkDef, encoding: Encoding<string>
 
   if (markDef.type === 'bar' && markDef.orient) {
     const cornerRadiusEnd = getMarkPropOrConfig('cornerRadiusEnd', markDef, config);
-    if (cornerRadiusEnd !== undefined) {
-      const newProps =
-        (markDef.orient === 'horizontal' && encoding.x2) || (markDef.orient === 'vertical' && encoding.y2)
-          ? (['cornerRadius'] as const)
-          : BAR_CORNER_RADIUS_END_INDEX[markDef.orient];
-
-      for (const newProp of newProps) {
-        markDef[newProp] = cornerRadiusEnd;
-      }
-
+    if (
+      cornerRadiusEnd !== undefined &&
+      ((markDef.orient === 'horizontal' && encoding.x2) || (markDef.orient === 'vertical' && encoding.y2))
+    ) {
+      markDef.cornerRadius = cornerRadiusEnd;
       if (markDef.cornerRadiusEnd !== undefined) {
         delete markDef.cornerRadiusEnd; // no need to keep the original cap cornerRadius
       }

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -26,19 +26,6 @@ export function initMarkdef(originalMarkDef: MarkDef, encoding: Encoding<string>
     log.warn(log.message.orientOverridden(markDef.orient, specifiedOrient));
   }
 
-  if (markDef.type === 'bar' && markDef.orient) {
-    const cornerRadiusEnd = getMarkPropOrConfig('cornerRadiusEnd', markDef, config);
-    if (
-      cornerRadiusEnd !== undefined &&
-      ((markDef.orient === 'horizontal' && encoding.x2) || (markDef.orient === 'vertical' && encoding.y2))
-    ) {
-      markDef.cornerRadius = cornerRadiusEnd;
-      if (markDef.cornerRadiusEnd !== undefined) {
-        delete markDef.cornerRadiusEnd; // no need to keep the original cap cornerRadius
-      }
-    }
-  }
-
   // set opacity and filled if not specified in mark config
   const specifiedOpacity = getMarkPropOrConfig('opacity', markDef, config);
   const specifiedFillOpacity = getMarkPropOrConfig('fillOpacity', markDef, config);

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -19,7 +19,7 @@ import {rect} from './rect.js';
 import {rule} from './rule.js';
 import {text} from './text.js';
 import {tick} from './tick.js';
-import {cornerRadiusEndForStackedBar} from './encode/corner-radius.js';
+import {CornerRadiusEnd, cornerRadiusEndForStackedBar} from './encode/corner-radius.js';
 
 const markCompiler: Record<Mark, MarkCompiler> = {
   arc,
@@ -46,11 +46,12 @@ export function parseMarkGroups(model: UnitModel): any[] {
     }
     // otherwise use standard mark groups
   } else if (model.mark === BAR) {
+    const cornerRadiusEnd = getMarkPropOrConfig('cornerRadiusEnd', model.markDef, model.config);
     const hasCornerRadius =
-      VG_CORNERRADIUS_CHANNELS.some((prop) => getMarkPropOrConfig(prop, model.markDef, model.config)) ||
-      getMarkPropOrConfig('cornerRadiusEnd', model.markDef, model.config);
+      cornerRadiusEnd ||
+      VG_CORNERRADIUS_CHANNELS.some((prop) => getMarkPropOrConfig(prop, model.markDef, model.config));
     if (model.stack && !model.fieldDef('size') && hasCornerRadius) {
-      return getGroupsForStackedBarWithCornerRadius(model);
+      return getGroupsForStackedBarWithCornerRadius(model, cornerRadiusEnd);
     }
   }
 
@@ -92,7 +93,7 @@ const STACK_GROUP_PREFIX = 'stack_group_';
  * If stack is used and the model doesn't have size encoding, we put the mark into groups,
  * and apply cornerRadius properties at the group.
  */
-function getGroupsForStackedBarWithCornerRadius(model: UnitModel) {
+function getGroupsForStackedBarWithCornerRadius(model: UnitModel, cornerRadiusEnd: CornerRadiusEnd | undefined) {
   // Generate the mark
   const [mark] = getMarkGroup(model, {fromPrefix: STACK_GROUP_PREFIX});
 
@@ -168,7 +169,7 @@ function getGroupsForStackedBarWithCornerRadius(model: UnitModel) {
   }
   groupUpdate = {
     ...groupUpdate,
-    ...cornerRadiusEndForStackedBar(model, fieldScale, {
+    ...cornerRadiusEndForStackedBar(model, cornerRadiusEnd, fieldScale, {
       minStart: stackField({prefix: 'min', suffix: 'start'}),
       maxStart: stackField({prefix: 'max', suffix: 'start'}),
       minEnd: stackField({prefix: 'min', suffix: 'end'}),

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -19,6 +19,7 @@ import {rect} from './rect.js';
 import {rule} from './rule.js';
 import {text} from './text.js';
 import {tick} from './tick.js';
+import {cornerRadiusEndForStackedBar} from './encode/corner-radius.js';
 
 const markCompiler: Record<Mark, MarkCompiler> = {
   arc,
@@ -45,9 +46,9 @@ export function parseMarkGroups(model: UnitModel): any[] {
     }
     // otherwise use standard mark groups
   } else if (model.mark === BAR) {
-    const hasCornerRadius = VG_CORNERRADIUS_CHANNELS.some((prop) =>
-      getMarkPropOrConfig(prop, model.markDef, model.config),
-    );
+    const hasCornerRadius =
+      VG_CORNERRADIUS_CHANNELS.some((prop) => getMarkPropOrConfig(prop, model.markDef, model.config)) ||
+      getMarkPropOrConfig('cornerRadiusEnd', model.markDef, model.config);
     if (model.stack && !model.fieldDef('size') && hasCornerRadius) {
       return getGroupsForStackedBarWithCornerRadius(model);
     }
@@ -165,6 +166,15 @@ function getGroupsForStackedBarWithCornerRadius(model: UnitModel) {
       mark.encode.update[key] = {value: 0};
     }
   }
+  groupUpdate = {
+    ...groupUpdate,
+    ...cornerRadiusEndForStackedBar(model, fieldScale, {
+      minStart: stackField({prefix: 'min', suffix: 'start'}),
+      maxStart: stackField({prefix: 'max', suffix: 'start'}),
+      minEnd: stackField({prefix: 'min', suffix: 'end'}),
+      maxEnd: stackField({prefix: 'max', suffix: 'end'}),
+    }),
+  };
 
   const groupby: string[] = [];
 

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -467,21 +467,9 @@ export function isRelativeBandSize(o: number | RelativeBandSize | ExprRef | Sign
   return hasProperty(o, 'band');
 }
 
-export const BAR_CORNER_RADIUS_INDEX: Partial<
-  Record<
-    Orientation,
-    ('cornerRadiusTopLeft' | 'cornerRadiusTopRight' | 'cornerRadiusBottomLeft' | 'cornerRadiusBottomRight')[]
-  >
-> = {
-  horizontal: ['cornerRadiusTopRight', 'cornerRadiusBottomRight'],
-  vertical: ['cornerRadiusTopLeft', 'cornerRadiusTopRight'],
-};
-
 export interface BarCornerRadiusMixins<ES extends ExprRef | SignalRef> {
   /**
-   * - For vertical bars, top-left and top-right corner radius.
-   *
-   * - For horizontal bars, top-right and bottom-right corner radius.
+   * Corner radius of the value-end side.
    */
   cornerRadiusEnd?: number | ES;
 }

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -203,6 +203,48 @@ describe('Mark: Bar', () => {
     });
   });
 
+  it('should round the left or right end of horizontal bars', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/cars.json'},
+      mark: {type: 'bar', cornerRadiusEnd: 5},
+      encoding: {
+        y: {field: 'Origin', type: 'nominal'},
+        x: {field: 'Acceleration', type: 'quantitative', stack: null},
+      },
+    });
+    const props = bar.encodeEntry(model);
+    const roundRight = [{test: 'scale("x", datum["Acceleration"]) > scale("x", 0)', value: 5}, {value: 0}];
+    const roundLeft = [{test: 'scale("x", datum["Acceleration"]) < scale("x", 0)', value: 5}, {value: 0}];
+
+    expect(props).toMatchObject({
+      cornerRadiusTopRight: roundRight,
+      cornerRadiusBottomRight: roundRight,
+      cornerRadiusTopLeft: roundLeft,
+      cornerRadiusBottomLeft: roundLeft,
+    });
+  });
+
+  it('should round the top or bottom end of vertical bars', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/cars.json'},
+      mark: {type: 'bar', cornerRadiusEnd: 5},
+      encoding: {
+        x: {field: 'Origin', type: 'nominal'},
+        y: {field: 'Acceleration', type: 'quantitative', stack: null},
+      },
+    });
+    const props = bar.encodeEntry(model);
+    const roundTop = [{test: 'scale("y", datum["Acceleration"]) < scale("y", 0)', value: 5}, {value: 0}];
+    const roundBottom = [{test: 'scale("y", datum["Acceleration"]) > scale("y", 0)', value: 5}, {value: 0}];
+
+    expect(props).toMatchObject({
+      cornerRadiusTopLeft: roundTop,
+      cornerRadiusTopRight: roundTop,
+      cornerRadiusBottomLeft: roundBottom,
+      cornerRadiusBottomRight: roundBottom,
+    });
+  });
+
   describe('simple horizontal with height band', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       data: {url: 'data/cars.json'},
@@ -1024,6 +1066,24 @@ describe('Mark: Bar', () => {
       expect(props.y).toEqual({scale: 'y', field: 'age'});
       expect(props.x).toEqual({scale: 'x', field: 'q1_people'});
       expect(props.x2).toEqual({scale: 'x', field: 'q3_people'});
+    });
+
+    it('should apply config cornerRadiusEnd to all corners for ranged bars', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        data: {url: 'data/population.json'},
+        mark: 'bar',
+        encoding: {
+          y: {field: 'age', type: 'ordinal'},
+          x: {field: 'people', aggregate: 'q1', type: 'quantitative'},
+          x2: {field: 'people', aggregate: 'q3'},
+        },
+        config: {bar: {cornerRadiusEnd: 5}},
+      });
+
+      const props = bar.encodeEntry(model);
+      expect(props.cornerRadius).toEqual({value: 5});
+      expect(props.cornerRadiusTopRight).toBeUndefined();
+      expect(props.cornerRadiusBottomRight).toBeUndefined();
     });
   });
 

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -245,6 +245,79 @@ describe('Mark: Bar', () => {
     });
   });
 
+  it('should fall back to explicit corner and generic cornerRadius properties at the non-value end', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/cars.json'},
+      mark: {type: 'bar', cornerRadiusEnd: 5, cornerRadiusBottomLeft: 8, cornerRadius: 2},
+      encoding: {
+        x: {field: 'Origin', type: 'nominal'},
+        y: {field: 'Acceleration', type: 'quantitative', stack: null},
+      },
+    });
+    const props = bar.encodeEntry(model);
+    const topEnd = 'scale("y", datum["Acceleration"]) < scale("y", 0)';
+    const bottomEnd = 'scale("y", datum["Acceleration"]) > scale("y", 0)';
+
+    expect(props).toMatchObject({
+      // cornerRadiusEnd overrides the value end; other corners keep their own radius.
+      cornerRadiusTopLeft: [{test: topEnd, value: 5}, {value: 2}],
+      cornerRadiusTopRight: [{test: topEnd, value: 5}, {value: 2}],
+      cornerRadiusBottomLeft: [{test: bottomEnd, value: 5}, {value: 8}],
+      cornerRadiusBottomRight: [{test: bottomEnd, value: 5}, {value: 2}],
+    });
+  });
+
+  it('should not let a config cornerRadiusEnd override mark corner radii', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/cars.json'},
+      mark: {type: 'bar', cornerRadius: 2, cornerRadiusTopLeft: 8},
+      encoding: {
+        x: {field: 'Origin', type: 'nominal'},
+        y: {field: 'Acceleration', type: 'quantitative', stack: null},
+      },
+      config: {bar: {cornerRadiusEnd: 5}},
+    });
+    const props = bar.encodeEntry(model);
+
+    // Mark-level properties beat the config-level cornerRadiusEnd.
+    expect(props.cornerRadiusTopLeft).toEqual({value: 8});
+    expect(props.cornerRadius).toEqual({value: 2});
+    expect(props.cornerRadiusBottomLeft).toBeUndefined();
+  });
+
+  it('should apply mark cornerRadiusEnd to all corners for ranged bars', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/population.json'},
+      mark: {type: 'bar', cornerRadiusEnd: 5},
+      encoding: {
+        y: {field: 'age', type: 'ordinal'},
+        x: {field: 'people', aggregate: 'q1', type: 'quantitative'},
+        x2: {field: 'people', aggregate: 'q3'},
+      },
+    });
+
+    const props = bar.encodeEntry(model);
+    expect(props.cornerRadius).toEqual({value: 5});
+    expect(props.cornerRadiusTopRight).toBeUndefined();
+    expect(props.cornerRadiusBottomRight).toBeUndefined();
+  });
+
+  it('should not let a config cornerRadiusEnd override the mark cornerRadius of ranged bars', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/population.json'},
+      mark: {type: 'bar', cornerRadius: 2},
+      encoding: {
+        y: {field: 'age', type: 'ordinal'},
+        x: {field: 'people', aggregate: 'q1', type: 'quantitative'},
+        x2: {field: 'people', aggregate: 'q3'},
+      },
+      config: {bar: {cornerRadiusEnd: 5}},
+    });
+
+    const props = bar.encodeEntry(model);
+    expect(props.cornerRadius).toEqual({value: 2});
+  });
+
   describe('simple horizontal with height band', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       data: {url: 'data/cars.json'},

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -5,14 +5,14 @@ import {parseUnitModelWithScaleAndLayoutSize, without} from '../../util.js';
 
 describe('compile/mark/init', () => {
   describe('initMarkDef', () => {
-    it('applies cornerRadiusEnd to all cornerRadius for ranged bars', () => {
+    it('preserves cornerRadiusEnd for ranged bars', () => {
       expect(
         initMarkdef(
           {type: 'bar', cornerRadiusEnd: 5},
           {x: {field: 'x', type: 'quantitative'}, x2: {field: 'x2'}},
           defaultConfig,
         ),
-      ).toMatchObject({cornerRadius: 5});
+      ).toMatchObject({cornerRadiusEnd: 5});
 
       expect(
         initMarkdef(
@@ -20,7 +20,7 @@ describe('compile/mark/init', () => {
           {y: {field: 'x', type: 'quantitative'}, y2: {field: 'x2'}},
           defaultConfig,
         ),
-      ).toMatchObject({cornerRadius: 5});
+      ).toMatchObject({cornerRadiusEnd: 5});
     });
 
     it('preserves cornerRadiusEnd for vertical bars', () => {

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -23,16 +23,16 @@ describe('compile/mark/init', () => {
       ).toMatchObject({cornerRadius: 5});
     });
 
-    it('applies cornerRadiusEnd to top cornerRadius for vertical bars', () => {
+    it('preserves cornerRadiusEnd for vertical bars', () => {
       expect(
         initMarkdef({type: 'bar', cornerRadiusEnd: 5}, {y: {field: 'x', type: 'quantitative'}}, defaultConfig),
-      ).toMatchObject({cornerRadiusTopLeft: 5, cornerRadiusTopRight: 5});
+      ).toMatchObject({cornerRadiusEnd: 5});
     });
 
-    it('applies cornerRadiusEnd to top cornerRadius for horizontal bars', () => {
+    it('preserves cornerRadiusEnd for horizontal bars', () => {
       expect(
         initMarkdef({type: 'bar', cornerRadiusEnd: 5}, {x: {field: 'x', type: 'quantitative'}}, defaultConfig),
-      ).toMatchObject({cornerRadiusBottomRight: 5, cornerRadiusTopRight: 5});
+      ).toMatchObject({cornerRadiusEnd: 5});
     });
   });
 

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -309,6 +309,29 @@ describe('Mark', () => {
       });
     });
 
+    it('should not let a config cornerRadiusEnd override a mark cornerRadius on stacked bar groups', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          cornerRadius: 2,
+        },
+        encoding: {
+          x: {type: 'nominal', field: 'bar'},
+          y: {type: 'quantitative', field: 'foo', aggregate: 'sum'},
+          color: {type: 'nominal', field: 'series'},
+        },
+        config: {bar: {cornerRadiusEnd: 5}},
+      });
+
+      const markGroup = parseMarkGroups(model);
+      const update = markGroup[0].encode.update;
+
+      // The mark-level cornerRadius wins, so no conditional value-end rounding is emitted.
+      expect(update.cornerRadius).toEqual({value: 2});
+      expect(update.cornerRadiusTopLeft).toBeUndefined();
+      expect(update.cornerRadiusBottomRight).toBeUndefined();
+    });
+
     describe('interactiveFlag', () => {
       it('should not contain flag if no selections', () => {
         const model = parseUnitModelWithScaleAndSelection({

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -251,6 +251,64 @@ describe('Mark', () => {
       expect(markGroup[0].from.facet.groupby).toEqual(['bar']);
     });
 
+    it('should round the left or right end of horizontal stacked bar groups', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          cornerRadiusEnd: 5,
+        },
+        encoding: {
+          x: {type: 'quantitative', field: 'foo', aggregate: 'sum'},
+          y: {type: 'nominal', field: 'bar'},
+          color: {type: 'nominal', field: 'series'},
+        },
+      });
+
+      const markGroup = parseMarkGroups(model);
+      const update = markGroup[0].encode.update;
+
+      const rightEnd = 'scale("x", datum["max_sum_foo_end"]) > scale("x", datum["max_sum_foo_start"])';
+      const leftEnd = 'scale("x", datum["min_sum_foo_end"]) < scale("x", datum["min_sum_foo_start"])';
+      const roundRight = [{test: rightEnd, value: 5}, {value: 0}];
+      const roundLeft = [{test: leftEnd, value: 5}, {value: 0}];
+
+      expect(update).toMatchObject({
+        cornerRadiusTopRight: roundRight,
+        cornerRadiusBottomRight: roundRight,
+        cornerRadiusTopLeft: roundLeft,
+        cornerRadiusBottomLeft: roundLeft,
+      });
+    });
+
+    it('should round the top or bottom end of vertical stacked bar groups', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {
+          type: 'bar',
+          cornerRadiusEnd: 5,
+        },
+        encoding: {
+          x: {type: 'nominal', field: 'bar'},
+          y: {type: 'quantitative', field: 'foo', aggregate: 'sum'},
+          color: {type: 'nominal', field: 'series'},
+        },
+      });
+
+      const markGroup = parseMarkGroups(model);
+      const update = markGroup[0].encode.update;
+
+      const topEnd = 'scale("y", datum["max_sum_foo_end"]) < scale("y", datum["max_sum_foo_start"])';
+      const bottomEnd = 'scale("y", datum["min_sum_foo_end"]) > scale("y", datum["min_sum_foo_start"])';
+      const roundTop = [{test: topEnd, value: 5}, {value: 0}];
+      const roundBottom = [{test: bottomEnd, value: 5}, {value: 0}];
+
+      expect(update).toMatchObject({
+        cornerRadiusTopLeft: roundTop,
+        cornerRadiusTopRight: roundTop,
+        cornerRadiusBottomLeft: roundBottom,
+        cornerRadiusBottomRight: roundBottom,
+      });
+    });
+
     describe('interactiveFlag', () => {
       it('should not contain flag if no selections', () => {
         const model = parseUnitModelWithScaleAndSelection({


### PR DESCRIPTION
New version of https://github.com/vega/vega-lite/pull/9868 so we rebuild examples etc. 

## PR Description

### Summary

Makes `cornerRadiusEnd` apply to the actual rendered value-end of bars:

- Positive horizontal bars round the top-right & bottom-right, negative bars round the top-left & bottom-left
- Positive vertical bars round the top-left & top-right, negative bars round the bottom-left & bottom-right
- Above applies to stacked bars too.
- Ranged bars round all corners.

### Motivation

Previously, Vega-Lite compiled `cornerRadiusEnd` to hardcoded corners (right-side for horizontal and top-side for vertical). This assumes positive values, causing negative bars to round the visually incorrect side.

Downstream consumers would need to post-process generated Vega specs, which is fragile.
It's best if we make the fix here since the behavior seems unintentional/bandaid-like.

### Example
<img alt="image" src="https://github.com/user-attachments/assets/9888cd75-4163-48bc-968c-90f4b6a83e6c" />

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
  "data": {
    "values": [
      {"category": "Positive", "value": 10},
      {"category": "Negative", "value": -10}
    ]
  },
  "mark": {"type": "bar", "cornerRadiusEnd": 5},
  "encoding": {
    "y": {"field": "category", "type": "nominal"},
    "x": {"field": "value", "type": "quantitative"}
  }
}
```