### PR TITLE
fix: align ranged offsets to closest-to-zero baseline

### DIFF
--- a/examples/compiled/area_ranged_offset_quantitative.vg.json
+++ b/examples/compiled/area_ranged_offset_quantitative.vg.json
@@ -71,7 +71,9 @@
               "y2": {
                 "scale": "y",
                 "field": "team",
-                "offset": {"scale": "yOffset", "value": 0}
+                "offset": {
+                  "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])), 0, bandwidth(\"y\")) : (isFinite(bandwidth(\"y\")) ? (bandwidth(\"y\")) / 2 : 0)"
+                }
               },
               "defined": {
                 "signal": "isValid(datum[\"score\"]) && isFinite(+datum[\"score\"])"
@@ -122,10 +124,20 @@
       "orient": "left",
       "grid": false,
       "title": "team",
-      "bandPosition": 1,
+      "bandPosition": {
+        "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5"
+      },
       "encode": {
         "labels": {
-          "update": {"y": {"scale": "y", "signal": "datum.value", "band": 1}}
+          "update": {
+            "y": {
+              "scale": "y",
+              "signal": "datum.value",
+              "band": {
+                "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5"
+              }
+            }
+          }
         }
       },
       "zindex": 0

--- a/examples/compiled/area_ranged_offset_quantitative.vg.json
+++ b/examples/compiled/area_ranged_offset_quantitative.vg.json
@@ -131,11 +131,7 @@
         "labels": {
           "update": {
             "y": {
-              "scale": "y",
-              "signal": "datum.value",
-              "band": {
-                "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5"
-              }
+              "signal": "scale(\"y\", datum.value) + bandwidth(\"y\") * (isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5)"
             }
           }
         }

--- a/examples/compiled/bar_ranged_offset_quantitative.vg.json
+++ b/examples/compiled/bar_ranged_offset_quantitative.vg.json
@@ -127,11 +127,7 @@
         "labels": {
           "update": {
             "y": {
-              "scale": "y",
-              "signal": "datum.value",
-              "band": {
-                "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5"
-              }
+              "signal": "scale(\"y\", datum.value) + bandwidth(\"y\") * (isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5)"
             }
           }
         }

--- a/examples/compiled/bar_ranged_offset_quantitative.vg.json
+++ b/examples/compiled/bar_ranged_offset_quantitative.vg.json
@@ -65,7 +65,9 @@
           "y2": {
             "scale": "y",
             "field": "team",
-            "offset": {"scale": "yOffset", "value": 0}
+            "offset": {
+              "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])), 0, bandwidth(\"y\")) : (isFinite(bandwidth(\"y\")) ? (bandwidth(\"y\")) / 2 : 0)"
+            }
           }
         }
       }
@@ -118,10 +120,20 @@
       "orient": "left",
       "grid": false,
       "title": "team",
-      "bandPosition": 1,
+      "bandPosition": {
+        "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5"
+      },
       "encode": {
         "labels": {
-          "update": {"y": {"scale": "y", "signal": "datum.value", "band": 1}}
+          "update": {
+            "y": {
+              "scale": "y",
+              "signal": "datum.value",
+              "band": {
+                "signal": "isFinite(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1]))) && isFinite(bandwidth(\"y\")) && bandwidth(\"y\") > 0 ? clamp(scale(\"yOffset\", clamp(0, extent(domain(\"yOffset\"))[0], extent(domain(\"yOffset\"))[1])) / bandwidth(\"y\"), 0, 1) : 0.5"
+              }
+            }
+          }
         }
       },
       "zindex": 0

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -1,5 +1,7 @@
+import {stringValue} from 'vega-util';
 import {getSecondaryRangeChannel, PositionScaleChannel} from '../../channel.js';
 import {channelDefType, getFieldOrDatumDef, isFieldDef, isPositionFieldOrDatumDef} from '../../channeldef.js';
+import {isSignalRef} from '../../vega.schema.js';
 import {formatCustomType, isCustomFormatType} from '../format.js';
 import {UnitModel} from '../unit.js';
 import {defaultBandPosition} from './properties.js';
@@ -101,11 +103,12 @@ function labelsPositionSpec(model: UnitModel, channel: PositionScaleChannel, spe
     return specifiedLabelsSpec;
   }
 
-  const positionRef = {
-    scale: model.scaleName(channel),
-    signal: 'datum.value',
-    band: bandPosition,
-  };
+  const scaleName = model.scaleName(channel);
+  const positionRef = isSignalRef(bandPosition)
+    ? {
+        signal: `scale(${stringValue(scaleName)}, datum.value) + bandwidth(${stringValue(scaleName)}) * (${bandPosition.signal})`,
+      }
+    : {scale: scaleName, signal: 'datum.value', band: bandPosition};
 
   return {
     ...(channel === 'x' ? {x: positionRef} : {y: positionRef}),

--- a/src/compile/axis/properties.ts
+++ b/src/compile/axis/properties.ts
@@ -23,6 +23,7 @@ import {contains, normalizeAngle} from '../../util.js';
 import {isSignalRef} from '../../vega.schema.js';
 import {mergeTitle, mergeTitleFieldDefs} from '../common.js';
 import {guideFormatType} from '../format.js';
+import {rangedOffsetBaseline} from '../scale/rangedOffset.js';
 import {UnitModel} from '../unit.js';
 import {ScaleType} from './../../scale.js';
 import {AxisComponentProps} from './component.js';
@@ -124,7 +125,7 @@ export function defaultGrid(scaleType: ScaleType, fieldDef: TypedFieldDef<string
 
 export function defaultBandPosition(model: UnitModel, channel: PositionScaleChannel) {
   if (model.isRangedOffset(channel)) {
-    return channel === 'x' ? 0 : 1;
+    return rangedOffsetBaseline(model, channel).bandPosition;
   }
   return undefined;
 }

--- a/src/compile/mark/encode/position-range.ts
+++ b/src/compile/mark/encode/position-range.ts
@@ -1,17 +1,12 @@
 import type {SignalRef} from 'vega';
-import {
-  getMainRangeChannel,
-  getOffsetScaleChannel,
-  getSecondaryRangeChannel,
-  getSizeChannel,
-  getVgPositionChannel,
-} from '../../../channel.js';
+import {getMainRangeChannel, getSecondaryRangeChannel, getSizeChannel, getVgPositionChannel} from '../../../channel.js';
 import {isFieldOrDatumDef} from '../../../channeldef.js';
 import * as log from '../../../log/index.js';
 import {isRelativeBandSize, Mark, MarkConfig, MarkDef} from '../../../mark.js';
 import {VgEncodeEntry, VgValueRef} from '../../../vega.schema.js';
 import {getMarkStyleConfig} from '../../common.js';
 import {UnitModel} from '../../unit.js';
+import {rangedOffsetBaseline} from '../../scale/rangedOffset.js';
 import {positionOffset} from './offset.js';
 import {vgAlignedPositionChannel} from './position-align.js';
 import {pointPosition, pointPositionDefaultRef} from './position-point.js';
@@ -138,21 +133,12 @@ function pointPosition2OrSize(
     }) ||
     position2orSize(channel, config[mark]) ||
     position2orSize(channel, config.mark) ||
-    (isFieldOrDatumDef(channelDef) && model.isRangedOffset(baseChannel)
+    (isFieldOrDatumDef(channelDef) && (baseChannel === 'x' || baseChannel === 'y') && model.isRangedOffset(baseChannel)
       ? {
-          [vgChannel]: ref.valueRefForFieldOrDatumDef(
-            channelDef,
-            scaleName,
-            {},
-            {
-              offset: ref.valueRefForFieldOrDatumDef(
-                {datum: 0},
-                model.scaleName(getOffsetScaleChannel(baseChannel)),
-                {},
-                {},
-              ),
-            },
-          ),
+          [vgChannel]: {
+            ...ref.valueRefForFieldOrDatumDef(channelDef, scaleName, {}, {}),
+            offset: rangedOffsetBaseline(model, baseChannel).offset,
+          },
         }
       : {
           [vgChannel]: pointPositionDefaultRef({

--- a/src/compile/scale/rangedOffset.ts
+++ b/src/compile/scale/rangedOffset.ts
@@ -1,0 +1,60 @@
+import {SignalRef} from 'vega';
+import {stringValue} from 'vega-util';
+import {getOffsetScaleChannel, PositionScaleChannel} from '../../channel.js';
+import {isContinuousToContinuous} from '../../scale.js';
+import {VgValueRef} from '../../vega.schema.js';
+import {UnitModel} from '../unit.js';
+
+export interface RangedOffsetBaseline {
+  offset: VgValueRef;
+  bandPosition: number | SignalRef;
+}
+
+/** Returns a safe offset baseline and its relative position within the base band. */
+export function rangedOffsetBaseline(model: UnitModel, channel: PositionScaleChannel): RangedOffsetBaseline {
+  const offsetChannel = getOffsetScaleChannel(channel);
+  const offsetScale = model.getScaleComponent(offsetChannel);
+  const offsetScaleName = model.scaleName(offsetChannel);
+  const positionScale = model.getScaleComponent(channel);
+  const positionScaleName = model.scaleName(channel);
+
+  if (!offsetScale || !offsetScaleName) {
+    return {offset: {value: 0}, bandPosition: positionScale?.get('type') === 'band' ? 0 : 0.5};
+  }
+
+  const offsetScaleType = offsetScale.get('type');
+  if (!isContinuousToContinuous(offsetScaleType)) {
+    return fallbackBaseline(positionScaleName, positionScale?.get('type'));
+  }
+
+  const offsetName = stringValue(offsetScaleName);
+  const domainExtent = `extent(domain(${offsetName}))`;
+  const closestToZero = `clamp(0, ${domainExtent}[0], ${domainExtent}[1])`;
+  const scaledBaseline = `scale(${offsetName}, ${closestToZero})`;
+
+  if (positionScale?.get('type') === 'band' && positionScaleName) {
+    const bandwidth = `bandwidth(${stringValue(positionScaleName)})`;
+    const valid = `isFinite(${scaledBaseline}) && isFinite(${bandwidth}) && ${bandwidth} > 0`;
+    return {
+      offset: {
+        signal: `${valid} ? clamp(${scaledBaseline}, 0, ${bandwidth}) : (isFinite(${bandwidth}) ? (${bandwidth}) / 2 : 0)`,
+      },
+      bandPosition: {
+        signal: `${valid} ? clamp(${scaledBaseline} / ${bandwidth}, 0, 1) : 0.5`,
+      },
+    };
+  }
+
+  return {offset: {value: 0}, bandPosition: 0.5};
+}
+
+function fallbackBaseline(positionScaleName: string, positionScaleType: string | undefined): RangedOffsetBaseline {
+  if (positionScaleType === 'band' && positionScaleName) {
+    return {
+      offset: {signal: `bandwidth(${stringValue(positionScaleName)}) / 2`},
+      bandPosition: 0.5,
+    };
+  }
+
+  return {offset: {value: 0}, bandPosition: 0.5};
+}

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -1,5 +1,6 @@
 import * as encode from '../../../src/compile/axis/encode.js';
 import {rangedOffsetBaseline} from '../../../src/compile/scale/rangedOffset.js';
+import {isSignalRef} from '../../../src/vega.schema.js';
 import {parseUnitModelWithScale} from '../../util.js';
 
 describe('compile/axis/encode', () => {
@@ -114,8 +115,12 @@ describe('compile/axis/encode', () => {
       });
 
       const labels = encode.labels(model, 'y', {});
+      const bandPosition = rangedOffsetBaseline(model, 'y').bandPosition;
+      if (!isSignalRef(bandPosition)) {
+        throw new Error('Expected a signal-valued band position.');
+      }
       expect(labels).toEqual({
-        y: {scale: 'y', signal: 'datum.value', band: rangedOffsetBaseline(model, 'y').bandPosition},
+        y: {signal: `scale("y", datum.value) + bandwidth("y") * (${bandPosition.signal})`},
       });
     });
 

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -1,4 +1,5 @@
 import * as encode from '../../../src/compile/axis/encode.js';
+import {rangedOffsetBaseline} from '../../../src/compile/scale/rangedOffset.js';
 import {parseUnitModelWithScale} from '../../util.js';
 
 describe('compile/axis/encode', () => {
@@ -114,7 +115,7 @@ describe('compile/axis/encode', () => {
 
       const labels = encode.labels(model, 'y', {});
       expect(labels).toEqual({
-        y: {scale: 'y', signal: 'datum.value', band: 1},
+        y: {scale: 'y', signal: 'datum.value', band: rangedOffsetBaseline(model, 'y').bandPosition},
       });
     });
 

--- a/test/compile/axis/properties.test.ts
+++ b/test/compile/axis/properties.test.ts
@@ -4,6 +4,7 @@ import {stringValue} from 'vega-util';
 import {getAxisConfigs} from '../../../src/compile/axis/config.js';
 import * as properties from '../../../src/compile/axis/properties.js';
 import {defaultLabelAlign, defaultLabelBaseline, getLabelAngle} from '../../../src/compile/axis/properties.js';
+import {rangedOffsetBaseline} from '../../../src/compile/scale/rangedOffset.js';
 import {TimeUnit, TimeUnitTransformParams} from '../../../src/timeunit.js';
 import {normalizeAngle} from '../../../src/util.js';
 import {isSignalRef} from '../../../src/vega.schema.js';
@@ -40,7 +41,7 @@ describe('compile/axis/properties', () => {
   });
 
   describe('bandPosition', () => {
-    it('should set y-axis bandPosition to 1 for bar with discrete y and continuous yOffset', () => {
+    it('should position the y-axis at the closest-to-zero yOffset baseline', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'bar',
         data: {values: [{a: 'A', b: 1, c: 'x'}]},
@@ -51,24 +52,24 @@ describe('compile/axis/properties', () => {
         },
       });
 
-      expect(
-        properties.axisRules.bandPosition({
-          axis: {},
-          model,
-          channel: 'y',
-          fieldOrDatumDef: model.encoding.y as any,
-          mark: model.mark,
-          scaleType: model.getScaleComponent('y').get('type'),
-          orient: 'left',
-          labelAngle: undefined,
-          format: undefined,
-          formatType: undefined,
-          config: model.config,
-        }),
-      ).toBe(1);
+      const bandPosition = properties.axisRules.bandPosition({
+        axis: {},
+        model,
+        channel: 'y',
+        fieldOrDatumDef: model.encoding.y as any,
+        mark: model.mark,
+        scaleType: model.getScaleComponent('y').get('type'),
+        orient: 'left',
+        labelAngle: undefined,
+        format: undefined,
+        formatType: undefined,
+        config: model.config,
+      });
+      expect(bandPosition).toEqual(rangedOffsetBaseline(model, 'y').bandPosition);
+      expect(isSignalRef(bandPosition)).toBe(true);
     });
 
-    it('should set x-axis bandPosition to 0 for bar with discrete x and continuous xOffset', () => {
+    it('should position the x-axis at the closest-to-zero xOffset baseline', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'bar',
         data: {values: [{a: 'A', b: 1, c: 'x'}]},
@@ -79,21 +80,36 @@ describe('compile/axis/properties', () => {
         },
       });
 
-      expect(
-        properties.axisRules.bandPosition({
-          axis: {},
-          model,
-          channel: 'x',
-          fieldOrDatumDef: model.encoding.x as any,
-          mark: model.mark,
-          scaleType: model.getScaleComponent('x').get('type'),
-          orient: 'bottom',
-          labelAngle: undefined,
-          format: undefined,
-          formatType: undefined,
-          config: model.config,
-        }),
-      ).toBe(0);
+      const bandPosition = properties.axisRules.bandPosition({
+        axis: {},
+        model,
+        channel: 'x',
+        fieldOrDatumDef: model.encoding.x as any,
+        mark: model.mark,
+        scaleType: model.getScaleComponent('x').get('type'),
+        orient: 'bottom',
+        labelAngle: undefined,
+        format: undefined,
+        formatType: undefined,
+        config: model.config,
+      });
+      expect(bandPosition).toEqual(rangedOffsetBaseline(model, 'x').bandPosition);
+      expect(isSignalRef(bandPosition)).toBe(true);
+    });
+
+    it('should keep the axis centered for point jitter', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: 'point',
+        data: {values: [{a: 1, b: 0.5, c: 'A'}]},
+        encoding: {
+          x: {field: 'a', type: 'quantitative'},
+          y: {field: 'c', type: 'ordinal'},
+          yOffset: {field: 'b', type: 'quantitative'},
+        },
+      });
+
+      expect(model.isRangedOffset('y')).toBe(false);
+      expect(properties.defaultBandPosition(model, 'y')).toBeUndefined();
     });
 
     it('should respect explicit axis.bandPosition', () => {

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -277,7 +277,8 @@ describe('compile/compile', () => {
     const point = spec.marks[2].encode.update;
 
     expect(bar.y).toEqual({scale: 'y', field: 'g', offset: {scale: 'yOffset', field: 'v'}});
-    expect(bar.y2).toEqual({scale: 'y', field: 'g', offset: {scale: 'yOffset', value: 0}});
+    expect(bar.y2).toMatchObject({scale: 'y', field: 'g'});
+    expect((bar.y2 as any).offset.signal).toContain('extent(domain("yOffset"))');
 
     expect(line.y).toEqual({scale: 'y', field: 'g', offset: {scale: 'yOffset', field: 'v'}});
     expect(point.y).toEqual({scale: 'y', field: 'g', offset: {scale: 'yOffset', field: 'v'}});
@@ -405,7 +406,8 @@ describe('compile/compile', () => {
 
     const update = (spec.marks[0] as any).marks[0].encode.update;
     expect(update.y).toEqual({scale: 'y', field: 'c', offset: {scale: 'yOffset', field: 'b'}});
-    expect(update.y2).toEqual({scale: 'y', field: 'c', offset: {scale: 'yOffset', value: 0}});
+    expect(update.y2).toMatchObject({scale: 'y', field: 'c'});
+    expect((update.y2 as any).offset.signal).toContain('extent(domain("yOffset"))');
   });
 
   it('should compile area with aggregated yOffset and no y as ranged geometry', () => {

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -1,6 +1,7 @@
 import {SignalRef} from 'vega';
 import {COLOR, X, Y} from '../../../src/channel.js';
 import {area} from '../../../src/compile/mark/area.js';
+import {rangedOffsetBaseline} from '../../../src/compile/scale/rangedOffset.js';
 import {Encoding} from '../../../src/encoding.js';
 import {NormalizedUnitSpec} from '../../../src/spec/index.js';
 import {internalField} from '../../../src/util.js';
@@ -128,7 +129,7 @@ describe('Mark: Area', () => {
 
     it('should use y as one edge and baseline at offset zero', () => {
       expect(props.y).toEqual({scale: 'y', field: 'Origin', offset: {scale: 'yOffset', field: 'US_Gross'}});
-      expect(props.y2).toEqual({scale: 'y', field: 'Origin', offset: {scale: 'yOffset', value: 0}});
+      expect(props.y2).toEqual({scale: 'y', field: 'Origin', offset: rangedOffsetBaseline(model, 'y').offset});
     });
 
     it('should not collapse to line geometry', () => {

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -1,5 +1,6 @@
 import {PositionFieldDef, SecondaryFieldDef} from '../../../src/channeldef.js';
 import {bar} from '../../../src/compile/mark/bar.js';
+import {rangedOffsetBaseline} from '../../../src/compile/scale/rangedOffset.js';
 import {DEFAULT_STEP} from '../../../src/config.js';
 import {defaultBarConfig} from '../../../src/mark.js';
 import {parseUnitModelWithScaleAndLayoutSize} from '../../util.js';
@@ -59,7 +60,7 @@ describe('Mark: Bar', () => {
     expect(props.y2).toEqual({
       scale: 'y',
       field: 'Cylinders',
-      offset: {scale: 'yOffset', value: 0},
+      offset: rangedOffsetBaseline(model, 'y').offset,
     });
     expect(props.height).toBeUndefined();
   });

--- a/test/compile/scale/rangedOffset.test.ts
+++ b/test/compile/scale/rangedOffset.test.ts
@@ -1,0 +1,131 @@
+import {parse, View} from 'vega';
+
+import {rangedOffsetBaseline} from '../../../src/compile/scale/rangedOffset.js';
+import {compile} from '../../../src/compile/compile.js';
+import {TopLevelSpec} from '../../../src/spec/index.js';
+import {parseUnitModelWithScale} from '../../util.js';
+
+describe('rangedOffsetBaseline', () => {
+  async function evaluateYAxisBandPosition(domain: number[], reverse = false, height?: number) {
+    const {spec} = compile({
+      height,
+      data: {
+        values: [
+          {category: 'A', offset: domain[0], value: 1},
+          {category: 'A', offset: domain[1], value: 2},
+        ],
+      },
+      mark: 'bar',
+      encoding: {
+        x: {field: 'value', type: 'quantitative'},
+        y: {field: 'category', type: 'nominal'},
+        yOffset: {field: 'offset', type: 'quantitative', scale: {domain, reverse}},
+      },
+    } as TopLevelSpec);
+
+    const axis = spec.axes?.find((candidate) => candidate.scale === 'y' && candidate.bandPosition !== undefined);
+    if (!axis || typeof axis.bandPosition !== 'object' || !('signal' in axis.bandPosition)) {
+      throw new Error('Expected a signal-valued y-axis bandPosition.');
+    }
+
+    spec.signals = [
+      ...(spec.signals ?? []),
+      {name: 'test_ranged_offset_band_position', update: axis.bandPosition.signal},
+    ];
+    const view = new View(parse(spec), {renderer: 'none'});
+    await view.runAsync();
+    return view.signal('test_ranged_offset_band_position') as number;
+  }
+
+  it.each([
+    {name: 'the lower endpoint for a positive domain', domain: [10, 20], expected: 1},
+    {name: 'the upper endpoint for a negative domain', domain: [-20, -10], expected: 0},
+    {name: 'zero for a diverging domain', domain: [-20, 10], expected: 1 / 3},
+    {name: 'zero for a reversed diverging scale', domain: [-20, 10], reverse: true, expected: 2 / 3},
+  ])('positions the baseline at $name', async ({domain, reverse, expected}) => {
+    expect(await evaluateYAxisBandPosition(domain, reverse)).toBeCloseTo(expected);
+  });
+
+  it('falls back to mid-band when the base bandwidth is zero', async () => {
+    expect(await evaluateYAxisBandPosition([10, 20], false, 0)).toBe(0.5);
+  });
+
+  it('falls back to mid-band for an unsupported offset scale', () => {
+    const model = parseUnitModelWithScale({
+      mark: 'bar',
+      encoding: {
+        x: {field: 'a', type: 'quantitative'},
+        y: {field: 'b', type: 'nominal'},
+        yOffset: {field: 'c', type: 'quantitative'},
+      },
+    });
+    model.getScaleComponent('yOffset').set('type', 'quantize', true);
+
+    expect(rangedOffsetBaseline(model, 'y')).toEqual({
+      offset: {signal: 'bandwidth("y") / 2'},
+      bandPosition: 0.5,
+    });
+  });
+
+  it('falls back to zero when the offset scale is disabled', () => {
+    const model = parseUnitModelWithScale({
+      mark: 'bar',
+      encoding: {
+        x: {field: 'a', type: 'quantitative'},
+        y: {field: 'b', type: 'nominal'},
+        yOffset: {field: 'c', type: 'quantitative', scale: null},
+      },
+    });
+
+    expect(rangedOffsetBaseline(model, 'y')).toEqual({offset: {value: 0}, bandPosition: 0});
+  });
+
+  it('falls back to the center for a point base scale', () => {
+    const model = parseUnitModelWithScale({
+      mark: 'bar',
+      encoding: {
+        x: {field: 'a', type: 'quantitative'},
+        y: {field: 'b', type: 'nominal'},
+        yOffset: {field: 'c', type: 'quantitative'},
+      },
+    });
+    model.getScaleComponent('y').set('type', 'point', true);
+
+    expect(rangedOffsetBaseline(model, 'y')).toEqual({offset: {value: 0}, bandPosition: 0.5});
+  });
+
+  it.each(['shared', 'independent'] as const)('resolves %s layered offset scale names', async (resolve) => {
+    const {spec} = compile({
+      data: {values: [{category: 'A', first: 1, second: 2, value: 1}]},
+      layer: [
+        {
+          mark: 'bar',
+          encoding: {
+            x: {field: 'value', type: 'quantitative'},
+            y: {field: 'category', type: 'nominal'},
+            yOffset: {field: 'first', type: 'quantitative'},
+          },
+        },
+        {
+          mark: 'bar',
+          encoding: {
+            x: {field: 'value', type: 'quantitative'},
+            y: {field: 'category', type: 'nominal'},
+            yOffset: {field: 'second', type: 'quantitative'},
+          },
+        },
+      ],
+      resolve: {scale: {yOffset: resolve}},
+    } as TopLevelSpec);
+
+    const scaleNames = resolve === 'shared' ? ['yOffset', 'yOffset'] : ['layer_0_yOffset', 'layer_1_yOffset'];
+    spec.marks.forEach((mark, index) => {
+      expect(((mark.encode.update.y2 as any).offset as {signal: string}).signal).toContain(
+        `extent(domain("${scaleNames[index]}"))`,
+      );
+    });
+
+    const view = new View(parse(spec), {renderer: 'none'});
+    await view.runAsync();
+  });
+});


### PR DESCRIPTION
This is a small follow up to #9823 with more intelligent placing of the axis tick and label.

Since #9823, ranged bars and areas with a quantitative offset place categorical axis ticks at a fixed band edge: `0` for `x` and `1` for `y`. This does not necessarily match the mark's offset baseline when the offset domain is asymmetric, reversed, or explicitly excludes zero. This PR positions the ranged mark baseline and its categorical axis at the offset-domain value closest to zero, which can be seen as the more natural baseline for most ranged marks.

| Offset domain | Baseline |
| --- | --- |
| Includes zero | `0` |
| Positive only | Domain minimum |
| Negative only | Domain maximum |

|  Before #9823 | After #9823 | After this PR |
|-|-|-|
| <img width="155" height="172" alt="image" src="https://github.com/user-attachments/assets/b65d16f5-5e5d-4ccd-950d-9f26f819f9b6" /> | <img width="155" height="172" alt="image" src="https://github.com/user-attachments/assets/e8449c03-7fb3-43a3-9e2a-df37c4c65ef1" /> | <img width="155" height="172" alt="image" src="https://github.com/user-attachments/assets/5c5ebd96-374d-46d4-8606-cedbd8b02b29" /> |
| <img width="116" height="172" alt="image" src="https://github.com/user-attachments/assets/86f8052c-d559-498c-ae34-dea896d923c2" /> | <img width="116" height="172" alt="image" src="https://github.com/user-attachments/assets/cd5cceef-d19d-41a8-beac-c5e4f7b6ea1c" /> | <img width="116" height="172" alt="image" src="https://github.com/user-attachments/assets/d15af8be-e812-49fd-a0f2-f256d3e715ff" /> |

[Diverging bars in the Vega Editor](https://vega.github.io/editor/#/url/vega-lite/N4IgFgpglg5mAuIBcoDO8IAdkDYAMAvgDQgAmAhvOcqAG7kA2ArhKsgNqjVIgCCIJAEbIAtACYAHCQDGyEAA8BZOQFsQxLnIBCS4UhEBOAKwy5ikqVXqimngGFdogCwBmUz3PKeAO2u2QACKO+gCMIe4KSpY+fiDcfMEhUiCyPACeUVYacdqJJilyGRZZNjn2wa4RRV4gvtnxQULIRvmpINXRtbHx-E36khGenXWl8Tp9Ii2DmTH1cg4TlQUeMyBqczyNIHqG4cuRxTzro3K928gGBlWrI-7j50hT+x1yt2UgCw8hbs+rx-5bPQhVqFP7qAC6xDW5AATgBrGggeBpTAQOSCWHWEAQbzSAD2pCg3hgiMUKBAADMoBAGJ1qFC0gB5CkU1AQRDkqk0zrCEjI1FyACOTHI3ngUCo4toaKh+IYeJhiK5tLksgZSupKp4lgIuqAA)

[Regular Bars in the Vega Editor](https://vega.github.io/editor/#/url/vega-lite/N4IgFgpglg5mAuIBcoDO8IAdkDYAMAvgDQgAmAhvOcqAG7kA2ArhKsgNqjVIgCCIJAEbIAtACYAHCQDGyEAA8BZOQFsQxLnIBCS4UhEBOAKwy5ikqVXqimngGFdogCwBmUz3PKeAO2u2QACKO+gCMIe4KSpY+fiDcfMEhUiCyPACeUVYacdqJJilyGRZZNjn2iW4F6Zkx2fFBQsgh+akgRV4gvnVy-I36khGe0Z2x8Tp9Ik4tZjUj3eUTBgDsg7Nq84HBImGrxTzrpfG9IHpJEe3DXYe5fc3ns1f+DreVrRcl-g0nyAb3eyDrAC6xAB5AATgBrGggeBpTAQOSCcHWEAQbzSAD2pCg3hg0MUKBAADMoBAGMNqCC0gB5IlE1AQRCEklk4bCEiw+FyACOTHI3ngUCogtoCJBmIYGLB0JZ5LksipMtJcp4lhI5HkUDYhKR3lIAAUMaghVAMb4kHgAHRGAi2ghAA)

I contemplated reverting to the default 0.5 bandsize and I still think we can consider that if we think these changes are too complex, but I believe the more natural position of the tick and label is this PR's "closest to 0" placement. I think this is where I'm the most likely to want a gridline to appear if I turn that on. It is also relatively straightforward to achieve the old 0.5 baseline manually with `"axis": {"bandPosition": 0.5}` whereas it is difficult to place the baseline close to 0 manually.

### A few notes

- The baseline is evaluated at runtime so it works with data-driven domains. Its scaled position is clamped to the base band, and invalid or unsupported scale calculations fall back to the middle of the band.
- Bar and area marks use the same computed baseline for their secondary edge and categorical axis.
- Axis ticks, grid lines, and labels remain aligned with the rendered baseline.
- Reversed and independently resolved offset scales are supported.
- Explicit `axis.bandPosition` values continue to take precedence.
- Point and line offsets remain centered, preserving jitter behavior.
- This PR only covers ranged offsets within an existing discrete `x` or `y` lane. Ranged offsets without a base position channel are intentionally outside its scope.

The distinction between ranged and non-ranged marks follows existing Vega-Lite geometry semantics: point and line offsets represent positional displacement, while bar and area offsets synthesize a range from an in-band baseline to the encoded offset value.