### PR TITLE
fix: keep explicit legend.type symbol for discretizing color scales

### DIFF
--- a/src/compile/legend/properties.ts
+++ b/src/compile/legend/properties.ts
@@ -66,12 +66,16 @@ export const legendRules: {
 
   title: ({fieldOrDatumDef, config}) => fieldDefTitle(fieldOrDatumDef, config, {allowDisabling: true}),
 
-  type: ({legendType, scaleType, channel}) => {
+  type: ({legend, legendType, scaleType, channel}) => {
     if (isColorChannel(channel) && isContinuousToContinuous(scaleType)) {
       if (legendType === 'gradient') {
         return undefined;
       }
-    } else if (legendType === 'symbol') {
+    } else if (legendType === 'symbol' && legend.type === undefined) {
+      // `symbol` is Vega's default legend type for these cases, so it can be omitted — but only
+      // when it was inferred. When the user explicitly sets `legend.type: "symbol"` (e.g. on a
+      // discretizing color scale, where Vega would otherwise default to a gradient), it must be
+      // kept, otherwise it is silently dropped (#9856).
       return undefined;
     }
     return legendType;

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -71,6 +71,48 @@ describe('compile/legend', () => {
     });
   });
 
+  describe('legend type for discretizing color scales (#9856)', () => {
+    it('keeps an explicit legend.type "symbol" for a threshold color scale', () => {
+      const unitModel = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          color: {
+            field: 'a',
+            type: 'quantitative',
+            scale: {type: 'threshold', domain: [1, 2, 3]},
+            legend: {type: 'symbol'},
+          },
+        },
+      });
+      expect(parseLegend(unitModel).color.get('type')).toBe('symbol');
+    });
+
+    it('keeps an explicit legend.type "symbol" for a quantize color scale', () => {
+      const unitModel = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          color: {
+            field: 'a',
+            type: 'quantitative',
+            scale: {type: 'quantize'},
+            legend: {type: 'symbol'},
+          },
+        },
+      });
+      expect(parseLegend(unitModel).color.get('type')).toBe('symbol');
+    });
+
+    it('still omits the inferred "symbol" type for a discrete (nominal) color scale', () => {
+      const unitModel = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          color: {field: 'a', type: 'nominal'},
+        },
+      });
+      expect(parseLegend(unitModel).color.get('type')).toBeUndefined();
+    });
+  });
+
   describe('parseLegendForChannel()', () => {
     it('should produce a Vega legend object with correct type and scale for color', () => {
       const model = parseUnitModelWithScale({


### PR DESCRIPTION
Closes #9856.

## Problem

For a quantitative color encoding with a discretizing scale (`quantile`, `quantize`, or `threshold`), an explicit `legend.type: "symbol"` was silently dropped during Vega-Lite → Vega compilation, so Vega rendered a gradient legend instead of the requested symbol legend.

The legend `type` rule omitted `legendType === 'symbol'` for all non-continuous-color cases, assuming `symbol` is always Vega's default. But Vega defaults these discretizing color scales to `gradient`, so the requested `symbol` was dropped and never applied.

## Fix

Only omit the `symbol` legend type when it was **inferred**. When the user explicitly sets `legend.type: "symbol"`, keep it so it isn't silently dropped. Inferred behavior is unchanged.

## Testing

- Added regression tests in `test/compile/legend/parse.test.ts`: explicit `legend.type: "symbol"` is kept for `threshold` and `quantize` color scales, and the inferred `symbol` type is still omitted for a discrete (nominal) color scale.
- Full unit suite `vitest run test/` — **3347 tests pass**; `vitest run examples/` — **3277 pass** (no example outputs changed); `eslint` + `prettier` clean.

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples. — N/A (bug fix)

</details>