### PR TITLE
fix: use faceted data source for data-driven scale range in shared sc…

### DIFF
--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -56,7 +56,7 @@ import {
 import {getStepFor, isStep, LayoutSizeMixins, Step} from '../../spec/base.js';
 import {isDiscrete} from '../../type.js';
 import * as util from '../../util.js';
-import {isSignalRef, VgRange} from '../../vega.schema.js';
+import {isSignalRef, isDataRefDomain, VgRange} from '../../vega.schema.js';
 import {exprFromSignalRefOrValue, signalOrStringValue} from '../common.js';
 import {getBinSignalName} from '../data/bin.js';
 import {SignalRefWrapper} from '../signal.js';
@@ -64,7 +64,8 @@ import {Explicit, makeExplicit, makeImplicit} from '../split.js';
 import {UnitModel} from '../unit.js';
 import {ScaleComponentIndex} from './component.js';
 import {durationExpr} from '../../timeunit.js';
-import {isFacetModel} from '../model.js';
+import {isFacetModel, Model} from '../model.js';
+import {FACET_SCALE_PREFIX} from '../data/optimize.js';
 
 export const RANGE_PROPERTIES: (keyof Scale)[] = ['range', 'scheme'];
 
@@ -79,6 +80,23 @@ export function parseUnitScaleRange(model: UnitModel) {
     }
 
     const rangeWithExplicit = parseRangeForChannel(channel, model);
+
+    // For a shared scale of a faceted plot, a data-driven range (e.g. `scale.range.field`) must
+    // reference the data from the cloned subtree after the facet, mirroring the domain remapping in
+    // `parseScaleDomain`. Otherwise the range points to a data source that only exists inside the
+    // facet cell, producing an "Undefined data set name" error (#9706).
+    if (model.component.data.isFaceted) {
+      let facetParent: Model = model;
+      while (!isFacetModel(facetParent) && facetParent.parent) {
+        facetParent = facetParent.parent;
+      }
+
+      const resolve = facetParent.component.resolve.scale[channel];
+      const range = rangeWithExplicit.value;
+      if (resolve === 'shared' && isObject(range) && isDataRefDomain(range)) {
+        range.data = FACET_SCALE_PREFIX + range.data.replace(FACET_SCALE_PREFIX, '');
+      }
+    }
 
     localScaleCmpt.setWithExplicit('range', rangeWithExplicit);
   }

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -29,6 +29,53 @@ describe('compile/compile', () => {
     expect(spec.marks).toHaveLength(1); // just the root group
   });
 
+  it('uses a valid top-level data source for a data-driven scale range in a faceted+layered plot (#9706)', () => {
+    const {spec} = compile({
+      data: {
+        values: [
+          {group: '2025', class: 'A', value: 23, deltaX: 322, class_color: '#041042'},
+          {group: '2025', class: 'B', value: 21.5, deltaX: 313, class_color: '#7c31c0'},
+          {group: '2025', class: 'C', value: 15, deltaX: 275, class_color: '#2652bc'},
+        ],
+      },
+      transform: [
+        {
+          window: [
+            {field: 'deltaX', op: 'max', as: 'deltaX_max'},
+            {field: 'value', op: 'max', as: 'value_max'},
+          ],
+          frame: [null, null],
+        },
+        {calculate: 'datum.deltaX / datum.deltaX_max * datum.value_max', as: 'value_published'},
+        {fold: ['value', 'value_published'], as: ['key', 'value']},
+      ],
+      facet: {row: {field: 'key'}},
+      spec: {
+        encoding: {
+          x: {field: 'value', type: 'quantitative'},
+          y: {field: 'group', type: 'nominal'},
+          yOffset: {field: 'class', type: 'nominal', sort: {field: 'y', order: 'ascending'}},
+        },
+        layer: [
+          {
+            mark: {type: 'bar'},
+            encoding: {
+              color: {field: 'class', type: 'nominal', scale: {range: {field: 'class_color'}}},
+            },
+          },
+          {mark: {type: 'text'}, encoding: {text: {field: 'class', type: 'nominal'}}},
+        ],
+      },
+    });
+
+    const colorScale = spec.scales!.find((s) => s.name === 'color')!;
+    const rangeData = (colorScale.range as {data: string}).data;
+    const dataNames = spec.data!.map((d) => d.name);
+    // The data-driven range must reference an existing top-level data source, not one that only
+    // exists inside the facet cell (which produced "Undefined data set name" when Vega parsed it).
+    expect(dataNames).toContain(rangeData);
+  });
+
   it('should return a spec with specified top-level properties, size signals, data and marks', () => {
     const {spec} = compile({
       padding: 123,


### PR DESCRIPTION
Closes #9706.

## Problem

In a faceted **and** layered plot, a mark that uses a data-driven scale range (e.g. `"color": {"scale": {"range": {"field": "class_color"}}}`) compiles to a Vega spec that references a data source which only exists inside the facet cell. Vega then fails to parse it with `Undefined data set name: "data_1"`.

The scale's **domain** is already remapped to the cloned post-facet data source for shared scales (`parseScaleDomain`), but the **range** was not — so the range kept pointing at the cell-scope data source.

## Fix

In `parseUnitScaleRange`, mirror the domain's facet remapping: for a shared scale of a faceted plot, remap a data-driven range's `data` with `FACET_SCALE_PREFIX` so it references the cloned post-facet data source (the same one the domain uses).

## Testing

- Added a regression test in `test/compile/compile.test.ts` compiling the faceted + layered spec from the issue and asserting the color scale's data-driven `range.data` references an existing top-level data source (previously it referenced the cell-only `data_1`).
- Verified the test fails without the fix and passes with it. Full unit suite (`vitest run test/`) and examples pass; `eslint` + `prettier` clean.

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples. — N/A (bug fix)

</details>