### PR TITLE
fix(layer): do not emit duplicate signals for a layer-level selection

### DIFF
--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -92,9 +92,16 @@ export class LayerModel extends Model {
 
   // TODO: Support same named selections across children.
   public assembleSignals(): NewSignal[] {
-    return this.children.reduce((signals, child) => {
-      return signals.concat(child.assembleSignals());
-    }, assembleAxisSignals(this));
+    // A selection declared on the layer parses into every child, so each child
+    // assembles the same signals for it. The copies are identical, and Vega
+    // rejects a duplicate signal name, so keep the first of each name.
+    const seen = new Set<string>();
+    const dedupe = (signals: NewSignal[]) => signals.filter((s) => !seen.has(s.name) && seen.add(s.name));
+
+    return this.children.reduce(
+      (signals, child) => signals.concat(dedupe(child.assembleSignals())),
+      dedupe(assembleAxisSignals(this)),
+    );
   }
 
   public assembleLayoutSignals(): NewSignal[] {

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -1,3 +1,6 @@
+import {parse} from 'vega';
+import {compile} from '../../src/compile/compile.js';
+import {TopLevelSpec} from '../../src/index.js';
 import {parseLayerModel} from '../util.js';
 
 describe('Layer', () => {
@@ -109,6 +112,46 @@ describe('Layer', () => {
 
       expect(model.component.axes['x']).toHaveLength(2);
       expect(model.component.axes['x'][1].implicit.orient).toBe('top');
+    });
+  });
+
+  describe('assembleSignals', () => {
+    // A parameter declared on a layer is pushed into each of its children, so
+    // every child assembles the same selection signals for it.
+    const layeredSelection = {
+      data: {url: 'data/cars.json'},
+      params: [{name: 'sel', select: {type: 'point', fields: ['Origin']}}],
+      encoding: {
+        x: {field: 'Horsepower', type: 'quantitative'},
+        y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+      },
+      layer: [{mark: 'point'}, {mark: {type: 'text', dy: -10}, encoding: {text: {field: 'Origin'}}}],
+    } as TopLevelSpec;
+
+    it('should not emit duplicate signals for a layer-level selection', () => {
+      const names = compile(layeredSelection).spec.signals.map((s) => s.name);
+      expect(names).toHaveLength(new Set(names).size);
+    });
+
+    it('should produce a parseable spec for a layer-level selection', () => {
+      expect(() => parse(compile(layeredSelection).spec)).not.toThrow();
+    });
+
+    it('should keep signals that only one child defines', () => {
+      const names = compile({
+        data: {url: 'data/cars.json'},
+        encoding: {
+          x: {field: 'Horsepower', type: 'quantitative'},
+          y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+        },
+        layer: [
+          {mark: 'point', params: [{name: 'first', select: 'point'}]},
+          {mark: 'point', params: [{name: 'second', select: 'interval'}]},
+        ],
+      } as TopLevelSpec).spec.signals.map((s) => s.name);
+
+      expect(names).toEqual(expect.arrayContaining(['first_tuple', 'second_x']));
+      expect(names).toHaveLength(new Set(names).size);
     });
   });
 });


### PR DESCRIPTION
This PR fixes a bug related to selections and layers. No previous example has run into this but it is a real bug affecting valid specs, and needs to be fixed to enable animated layer specs.

**Description pasted from Claude below**

### The bug

A selection that lands on more than one child of a layer compiles to Vega that fails to parse:

```
Error: Duplicate signal name: "sel_tuple"
```

Two spec shapes produce the error. A selection declared on the layer itself:

```json
{
  "data": {"url": "data/cars.json"},
  "params": [
    {"name": "sel", "select": {"type": "point", "fields": ["Origin"]}}
  ],
  "layer": [
    {"mark": "point", "encoding": {...}},
    {"mark": "circle", "encoding": {...}}
  ]
}
```

A selection scoped with `views` to several named children:

```json
"params": [
  {"name": "sel", "select": {"type": "point", "fields": ["Origin"]}, "views": ["a", "b"]}
],
"layer": [{"name": "a", ...}, {"name": "b", ...}]
```

Both shapes emit `sel_tuple`, `sel_tuple_fields`, `sel_toggle`, and `sel_modify` twice into one scope.

### Why these specs are legitimate

`TopLevelSelectionsNormalizer` hoists selection params out of a non-unit spec and pushes them down into unit views. A comment in its `mapUnit` states the default:

```
// By default, apply selections to all unit views.
```

`mapUnit` then branches on `selection.views` to narrow that set, matching a view by `spec.name` or by path membership. `test/normalize/toplevelselection.test.ts` exercises both paths in `'should push top-level selections to all units by default'` and `'should push top-level selections to given units'`. The second test runs over named vconcat and layer children.

`site/docs/` does not document `views` as far as I can find. The two layer mentions in `docs/parameter/select.md` cover interval selections over binned fields and a `nearest` limitation. Vega-Lite implements the behavior intentionally and tests it without documenting it. A spec relying on the behavior passes every check Vega-Lite applies, and only the compile step fails.

### Cause

The normalizer copies the selection into each child, and each child then assembles its own `sel_tuple`, `sel_tuple_fields`, `sel_toggle`, and `sel_modify`. For **concat** and **facet** the copies are harmless, because each child's signals live inside its own group and identical names sit in different scopes. For **layer**, children share the parent group's scope, and `LayerModel.assembleSignals` concatenates the duplicates into that shared scope.

#6919 (`feat: top-level selections`, Nov 2020) introduced the bug when it first made a selection above a unit possible.

### Why no test caught it

- No example in `examples/specs` has a top-level selection over any multi-view spec.
- `test/normalize/toplevelselection.test.ts` covers "push top-level selections to all units by default" using a **vconcat**, which does not collide.
- The layer cases in that file use `views` to give each child a *different* selection, never the same selection to two children.
- Those tests assert the normalized Vega-Lite spec and stop there. No test compiles the result and parses it with Vega.

### Fix

`LayerModel.assembleSignals` now keeps the first signal of each name when merging children's signals. The duplicates are byte-identical, because they are the same selection compiled twice. Signals that only one child defines pass through unchanged.

### Scope

This PR leaves the `TODO: Support same named selections across children` above that merge in place. The TODO covers the larger problem of genuinely distinct selections sharing a name. This fix stops the compiler from emitting identical copies of one selection twice, and nothing more.

### Tests

Three cases in `test/compile/layer.test.ts`: a layer-level selection emits no duplicate names, the compiled spec parses with `vega.parse`, and signals unique to one child survive. The first two cases fail on `main`. I verified the failure by reverting the source change with the tests in place.

No example output changes. `examples/compiled` regenerates byte-identical, so nothing in the corpus relied on the duplicate signals.

### Why this blocks layered animation

The compiler repoints an animated mark from its source dataset to the per-frame `*_curr` dataset, and the unit owning a timer selection drives that rewrite. A layered animation needs every layer repointed. A layer the rewrite misses draws all frames at once while the other layers animate.

```
┌─────────────────────────────┬──────────────────────────────────────────────────────────┐
│ Where the timer param sits  │                   Resulting mark data                    │
├─────────────────────────────┼──────────────────────────────────────────────────────────┤
│ On the layer (all children) │ ["source_0_curr", "source_0_curr"] — both layers animate │
├─────────────────────────────┼──────────────────────────────────────────────────────────┤
│ Inside one child            │ ["data_0_curr", "data_1"] — second layer static          │
└─────────────────────────────┴──────────────────────────────────────────────────────────┘
```

*Mark data sources for a two-layer animated spec. Only a param on the layer itself animates every layer.*

Putting the param inside one child is the only shape that avoids the duplicate-signal bug, and it draws a broken chart. A racing bar chart's labels smear across every year while its bars animate.

A correct layered animation therefore requires the selection on more than one child, which is exactly the case that fails to parse. With this fix reverted, the layered animation example fails with `Duplicate signal name: "frame_tuple"`.