### PR TITLE
fix: allow disabling line and point overlay via style config

### DIFF
--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -10,7 +10,7 @@ import {stack} from '../stack.js';
 import {keys, omit, pick} from '../util.js';
 import {NonFacetUnitNormalizer, NormalizeLayerOrUnit, NormalizerParams} from './base.js';
 import {DEFAULT_REDUCED_OPACITY, initMarkdef} from '../compile/mark/init.js';
-import {getMarkPropOrConfig} from '../compile/common.js';
+import {getMarkPropOrConfig, getMarkStyleConfig} from '../compile/common.js';
 
 type UnitSpecWithPathOverlay = GenericUnitSpec<Encoding<string>, Mark | MarkDef<'line' | 'area' | 'rule' | 'trail'>>;
 
@@ -30,12 +30,24 @@ function dropLineAndPointFromConfig(config: Config<SignalRef>) {
       };
     }
   }
+  // Also drop line/point from style config so the overlaid child layers do not re-match
+  // the path-overlay normalizer (which now also reads the style config) and recurse infinitely.
+  if (config.style) {
+    const style = {...config.style};
+    for (const styleName of keys(style)) {
+      if (style[styleName]) {
+        // TODO: remove as any
+        style[styleName] = omit(style[styleName], ['point', 'line'] as any);
+      }
+    }
+    config = {...config, style};
+  }
   return config;
 }
 
 function getPointOverlay(
   markDef: MarkDef,
-  markConfig: LineConfig<ExprRef | SignalRef> = {},
+  config: Config<SignalRef>,
   encoding: Encoding<string>,
 ): MarkConfig<ExprRef | SignalRef> {
   if (markDef.point === 'transparent') {
@@ -47,20 +59,24 @@ function getPointOverlay(
     // false or null
     return null;
   } else {
-    // undefined (not disabled)
-    if (markConfig.point || encoding.shape) {
-      // enable point overlay if config[mark].point is truthy or if encoding.shape is provided
-      return isObject(markConfig.point) ? markConfig.point : {};
+    // undefined (not disabled): resolve the point overlay from the config.
+    // The style config (config.style) takes precedence over the mark-type config (config[mark.type]),
+    // consistent with getMarkConfig, so a point overlay can be disabled via style config.
+    const stylePoint = getMarkStyleConfig('point', markDef, config.style ?? {});
+    const markConfigPoint = (config[markDef.type] as LineConfig<ExprRef | SignalRef>)?.point;
+    const point = stylePoint !== undefined ? stylePoint : markConfigPoint;
+    if (point || encoding.shape) {
+      // enable point overlay if the resolved config point is truthy or if encoding.shape is provided
+      return isObject(point) ? point : {};
+    } else if (point !== undefined) {
+      // explicitly disabled via config (e.g. config.style[...].point: false)
+      return null;
     }
-    // markDef.point is defined as falsy
     return undefined;
   }
 }
 
-function getLineOverlay(
-  markDef: MarkDef,
-  markConfig: AreaConfig<ExprRef | SignalRef> = {},
-): MarkConfig<ExprRef | SignalRef> {
+function getLineOverlay(markDef: MarkDef, config: Config<SignalRef>): MarkConfig<ExprRef | SignalRef> {
   if (markDef.line) {
     // true or object
     return markDef.line === true ? {} : markDef.line;
@@ -68,12 +84,19 @@ function getLineOverlay(
     // false or null
     return null;
   } else {
-    // undefined (not disabled)
-    if (markConfig.line) {
-      // enable line overlay if config[mark].line is truthy
-      return markConfig.line === true ? {} : markConfig.line;
+    // undefined (not disabled): resolve the line overlay from the config.
+    // The style config (config.style) takes precedence over the mark-type config (config[mark.type]),
+    // consistent with getMarkConfig, so a line overlay can be disabled via style config (#9547).
+    const styleLine = getMarkStyleConfig('line', markDef, config.style ?? {});
+    const markConfigLine = (config[markDef.type] as AreaConfig<ExprRef | SignalRef>)?.line;
+    const line = styleLine !== undefined ? styleLine : markConfigLine;
+    if (line) {
+      // enable line overlay if the resolved config line is truthy
+      return line === true ? {} : line;
+    } else if (line !== undefined) {
+      // explicitly disabled via config (e.g. config.style[...].line: false)
+      return null;
     }
-    // markDef.point is defined as falsy
     return undefined;
   }
 }
@@ -89,12 +112,12 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
         case 'line':
         case 'rule':
         case 'trail':
-          return !!getPointOverlay(markDef, config[markDef.type], encoding);
+          return !!getPointOverlay(markDef, config as Config<SignalRef>, encoding);
         case 'area':
           return (
             // false / null are also included as we want to remove the properties
-            !!getPointOverlay(markDef, config[markDef.type], encoding) ||
-            !!getLineOverlay(markDef, config[markDef.type])
+            !!getPointOverlay(markDef, config as Config<SignalRef>, encoding) ||
+            !!getLineOverlay(markDef, config as Config<SignalRef>)
           );
       }
     }
@@ -110,9 +133,9 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
 
     const markDef: MarkDef = isMarkDef(mark) ? mark : {type: mark};
 
-    const pointOverlay = getPointOverlay(markDef, config[markDef.type], encoding);
+    const pointOverlay = getPointOverlay(markDef, config, encoding);
 
-    const lineOverlay = markDef.type === 'area' && getLineOverlay(markDef, config[markDef.type]);
+    const lineOverlay = markDef.type === 'area' && getLineOverlay(markDef, config);
 
     const layer: NormalizedUnitSpec[] = [
       {

--- a/test/normalize/pathoverlay.test.ts
+++ b/test/normalize/pathoverlay.test.ts
@@ -288,6 +288,99 @@ describe('PathOverlayNormalizer', () => {
     }
   });
 
+  it('correctly disables line overlay via style config even when enabled in mark config (#9547).', () => {
+    const spec: TopLevelSpec = {
+      data: {url: 'data/stocks.csv'},
+      mark: {type: 'area', style: 'non-default-area'},
+      encoding: {
+        x: {field: 'date', type: 'temporal'},
+        y: {field: 'price', type: 'quantitative'},
+      },
+      config: {
+        area: {line: true},
+        style: {'non-default-area': {line: false}},
+      },
+    };
+    const normalizedSpec = normalize(spec);
+    expect(normalizedSpec).toEqual({
+      data: {url: 'data/stocks.csv'},
+      mark: {type: 'area', style: 'non-default-area'},
+      encoding: {
+        x: {field: 'date', type: 'temporal'},
+        y: {field: 'price', type: 'quantitative'},
+      },
+      config: {
+        area: {line: true},
+        style: {'non-default-area': {line: false}},
+      },
+    });
+  });
+
+  it('correctly disables point overlay via style config even when enabled in mark config.', () => {
+    const spec: TopLevelSpec = {
+      data: {url: 'data/stocks.csv'},
+      mark: {type: 'line', style: 'non-default-line'},
+      encoding: {
+        x: {field: 'date', type: 'temporal'},
+        y: {field: 'price', type: 'quantitative'},
+      },
+      config: {
+        line: {point: true},
+        style: {'non-default-line': {point: false}},
+      },
+    };
+    const normalizedSpec = normalize(spec);
+    expect(normalizedSpec).toEqual({
+      data: {url: 'data/stocks.csv'},
+      mark: {type: 'line', style: 'non-default-line'},
+      encoding: {
+        x: {field: 'date', type: 'temporal'},
+        y: {field: 'price', type: 'quantitative'},
+      },
+      config: {
+        line: {point: true},
+        style: {'non-default-line': {point: false}},
+      },
+    });
+  });
+
+  it('correctly enables line overlay via style config.', () => {
+    const spec: TopLevelSpec = {
+      data: {url: 'data/stocks.csv'},
+      mark: {type: 'area', style: 'lined-area'},
+      encoding: {
+        x: {field: 'date', type: 'temporal'},
+        y: {field: 'price', type: 'quantitative'},
+      },
+      config: {
+        style: {'lined-area': {line: true}},
+      },
+    };
+    const normalizedSpec = normalize(spec);
+    expect(normalizedSpec).toEqual({
+      data: {url: 'data/stocks.csv'},
+      layer: [
+        {
+          mark: {type: 'area', style: 'lined-area', opacity: 0.7},
+          encoding: {
+            x: {field: 'date', type: 'temporal'},
+            y: {field: 'price', type: 'quantitative'},
+          },
+        },
+        {
+          mark: {type: 'line'},
+          encoding: {
+            x: {field: 'date', type: 'temporal'},
+            y: {field: 'price', type: 'quantitative', stack: 'zero'},
+          },
+        },
+      ],
+      config: {
+        style: {'lined-area': {line: true}},
+      },
+    });
+  });
+
   it('correctly normalizes stacked area with overlay line', () => {
     const spec: TopLevelSpec = {
       data: {url: 'data/stocks.csv'},


### PR DESCRIPTION
Closes #9547.

## Problem

The path-overlay normalizer only read `config[mark.type]` (e.g. `config.area`) when deciding whether to add a line/point overlay, ignoring the `style` config. As a result, `config.style[...].line` / `config.style[...].point` could neither enable nor disable the overlay.

## Fix

- Resolve the line/point overlay from the **style config with precedence over the mark-type config**, consistent with `getMarkConfig`. Applied to both line and point overlays.
- Strip `line`/`point` from the `style` config of the overlaid child layers, to avoid infinite re-matching now that the style config can enable an overlay.

## Testing

- Added regression tests in `test/normalize/pathoverlay.test.ts`: disable line overlay via style config (#9547), disable point overlay via style config, and enable line overlay via style config.
- Full unit suite `vitest run test/` — **3347 tests pass**; `vitest run examples/` — **3277 pass**; `eslint` + `prettier` clean; generated JSON schema unchanged.

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples. — N/A (bug fix; behavior now matches the documented config precedence)

</details>