### PR TITLE
fix: infer area orientation from quantitative offsets for ranged marks

### DIFF
--- a/examples/compiled/area_ranged_offset_quantitative.vg.json
+++ b/examples/compiled/area_ranged_offset_quantitative.vg.json
@@ -58,6 +58,7 @@
           "encode": {
             "update": {
               "opacity": {"value": 0.8},
+              "orient": {"value": "vertical"},
               "fill": {"value": "#4c78a8"},
               "description": {
                 "signal": "\"quarter: \" + (isValid(datum[\"quarter\"]) ? isArray(datum[\"quarter\"]) ? join(datum[\"quarter\"], ' ') : datum[\"quarter\"] : \"\"+datum[\"quarter\"]) + \"; team: \" + (isValid(datum[\"team\"]) ? isArray(datum[\"team\"]) ? join(datum[\"team\"], ' ') : datum[\"team\"] : \"\"+datum[\"team\"]) + \"; score: \" + (format(datum[\"score\"], \"\"))"

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -86,6 +86,12 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
   switch (mark) {
     case TEXT:
     case BAR:
+      if (mark === BAR && !isUnbinnedQuantitativeFieldOrDatumDef(y) && yOffsetIsMeasure) {
+        return specifiedOrient ?? 'vertical';
+      }
+      if (mark === BAR && !isUnbinnedQuantitativeFieldOrDatumDef(x) && xOffsetIsMeasure) {
+        return specifiedOrient ?? 'horizontal';
+      }
       if (!y && yOffsetIsMeasure) {
         return specifiedOrient ?? 'vertical';
       }

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -135,10 +135,10 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
 
     // falls through
     case AREA:
-      if (!y && yOffsetIsMeasure) {
+      if (mark === AREA && !isUnbinnedQuantitativeFieldOrDatumDef(y) && yOffsetIsMeasure) {
         return specifiedOrient ?? 'vertical';
       }
-      if (!x && xOffsetIsMeasure) {
+      if (mark === AREA && !isUnbinnedQuantitativeFieldOrDatumDef(x) && xOffsetIsMeasure) {
         return specifiedOrient ?? 'horizontal';
       }
       // If there are range for both x and y, y (vertical) has higher precedence.

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -172,8 +172,8 @@ export function stack(m: Mark | MarkDef, encoding: Encoding<string>): StackPrope
 
   if (
     stackedFieldDef.stack === undefined &&
-    ((fieldChannel === 'x' && !encoding.y && channelHasQuantitativeOffset(encoding, 'y')) ||
-      (fieldChannel === 'y' && !encoding.x && channelHasQuantitativeOffset(encoding, 'x')))
+    ((fieldChannel === 'x' && channelHasQuantitativeOffset(encoding, 'y')) ||
+      (fieldChannel === 'y' && channelHasQuantitativeOffset(encoding, 'x')))
   ) {
     return null;
   }

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -358,6 +358,40 @@ describe('compile/compile', () => {
     }
   });
 
+  it('should not impute or default-stack x for density areas with a discrete yOffset baseline', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {mass: 3000, species: 'A', sex: 'F'},
+          {mass: 3500, species: 'A', sex: 'M'},
+          {mass: 4000, species: 'B', sex: 'F'},
+          {mass: 4500, species: 'B', sex: 'M'},
+        ],
+      },
+      transform: [
+        {density: 'mass', groupby: ['species', 'sex'], resolve: 'independent'},
+        {calculate: "datum.sex === 'F' ? -datum.density : datum.density", as: 'signed_density'},
+      ],
+      mark: 'area',
+      encoding: {
+        x: {field: 'value', type: 'quantitative'},
+        y: {field: 'species', type: 'nominal'},
+        yOffset: {field: 'signed_density', type: 'quantitative'},
+        detail: [
+          {field: 'sex', type: 'nominal'},
+          {field: 'species', type: 'nominal'},
+        ],
+        color: {field: 'sex', type: 'nominal'},
+      },
+    });
+
+    const transformTypes = spec.data.flatMap(
+      (data: any) => data.transform?.map((transform: any) => transform.type) ?? [],
+    );
+    expect(transformTypes).not.toContain('impute');
+    expect(transformTypes).not.toContain('stack');
+  });
+
   it('should use containerSize for width and autosize to fit-x/padding', () => {
     const {spec} = compile({
       width: 'container',

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -118,7 +118,7 @@ describe('Mark: Area', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'area',
       encoding: {
-        x: {timeUnit: 'year', field: 'Year', type: 'temporal'},
+        x: {field: 'IMDB_Rating', type: 'quantitative'},
         y: {field: 'Origin', type: 'nominal'},
         yOffset: {field: 'US_Gross', type: 'quantitative'},
       },
@@ -134,6 +134,10 @@ describe('Mark: Area', () => {
     it('should not collapse to line geometry', () => {
       expect(props.x2).toBeUndefined();
       expect(props.y2).toBeDefined();
+    });
+
+    it('should orient the Vega area vertically', () => {
+      expect(props.orient).toEqual({value: 'vertical'});
     });
   });
 

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -64,6 +64,27 @@ describe('Mark: Bar', () => {
     expect(props.height).toBeUndefined();
   });
 
+  it('should use quantitative x as the dimension when yOffset drives a vertical range', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      data: {url: 'data/penguins.json'},
+      mark: 'bar',
+      encoding: {
+        x: {field: 'value', type: 'quantitative'},
+        y: {field: 'Species', type: 'nominal'},
+        yOffset: {field: 'density', type: 'quantitative'},
+      },
+    });
+    const props = bar.encodeEntry(model);
+
+    expect(model.markDef.orient).toBe('vertical');
+    expect(props.xc).toEqual({scale: 'x', field: 'value'});
+    expect(props.width).toEqual({value: defaultBarConfig.continuousBandSize});
+    expect(props.x).toBeUndefined();
+    expect(props.x2).toBeUndefined();
+    expect(props.y).toEqual({scale: 'y', field: 'Species', offset: {scale: 'yOffset', field: 'density'}});
+    expect(props.y2).toEqual({scale: 'y', field: 'Species', offset: {scale: 'yOffset', value: 0}});
+  });
+
   it('should draw horizontal bar, with y from zero to field value and bar with quantitative x, x2, and y', () => {
     const x: PositionFieldDef<string> = {field: 'q_start', type: 'quantitative'};
     const x2: SecondaryFieldDef<string> = {field: 'q_end'};

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -513,12 +513,36 @@ describe('compile/mark/init', () => {
       expect(model.markDef.orient).toBe('vertical');
     });
 
+    it('should return vertical orient for area with discrete y and quantitative yOffset', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: 'area',
+        encoding: {
+          x: {field: 'value', type: 'quantitative'},
+          y: {field: 'category', type: 'nominal'},
+          yOffset: {field: 'density', type: 'quantitative'},
+        },
+      });
+      expect(model.markDef.orient).toBe('vertical');
+    });
+
     it('should return horizontal orient for area with only xOffset quantitative', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'area',
         encoding: {
           y: {field: 'value', type: 'quantitative'},
           xOffset: {field: 'density', type: 'quantitative'},
+        },
+      });
+      expect(model.markDef.orient).toBe('horizontal');
+    });
+
+    it('should return horizontal orient for area with discrete x and quantitative xOffset', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: 'area',
+        encoding: {
+          x: {field: 'category', type: 'nominal'},
+          xOffset: {field: 'density', type: 'quantitative'},
+          y: {field: 'value', type: 'quantitative'},
         },
       });
       expect(model.markDef.orient).toBe('horizontal');

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -443,12 +443,36 @@ describe('compile/mark/init', () => {
       expect(model.markDef.orient).toBe('vertical');
     });
 
+    it('should return vertical orient for bar with discrete y and quantitative yOffset', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: 'bar',
+        encoding: {
+          x: {field: 'value', type: 'quantitative'},
+          y: {field: 'category', type: 'nominal'},
+          yOffset: {field: 'density', type: 'quantitative'},
+        },
+      });
+      expect(model.markDef.orient).toBe('vertical');
+    });
+
     it('should return horizontal orient for bar with only xOffset quantitative', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'bar',
         encoding: {
           y: {field: 'value', type: 'quantitative'},
           xOffset: {field: 'density', type: 'quantitative'},
+        },
+      });
+      expect(model.markDef.orient).toBe('horizontal');
+    });
+
+    it('should return horizontal orient for bar with discrete x and quantitative xOffset', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: 'bar',
+        encoding: {
+          x: {field: 'category', type: 'nominal'},
+          xOffset: {field: 'density', type: 'quantitative'},
+          y: {field: 'value', type: 'quantitative'},
         },
       });
       expect(model.markDef.orient).toBe('horizontal');

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -127,7 +127,7 @@ describe('stack', () => {
     }
   });
 
-  it('should disable default x/y stacking when only offset is present on the orthogonal axis', () => {
+  it('should disable default x/y stacking when quantitative offset is present on the orthogonal axis', () => {
     for (const mark of [BAR, AREA]) {
       expect(
         stack(mark, {
@@ -140,6 +140,22 @@ describe('stack', () => {
         stack(mark, {
           y: {field: 'value', type: 'quantitative'},
           xOffset: {field: 'density', type: 'quantitative'},
+        }),
+      ).toBeNull();
+
+      expect(
+        stack(mark, {
+          x: {field: 'value', type: 'quantitative'},
+          y: {field: 'category', type: 'nominal'},
+          yOffset: {field: 'density', type: 'quantitative'},
+        }),
+      ).toBeNull();
+
+      expect(
+        stack(mark, {
+          x: {field: 'category', type: 'nominal'},
+          xOffset: {field: 'density', type: 'quantitative'},
+          y: {field: 'value', type: 'quantitative'},
         }),
       ).toBeNull();
     }


### PR DESCRIPTION
Previously, bars and areas in offset channels inferred the wrong orientation. E.g. with quantitative `x`, nominal `y`, and quantitative `yOffset` a horizontal orientation was inferred. After this PR, Vega-Lite recognizes the quantitative offset as the ranged measure and infers the appropriate orientation automatically:

| Before this PR | After this PR |
|-|-|
| <img width="348" height="227" alt="image" src="https://github.com/user-attachments/assets/7ad84659-c54a-4e2c-95af-380ac1cf491e" /> | <img width="348" height="227" alt="image" src="https://github.com/user-attachments/assets/6f5b1f91-8b2f-479e-b883-506de764850a" /> |
| <img width="348" height="227" alt="image" src="https://github.com/user-attachments/assets/f4e8f914-8804-4047-8a8f-f01c8bcfd043" /> | <img width="348" height="227" alt="image" src="https://github.com/user-attachments/assets/34a0e5cd-0f23-448f-bc4b-50e0c856561b" /> |

[Open the Chart in the Vega Editor](http://localhost:1234/editor/#/url/vega-lite/N4IgJghgLhIFygK4CcA29zQgegA4FMA7Ac0QEtCBnAOgCtKB7QkAXwBoQALfM4zqeACYADMI5RkEKgDMGyALbwA2qDBFKZKAE8MAIQZgtAAgCyESpSMAKYgEoQHYsgaJcAIx1wlIAMoEAxmT4lCAAuhzIwQyoAG74GBRqBIRqhAIs4SDyEMgA1vCg2gQYOfiw7CBE-gYUxAUgAB710kGoYBgxEKiI8eJaxXAgAI6IUlCa0GRxrByeoC34bRh++IHBDiBF8YOEDPIUXTMgWgDy0tKU+AIIIAtLg6ka2htbGCNjE+PTFWowZOg3O7tQYrNYhFgQoA) (Using bars for a density is of course not a real use case, but it was a convenient way to demo the orientation issues that would occur if bars were used for a quantitative field) 

This also works as expected for diverging areas:

| Densities | Histogram |
|-|-|
| <img width="421" height="323" alt="image" src="https://github.com/user-attachments/assets/11031595-f496-4dc4-a81f-b3942ab1281e" /> | <img width="416" height="213" alt="image" src="https://github.com/user-attachments/assets/60df3e5e-0c46-452a-9063-eefc624bb8b5" /> |

(Just showing the histogram here as a point of reference, bars on binned fields were orientated correctly already before this PR)

A fun side effect of this is that we now have a second approach for creating violins by mirroring the density values in negative space (when it rains, pours...):

<img width="358" height="317" alt="image" src="https://github.com/user-attachments/assets/cd8e3196-70ce-4cb9-ba44-6e73816f629d" />

[Open the Chart in the Vega Editor](https://vega.github.io/editor/#/url/vega-lite/N4IgJghgLhIFygK4CcA29zQgegA4FMA7Ac0QEtCBnAOgCtKB7QkAXwBoQALfM4zqeAGYADMI5RkEKgDMGyALbwA2qGllUUfMniqy+VGAwBlfAA8QHJvgDy05SACyAQQAyAUQsgAYm+fuQALos7KBgRJRkUACeGABCDGBRAAQOEJSUSQAUxACUnsTIDIi4AEYxcEogRgQAxnqUgRzI+IyoAG74GBRhBIRhhAIhIDUQqDWIqNCdcCAAtJBQiPLU-RHRnmkYhPjEAPqrkTFDsgb2B+sc23vnMQEcmxXDDKi7hBDynRwRxNtg++GHQIsO4geQQZAAax0IGiBAw4PwsHYICINQSFGI0PMCBAan0hhmbVGiE+MKicJmAEdEFIoJFoGQOqwOOVdPjjLV6p5YdMQIQGPIKKNmSAorZpJR8AIcXjTjNvr9-lRAeJybzqbT6XSmciwjB1Mo2XKqpyWty1VsBUL0Mc9Ma0S83h9zRS+Va3jagiwgA)

(I believe that the while line going through the middle of the violins is a result of this bug https://github.com/vega/vega/issues/3980; a workaround is to add a `stroke` encoding.)

I don't think the approach here replaces https://github.com/vega/vega-lite/pull/9883 since that approach can be combined with a categorical offset and this cannot (unless we also introduce nested offsets, but that sounds like a large lift although it could of course be useful in some cases). The approach here also creates two separate marks per "violin", whereas #9883 creates a single area. It would of course be neat if there was an easy way to transition from a violin to a split violin without completely changing specs, but that's better explored in its own issue I think.

### Notes on disabled stacking

Previously, Vega-Lite could select the orthogonal quantitative position as the default stack channel. For a density area with quantitative `x` and quantitative `yOffset`, this resulted in generated `impute` and `stack` transforms on `x`. The imputation could create synthetic rows without the categorical baseline field, causing an unexpected `"undefined"` category to appear.

Default `x` or `y` stacking is now disabled when a quantitative offset on the orthogonal axis drives the ranged mark. Follow up work on making stacking work is separated out into https://github.com/vega/vega-lite/pull/9897.

