### PR TITLE
test: add discrete/continuous predicate and binned-offset compile coverage

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -18,9 +18,23 @@ export function isType(t: any): t is Type {
   return hasOwnProperty(Type, t);
 }
 
+/**
+ * Type-only continuous check (does not consider binning).
+ * A binned quantitative field still counts as continuous here, whereas the
+ * field-aware `isDiscrete` in `./channeldef.js` treats it as discrete.
+ */
 export function isContinuous(type: Type): type is 'quantitative' | 'temporal' {
   return type === 'quantitative' || type === 'temporal';
 }
+
+/**
+ * Type-only discrete check (does not consider binning).
+ * For a field-aware version that treats binned quantitative fields as discrete,
+ * use `isDiscrete` from `./channeldef.js`.
+ * Note: `tooltipRefForEncoding` relies on this type-only check so that binned
+ * quantitative fields keep the bin-range tooltip format instead of the
+ * discrete format.
+ */
 export function isDiscrete(type: Type): type is 'ordinal' | 'nominal' {
   return type === 'ordinal' || type === 'nominal';
 }

--- a/test/channeldef.test.ts
+++ b/test/channeldef.test.ts
@@ -7,6 +7,7 @@ import {
   defaultType,
   functionalTitleFormatter,
   initChannelDef,
+  isDiscrete,
   TypedFieldDef,
   vgField,
 } from '../src/channeldef.js';
@@ -344,5 +345,51 @@ describe('fieldDef', () => {
       const fieldDef = {field: 'f', type: TEMPORAL};
       expect(defaultTitle(fieldDef, {})).toBe('f');
     });
+  });
+});
+
+describe('isDiscrete()', () => {
+  it('returns true for nominal field def', () => {
+    expect(isDiscrete({field: 'f', type: 'nominal'})).toBe(true);
+  });
+
+  it('returns true for ordinal field def', () => {
+    expect(isDiscrete({field: 'f', type: 'ordinal'})).toBe(true);
+  });
+
+  it('returns true for geojson field def', () => {
+    expect(isDiscrete({field: 'f', type: 'geojson'})).toBe(true);
+  });
+
+  it('returns false for temporal field def', () => {
+    expect(isDiscrete({field: 'f', type: 'temporal'})).toBe(false);
+  });
+
+  it('returns false for unbinned quantitative field def', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative'})).toBe(false);
+  });
+
+  it('returns true for binned quantitative field def (bin: true)', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative', bin: true})).toBe(true);
+  });
+
+  it('returns true for pre-binned quantitative field def (bin: "binned")', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative', bin: 'binned'})).toBe(true);
+  });
+
+  it('returns true for quantitative field def with bin params', () => {
+    expect(isDiscrete({field: 'f', type: 'quantitative', bin: {maxbins: 10}})).toBe(true);
+  });
+
+  it('returns false for quantitative datum def (datum defs cannot be binned)', () => {
+    expect(isDiscrete({datum: 1, type: 'quantitative'})).toBe(false);
+  });
+
+  it('returns true for nominal datum def', () => {
+    expect(isDiscrete({datum: 'a', type: 'nominal'})).toBe(true);
+  });
+
+  it('throws for a def without explicit type', () => {
+    expect(() => isDiscrete({datum: 1} as any)).toThrow('Invalid field type "undefined".');
   });
 });

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -644,3 +644,60 @@ it('should not generate cursor for interval selection', () => {
 
   expect(spec.marks[0].encode.update.cursor).toBeUndefined();
 });
+
+describe('compile with binned position and offset channel', () => {
+  it(
+    'drops xOffset for binned x (bin: true) and compiles without an xOffset scale',
+    log.wrap((localLogger) => {
+      const {spec} = compile({
+        data: {values: [{a: 1, b: 'P'}]},
+        mark: 'bar',
+        encoding: {
+          x: {field: 'a', type: 'quantitative', bin: true},
+          y: {aggregate: 'count', type: 'quantitative'},
+          xOffset: {field: 'b', type: 'nominal'},
+        },
+      });
+
+      expect(localLogger.warns).toContain(log.message.offsetNestedInsideContinuousPositionScaleDropped('x'));
+      expect((spec.scales ?? []).map((s) => s.name)).not.toContain('xOffset');
+    }),
+  );
+
+  it(
+    'drops xOffset for pre-binned x (bin: "binned") and compiles without an xOffset scale',
+    log.wrap((localLogger) => {
+      const {spec} = compile({
+        data: {values: [{a: 1, a_end: 2, b: 'P'}]},
+        mark: 'bar',
+        encoding: {
+          x: {field: 'a', bin: 'binned', type: 'quantitative'},
+          x2: {field: 'a_end'},
+          y: {aggregate: 'count', type: 'quantitative'},
+          xOffset: {field: 'b', type: 'nominal'},
+        },
+      });
+
+      expect(localLogger.warns).toContain(log.message.offsetNestedInsideContinuousPositionScaleDropped('x'));
+      expect((spec.scales ?? []).map((s) => s.name)).not.toContain('xOffset');
+    }),
+  );
+
+  it(
+    'drops yOffset for binned y and compiles without a yOffset scale',
+    log.wrap((localLogger) => {
+      const {spec} = compile({
+        data: {values: [{a: 1, b: 'P'}]},
+        mark: 'bar',
+        encoding: {
+          y: {field: 'a', type: 'quantitative', bin: true},
+          x: {aggregate: 'count', type: 'quantitative'},
+          yOffset: {field: 'b', type: 'nominal'},
+        },
+      });
+
+      expect(localLogger.warns).toContain(log.message.offsetNestedInsideContinuousPositionScaleDropped('y'));
+      expect((spec.scales ?? []).map((s) => s.name)).not.toContain('yOffset');
+    }),
+  );
+});

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -311,6 +311,20 @@ describe('compile/scale', () => {
         }
       });
 
+      it('should return a plain step (not an offset-based signal) when the offset field is binned quantitative', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          width: {step: 20},
+          mark: 'bar',
+          encoding: {
+            x: {field: 'b', type: 'nominal'},
+            y: {aggregate: 'count', type: 'quantitative'},
+            xOffset: {field: 'a', type: 'quantitative', bin: true},
+          },
+        });
+
+        expect(parseRangeForChannel('x', model)).toEqual(makeExplicit({step: 20}));
+      });
+
       it('should drop rangeStep for continuous scales', () => {
         for (const scaleType of QUANTITATIVE_SCALES) {
           log.wrap((localLogger) => {

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -13,6 +13,7 @@ import {
 import {isPositionFieldOrDatumDef} from '../src/channeldef.js';
 import {defaultConfig} from '../src/config.js';
 import {
+  channelHasNestedOffsetScale,
   Encoding,
   extractTransformsFromEncoding,
   fieldDefs,
@@ -102,6 +103,26 @@ describe('encoding', () => {
 
         expect(encoding).toEqual({
           x: {field: 'a', type: 'quantitative'},
+        });
+        expect(logger.warns[0]).toEqual(log.message.offsetNestedInsideContinuousPositionScaleDropped('x'));
+      }),
+    );
+
+    it(
+      'drops xOffset if x is binned quantitative',
+      log.wrap((logger) => {
+        const encoding = initEncoding(
+          {
+            x: {field: 'a', type: 'quantitative', bin: true},
+            xOffset: {field: 'b', type: 'nominal'},
+          },
+          'point',
+          false,
+          defaultConfig,
+        );
+
+        expect(encoding).toEqual({
+          x: {field: 'a', type: 'quantitative', bin: {maxbins: 10}},
         });
         expect(logger.warns[0]).toEqual(log.message.offsetNestedInsideContinuousPositionScaleDropped('x'));
       }),
@@ -559,6 +580,57 @@ describe('encoding', () => {
         {field: 'foo', type: 'quantitative'},
         {field: 'bar', test: 'datum.val > 12', type: 'quantitative'},
       ]);
+    });
+  });
+
+  describe('channelHasNestedOffsetScale', () => {
+    it('returns true for nominal x with xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'nominal'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for ordinal x with xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'ordinal'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for binned quantitative x with xOffset (type-only check ignores binning)', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'quantitative', bin: true}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for unbinned quantitative x with xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'quantitative'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false when offset channel is missing', () => {
+      expect(channelHasNestedOffsetScale<string>({x: {field: 'a', type: 'nominal'}}, 'x')).toBe(false);
+    });
+
+    it('returns true for temporal x with timeUnit and xOffset', () => {
+      expect(
+        channelHasNestedOffsetScale<string>(
+          {x: {field: 'a', type: 'temporal', timeUnit: 'year'}, xOffset: {field: 'b', type: 'nominal'}},
+          'x',
+        ),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Salvages the test coverage and documentation clarifications from #9843 (thanks @1wos!) without any production logic changes, and adds the compile-level regression tests that the review of that PR surfaced as missing. Refs #9596.

## Salvaged from #9843 (adapted to current `main` behavior)

- Doc comments on `isDiscrete`/`isContinuous` in `src/type.ts` clarifying that they are type-only (not bin-aware), pointing to the field-aware `isDiscrete` in `src/channeldef.ts`, and noting that the tooltip encoder deliberately relies on the type-only check to keep the bin-range tooltip format.
- Unit tests for `channeldef.isDiscrete` covering all five types, `bin: true` / bin params / `bin: "binned"`, datum defs, and the throw on a missing type.
- Unit tests for `channelHasNestedOffsetScale` (nominal/ordinal/binned/unbinned quantitative, missing offset channel, temporal + timeUnit), pinning the current type-only semantics.
- An `initEncoding` test pinning that `xOffset` is dropped (with a warning) when `x` is binned quantitative.

## New compile-level regression tests

The review of #9843 showed that changing these predicates could crash `compile()` or silently change sizing without any existing test failing. These tests pin the current end-to-end behavior:

- Binned `x` (`bin: true`) + `xOffset` compiles with the `offsetNestedInsideContinuousPositionScaleDropped` warning and no `xOffset` scale (also covered for pre-binned `bin: "binned"` + `x2`, and for `y`/`yOffset`).
- Nominal `x` + binned quantitative `xOffset` with `width: {step: 20}` keeps a plain `{step: 20}` range instead of an offset-based step signal.

## Test plan

- `npx vitest run test/` — 129 files, 3296 tests passing
- `npx tsc --noEmit -p .` — clean
- `prettier --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)