### PR TITLE
chore: drop mergeConfig/writeConfig wrappers, re-export from vega-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "tslib": "~2.8.1",
         "vega-event-selector": "~4.0.0",
         "vega-expression": "~6.1.0",
-        "vega-util": "~2.1.1",
+        "vega-util": "~2.1.2",
         "yargs": "~18.0.0"
       },
       "bin": {
@@ -10464,9 +10464,9 @@
       }
     },
     "node_modules/vega-util": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.1.tgz",
-      "integrity": "sha512-tpNmm8bGtUa8gKfFDSjXPffxqSyPr91vaWIEBnJS/rijhoLZMwM+mgYQG6XfwdcBSN1+jkZ57P0sYSEW/jophw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.2.tgz",
+      "integrity": "sha512-Mdvv33BUlx4no5gz2VHdue4bJ6ejWmInuieID3JGnAXwewHKrPWE/Xr2vVWA+xS9Om1eHvj/0wVsiBGJ61v2uQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "tslib": "~2.8.1",
     "vega-event-selector": "~4.0.0",
     "vega-expression": "~6.1.0",
-    "vega-util": "~2.1.1",
+    "vega-util": "~2.1.2",
     "yargs": "~18.0.0"
   },
   "peerDependencies": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,23 +2,17 @@ import {
   hasOwnProperty,
   isNumber,
   isString,
-  mergeConfig as mergeConfig_,
+  mergeConfig,
   splitAccessPath,
   stringValue,
-  writeConfig as writeConfig_,
+  writeConfig,
   isObject,
 } from 'vega-util';
 import {isLogicalAnd, isLogicalNot, isLogicalOr, LogicalComposition} from './logical.js';
 
 export const duplicate = structuredClone;
 
-export function mergeConfig<C extends object>(...configs: C[]): C {
-  return mergeConfig_(...(configs as any[])) as C;
-}
-
-export function writeConfig<C extends object>(config: C, key: string, value: any, recurse?: boolean | object): void {
-  writeConfig_(config as any, key, value, recurse as any);
-}
+export {mergeConfig, writeConfig};
 
 export function never(message: string): never {
   throw new Error(message);


### PR DESCRIPTION
## Summary

Removes the `mergeConfig`/`writeConfig` wrappers in `src/util.ts` and re-exports the functions from vega-util directly, and requires `vega-util@~2.1.2`.

The wrappers were added in #9873 to work around vega-util 2.1.1 shipping over-narrow structural types for these functions (declared interfaces like the vega-lite/vega-typings `Config` have no implicit index signature, so they weren't assignable). vega/vega#4312 (released as vega-util **2.1.2**) restores the generic signatures — `mergeConfig<C extends object>(...configs: C[]): C` — which is exactly what the local wrapper declared, so the wrapper and its `as any` casts are redundant.

The range bump `~2.1.1` → `~2.1.2` also keeps the broken 2.1.1 types out of fresh installs.

## Testing

- `tsc --noEmit` passes against the published vega-util 2.1.2
- Types-only + re-export change; no runtime behavior difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)