### PR TITLE
refactor: back mark type guards by shared as-const lists and sets

### DIFF
--- a/src/mark.ts
+++ b/src/mark.ts
@@ -51,12 +51,21 @@ export const PATH_MARKS = ['line', 'area', 'trail'] as const;
 
 export type PathMark = (typeof PATH_MARKS)[number];
 
+const PATH_MARK_SET = new Set(PATH_MARKS) as ReadonlySet<Mark | CompositeMark>;
+
 export function isPathMark(m: Mark | CompositeMark): m is PathMark {
-  return ['line', 'area', 'trail'].includes(m);
+  return PATH_MARK_SET.has(m);
 }
 
-export function isRectBasedMark(m: Mark | CompositeMark): m is 'rect' | 'bar' | 'image' | 'arc' | 'tick' {
-  return ['rect', 'bar', 'image', 'arc', 'tick' /* arc is rect/interval in polar coordinate */].includes(m);
+/* arc is rect/interval in polar coordinate */
+export const RECT_BASED_MARKS = ['rect', 'bar', 'image', 'arc', 'tick'] as const;
+
+export type RectBasedMark = (typeof RECT_BASED_MARKS)[number];
+
+const RECT_BASED_MARK_SET = new Set(RECT_BASED_MARKS) as ReadonlySet<Mark | CompositeMark>;
+
+export function isRectBasedMark(m: Mark | CompositeMark): m is RectBasedMark {
+  return RECT_BASED_MARK_SET.has(m);
 }
 
 export const PRIMITIVE_MARKS = new Set(keys(Mark));


### PR DESCRIPTION
Aligns the mark type-guard helpers in `src/mark.ts` with the repo's existing set/typing convention (single `as const` list → derived union type → `ReadonlySet` for membership → type-guard function), as used in e.g. `aggregate.ts` and `scale.ts`:

- `isPathMark` no longer re-lists `['line', 'area', 'trail']` inline — it now checks membership in a `ReadonlySet` built from the existing `PATH_MARKS` list, deduping the array.
- `isRectBasedMark` gets the full treatment: new `RECT_BASED_MARKS` as-const list (keeping the `/* arc is rect/interval in polar coordinate */` note), derived `RectBasedMark` type used as the guard's return type, and `ReadonlySet` membership instead of an inline array.

Pure type/structure refactor — no behavior change. `PRIMITIVE_MARKS` keeps its existing cast in `isPrimitiveMark` because widening it to `ReadonlySet<Mark | CompositeMark>` ripples into tests that iterate the set as `Mark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)