### PR TITLE
fix: anchor ranged offsets without base channels

### DIFF
--- a/src/compile/mark/encode/position-point.ts
+++ b/src/compile/mark/encode/position-point.ts
@@ -29,7 +29,7 @@ export function pointPosition(
     defaultPos,
     vgChannel,
   }: {
-    defaultPos: 'mid' | 'zeroOrMin' | 'zeroOrMax' | null;
+    defaultPos: 'mid' | 'zeroOrMin' | 'zeroOrMax' | 'start' | null;
     vgChannel?: 'x' | 'y' | 'xc' | 'yc';
   },
 ) {
@@ -127,7 +127,7 @@ export function pointPositionDefaultRef({
   scale,
 }: {
   model: UnitModel;
-  defaultPos: 'mid' | 'zeroOrMin' | 'zeroOrMax' | null;
+  defaultPos: 'mid' | 'zeroOrMin' | 'zeroOrMax' | 'start' | null;
   channel: PositionChannel | PolarPositionChannel;
   scaleName: string;
   scale: ScaleComponent;
@@ -143,6 +143,8 @@ export function pointPositionDefaultRef({
     }
 
     switch (defaultPos) {
+      case 'start':
+        return {value: 0};
       case 'zeroOrMin':
         return zeroOrMinOrMaxPosition({scaleName, scale, mode: 'zeroOrMin', mainChannel, config});
       case 'zeroOrMax':

--- a/src/compile/mark/encode/position-range.ts
+++ b/src/compile/mark/encode/position-range.ts
@@ -29,8 +29,8 @@ export function pointOrRangePosition(
     defaultPos2,
     range,
   }: {
-    defaultPos: 'zeroOrMin' | 'zeroOrMax' | 'mid';
-    defaultPos2: 'zeroOrMin' | 'zeroOrMax';
+    defaultPos: 'zeroOrMin' | 'zeroOrMax' | 'mid' | 'start';
+    defaultPos2: 'zeroOrMin' | 'zeroOrMax' | 'start';
     range: boolean;
   },
 ) {
@@ -47,11 +47,15 @@ export function rangePosition(
     defaultPos,
     defaultPos2,
   }: {
-    defaultPos: 'zeroOrMin' | 'zeroOrMax' | 'mid';
-    defaultPos2: 'zeroOrMin' | 'zeroOrMax';
+    defaultPos: 'zeroOrMin' | 'zeroOrMax' | 'mid' | 'start';
+    defaultPos2: 'zeroOrMin' | 'zeroOrMax' | 'start';
   },
 ): VgEncodeEntry {
   const {markDef, config} = model;
+  if (!model.encoding[channel] && model.isRangedOffset(channel)) {
+    defaultPos = 'start';
+    defaultPos2 = 'start';
+  }
   const channel2 = getSecondaryRangeChannel(channel);
   const sizeChannel = getSizeChannel(channel);
 
@@ -75,7 +79,7 @@ export function rangePosition(
  */
 function pointPosition2OrSize(
   model: UnitModel,
-  defaultPos: 'zeroOrMin' | 'zeroOrMax',
+  defaultPos: 'zeroOrMin' | 'zeroOrMax' | 'start',
   channel: 'x2' | 'y2' | 'radius2' | 'theta2',
 ) {
   const {encoding, mark, markDef, stack, config} = model;
@@ -138,21 +142,19 @@ function pointPosition2OrSize(
     }) ||
     position2orSize(channel, config[mark]) ||
     position2orSize(channel, config.mark) ||
-    (isFieldOrDatumDef(channelDef) && model.isRangedOffset(baseChannel)
+    (model.isRangedOffset(baseChannel)
       ? {
-          [vgChannel]: ref.valueRefForFieldOrDatumDef(
-            channelDef,
-            scaleName,
-            {},
-            {
-              offset: ref.valueRefForFieldOrDatumDef(
-                {datum: 0},
-                model.scaleName(getOffsetScaleChannel(baseChannel)),
-                {},
-                {},
-              ),
-            },
-          ),
+          [vgChannel]: {
+            ...(isFieldOrDatumDef(channelDef)
+              ? ref.valueRefForFieldOrDatumDef(channelDef, scaleName, {}, {})
+              : pointPositionDefaultRef({model, defaultPos, channel: baseChannel, scaleName, scale})()),
+            offset: ref.valueRefForFieldOrDatumDef(
+              {datum: 0},
+              model.scaleName(getOffsetScaleChannel(baseChannel)),
+              {},
+              {},
+            ),
+          },
         }
       : {
           [vgChannel]: pointPositionDefaultRef({

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -402,6 +402,9 @@ function getOffsetRange(channel: string, model: UnitModel, offsetScaleType: Scal
   const positionScaleCmpt = model.getScaleComponent(positionChannel);
 
   if (!positionScaleCmpt) {
+    if (model.isRangedOffset(positionChannel)) {
+      return fullWidthOrHeightRange(positionChannel, model, offsetScaleType);
+    }
     return fullWidthOrHeightRange(positionChannel, model, offsetScaleType, {center: true});
   }
 

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -298,6 +298,33 @@ describe('compile/compile', () => {
     expect((pointSpec.scales.find((s: any) => s.name === 'yOffset') as any).zero).toBe(false);
   });
 
+  it('should compile signed yOffset bars around offset zero when y is omitted', () => {
+    const {spec} = compile({
+      height: 300,
+      data: {
+        values: [
+          {a: 'A', b: -28, c: 'x'},
+          {a: 'B', b: -55, c: 'x'},
+          {a: 'A', b: 88, c: 'y'},
+          {a: 'B', b: 55, c: 'y'},
+        ],
+      },
+      mark: 'bar',
+      encoding: {
+        x: {field: 'a'},
+        yOffset: {field: 'b', type: 'quantitative'},
+        color: {field: 'c'},
+      },
+    });
+
+    const yOffsetScale = spec.scales.find((scale) => scale.name === 'yOffset') as any;
+    expect(yOffsetScale.range).toEqual([{signal: 'height'}, 0]);
+    expect(yOffsetScale.zero).toBe(true);
+    expect(spec.marks[0].encode.update.y).toEqual({value: 0, offset: {scale: 'yOffset', field: 'b'}});
+    expect(spec.marks[0].encode.update.y2).toEqual({value: 0, offset: {scale: 'yOffset', value: 0}});
+    expect(spec.scales.some((scale) => scale.name === 'y')).toBe(false);
+  });
+
   it('should group line paths by an explicit detail field when yOffset is aggregated', () => {
     const {spec} = compile({
       data: {
@@ -431,7 +458,7 @@ describe('compile/compile', () => {
 
     const update = spec.marks[0].encode.update;
     expect(update.y).toEqual({value: 0, offset: {scale: 'yOffset', field: 'sum_b'}});
-    expect(update.y2).toEqual({field: {group: 'height'}});
+    expect(update.y2).toEqual({value: 0, offset: {scale: 'yOffset', value: 0}});
   });
 
   it('should use containerSize for width and autosize to fit-y/padding', () => {

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -156,7 +156,23 @@ describe('Mark: Area', () => {
 
     it('should use zero as the offset edge to match line and point positions', () => {
       expect(props.y).toEqual({value: 0, offset: {scale: 'yOffset', field: 'sum_b'}});
-      expect(props.y2).toEqual({field: {group: 'height'}});
+      expect(props.y2).toEqual({value: 0, offset: {scale: 'yOffset', value: 0}});
+    });
+  });
+
+  describe('horizontal area with only xOffset', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      mark: 'area',
+      encoding: {
+        y: {field: 'a', type: 'nominal'},
+        xOffset: {field: 'b', type: 'quantitative'},
+      },
+    });
+    const props = area.encodeEntry(model);
+
+    it('should use zero as the offset edge', () => {
+      expect(props.x).toEqual({value: 0, offset: {scale: 'xOffset', field: 'b'}});
+      expect(props.x2).toEqual({value: 0, offset: {scale: 'xOffset', value: 0}});
     });
   });
 

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -64,6 +64,36 @@ describe('Mark: Bar', () => {
     expect(props.height).toBeUndefined();
   });
 
+  it('should draw yOffset bars from offset zero when y is omitted', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      mark: 'bar',
+      encoding: {
+        x: {field: 'category', type: 'nominal'},
+        yOffset: {field: 'value', type: 'quantitative'},
+      },
+    });
+    const props = bar.encodeEntry(model);
+
+    expect(props.y).toEqual({value: 0, offset: {scale: 'yOffset', field: 'value'}});
+    expect(props.y2).toEqual({value: 0, offset: {scale: 'yOffset', value: 0}});
+    expect(props.x).toEqual({scale: 'x', field: 'category'});
+  });
+
+  it('should draw xOffset bars from offset zero when x is omitted', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      mark: 'bar',
+      encoding: {
+        y: {field: 'category', type: 'nominal'},
+        xOffset: {field: 'value', type: 'quantitative'},
+      },
+    });
+    const props = bar.encodeEntry(model);
+
+    expect(props.x).toEqual({value: 0, offset: {scale: 'xOffset', field: 'value'}});
+    expect(props.x2).toEqual({value: 0, offset: {scale: 'xOffset', value: 0}});
+    expect(props.y).toEqual({scale: 'y', field: 'category'});
+  });
+
   it('should draw horizontal bar, with y from zero to field value and bar with quantitative x, x2, and y', () => {
     const x: PositionFieldDef<string> = {field: 'q_start', type: 'quantitative'};
     const x2: SecondaryFieldDef<string> = {field: 'q_end'};

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -344,6 +344,19 @@ describe('compile/scale', () => {
     });
 
     describe('xOffset', () => {
+      it('returns the full width for a ranged bar without x', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          width: 500,
+          mark: 'bar',
+          encoding: {
+            y: {field: 'y', type: 'nominal'},
+            xOffset: {field: 'value', type: 'quantitative'},
+          },
+        });
+
+        expect(parseRangeForChannel('xOffset', model)).toEqual(makeImplicit([0, {signal: 'width'}]));
+      });
+
       it('returns [0, bandwidth] if x is band scale with fixed width', () => {
         const model = parseUnitModelWithScaleExceptRange({
           width: 500,
@@ -415,6 +428,34 @@ describe('compile/scale', () => {
     });
 
     describe('yOffset', () => {
+      it('returns the full reversed height for a ranged bar without y', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          height: 500,
+          mark: 'bar',
+          encoding: {
+            x: {field: 'x', type: 'nominal'},
+            yOffset: {field: 'value', type: 'quantitative'},
+          },
+        });
+
+        expect(parseRangeForChannel('yOffset', model)).toEqual(makeImplicit([{signal: 'height'}, 0]));
+      });
+
+      it('keeps a centered range for a point without y', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          height: 500,
+          mark: 'point',
+          encoding: {
+            x: {field: 'x', type: 'nominal'},
+            yOffset: {field: 'value', type: 'quantitative'},
+          },
+        });
+
+        expect(parseRangeForChannel('yOffset', model)).toEqual(
+          makeImplicit([{signal: 'height/2'}, {signal: '-height/2'}]),
+        );
+      });
+
       it("returns [bandwidth('y'), 0] for continuous yOffset nested in band y", () => {
         const model = parseUnitModelWithScaleExceptRange({
           mark: 'bar',


### PR DESCRIPTION
This is a minor follow up on #9823 which makes ranged offset also work when there only one axis encoding.

These changes treat a missing x or y position as one implicit full-view lane/band when a bar or area is driven by a quantitative offset. Both generated range edges are anchored at the same screen origin, using the encoded offset for one edge and offset zero for the other. Ranged xOffset and yOffset now scales the full width or reversed height so signed values remain visible and diverge in the expected directions. Centered offset ranges for point and line marks are preserved.

| Before this PR | After this PR |
|-|-|
| <img width="129" height="192" alt="image" src="https://github.com/user-attachments/assets/29b14a93-cd62-4b7f-9943-56f37d388be3" /> | <img width="133" height="144" alt="image" src="https://github.com/user-attachments/assets/6c17c729-435a-4332-9a11-6745833b7b8f" /> |

[Open the Chart in the Vega Editor](https://vega.github.io/editor/#/url/vega-lite/N4IgFgpglg5mAuIBcBGADGgNCAJgQ3j2VADc8AbAVwgGdkBtUIpEAQRGwCNkBaAJgAc2AMbIQADw64xAWxABfTEzEAhKdyQ8ArFpFjJ2HLIVKQzEAGF1vACwBmPSwPSWAOxPKWAEWuaAnCiOElJGbh5mYuxcyAJCIKIsAJ4hxoqeIGrRSDpByYappuZWWfa5KWFpEd6+OfFieS4g7vIAuoogMngATgDWxCDwiQAOEGKc3SYgEK7CAPY4UK4w-ZJIoABmUBDkoRHtiQDy6+s0EIhrIJvbu9zYgyNiAI6UeK7wUITvJKPtc+SzXX6Vx2YlE8nBQA)

Note that on main you could add an undefined channel (e.g. `"y": {"field": "aa"}`) to see something closer to the correct behavior, but with this PR that workaround will not be needed:


<img width="199" height="142" alt="image" src="https://github.com/user-attachments/assets/86a858a0-3ade-424a-91e8-084549cc6c3e" />



