### PR TITLE
fix: support escaped fields in point selections

### DIFF
--- a/src/compile/selection/inputs.ts
+++ b/src/compile/selection/inputs.ts
@@ -1,6 +1,5 @@
-import {stringValue} from 'vega-util';
 import {disableDirectManipulation, TUPLE, SelectionCompiler} from './index.js';
-import {varName} from '../../util.js';
+import {flatAccessWithDatum, varName} from '../../util.js';
 import {assembleInit} from './assemble.js';
 import nearest from './nearest.js';
 import {TUPLE_FIELDS} from './project.js';
@@ -39,7 +38,7 @@ const inputBindings: SelectionCompiler<'point'> = {
             ? [
                 {
                   events: selCmpt.events,
-                  update: `datum && item().mark.marktype !== 'group' ? ${datum}[${stringValue(p.field)}] : null`,
+                  update: `datum && item().mark.marktype !== 'group' ? ${flatAccessWithDatum(p.field, datum)} : null`,
                 },
               ]
             : [],

--- a/src/compile/selection/point.ts
+++ b/src/compile/selection/point.ts
@@ -1,8 +1,7 @@
 import {Signal, Stream} from 'vega';
-import {stringValue} from 'vega-util';
 import {SelectionCompiler, TUPLE, isTimerSelection, unitName} from './index.js';
 import {SELECTION_ID} from '../../selection.js';
-import {vals} from '../../util.js';
+import {flatAccessWithDatum, vals} from '../../util.js';
 import {BRUSH} from './interval.js';
 import {TUPLE_FIELDS} from './project.js';
 import {TIME} from '../../channel.js';
@@ -95,7 +94,7 @@ const point: SelectionCompiler<'point'> = {
     let update = `unit: ${unitName(model)}, `;
 
     if (selCmpt.project.hasSelectionId) {
-      update += `${SELECTION_ID}: ${datum}[${stringValue(SELECTION_ID)}]`;
+      update += `${SELECTION_ID}: ${flatAccessWithDatum(SELECTION_ID, datum)}`;
     } else if (isTimerSelection(selCmpt)) {
       update += `fields: ${fieldsSg}, values: [${ANIM_VALUE} ? ${ANIM_VALUE} : ${MIN_EXTENT}]`;
     } else {
@@ -104,9 +103,9 @@ const point: SelectionCompiler<'point'> = {
           const fieldDef = model.fieldDef(p.channel);
           // Binned fields should capture extents, for a range test against the raw field.
           return fieldDef?.bin
-            ? `[${datum}[${stringValue(model.vgField(p.channel, {}))}], ` +
-                `${datum}[${stringValue(model.vgField(p.channel, {binSuffix: 'end'}))}]]`
-            : `${datum}[${stringValue(p.field)}]`;
+            ? `[${flatAccessWithDatum(model.vgField(p.channel, {}), datum)}, ` +
+                `${flatAccessWithDatum(model.vgField(p.channel, {binSuffix: 'end'}), datum)}]`
+            : flatAccessWithDatum(p.field, datum);
         })
         .join(', ');
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -303,7 +303,7 @@ export function accessPathWithDatum(path: string, datum = 'datum') {
  * @param path The field name.
  * @param datum The string to use for `datum`.
  */
-export function flatAccessWithDatum(path: string, datum: 'datum' | 'parent' | 'datum.datum' = 'datum') {
+export function flatAccessWithDatum(path: string, datum: string = 'datum') {
   return `${datum}[${stringValue(splitAccessPath(path).join('.'))}]`;
 }
 

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -249,6 +249,35 @@ describe('Inputs Selection Transform', () => {
     });
   });
 
+  it('accesses escaped fields in bound selection events', () => {
+    const escaped = parseUnitSelection(model, [
+      {
+        name: 'escaped',
+        select: {
+          type: 'point',
+          fields: ['y\\[foo\\]'],
+          nearest: true,
+          on: 'click',
+        },
+        bind: {input: 'range', min: 0, max: 10, step: 1},
+      },
+    ]);
+    model.component.selection = escaped;
+
+    expect(assembleTopLevelSignals(model, [])).toContainEqual({
+      name: 'escaped_y__foo__',
+      value: null,
+      on: [
+        {
+          events: [{source: 'scope', type: 'click', markname: 'voronoi'}],
+          update:
+            'datum && item().mark.marktype !== \'group\' ? (item().isVoronoi ? datum.datum : datum)["y[foo]"] : null',
+        },
+      ],
+      bind: {input: 'range', min: 0, max: 10, step: 1},
+    });
+  });
+
   it('respects initialization', () => {
     model.component.selection = {seven: selCmpts['seven']};
     expect(assembleUnitSelectionSignals(model, [])).toEqual(

--- a/test/compile/selection/point.test.ts
+++ b/test/compile/selection/point.test.ts
@@ -220,6 +220,29 @@ describe('Multi Selection', () => {
     model.component.selection = selCmpts;
   });
 
+  it('accesses escaped fields in tuple signals', () => {
+    const escaped = parseUnitSelection(model, [
+      {
+        name: 'escaped',
+        select: {type: 'point', fields: ['y\\[foo\\]']},
+      },
+    ]);
+
+    expect(point.signals(model, escaped['escaped'], [])).toEqual([
+      {
+        name: 'escaped_tuple',
+        on: [
+          {
+            events: [{source: 'scope', type: 'click'}],
+            update:
+              'datum && item().mark.marktype !== \'group\' && indexof(item().mark.role, \'legend\') < 0 ? {unit: "", fields: escaped_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)["y[foo]"]]} : null',
+            force: true,
+          },
+        ],
+      },
+    ]);
+  });
+
   it('builds modify signals', () => {
     const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(


### PR DESCRIPTION
## PR Description

### Summary

Use `flatAccessWithDatum` when extracting point-selection values.

- Escaped fields (ex. `"field": "y\\[foo\\]"`) now access `datum["y[foo]"]`.
    - This change applies to point-selection and bound input selections.
- Existing point-selection behavior remains unchanged for fields without escaped chars.
- Added regression testing for point tuples and nearest bound selections.

### Motivation

Point selections manually generated datum access with `stringValue`, which quoted escaped field paths without interpreting them:

```js
datum["y\\[foo\\]"]
```

Other Vega-Lite compiler paths use shared field-access helpers that correctly generate:

```js
datum["y[foo]"]
```

This caused point-selection behavior to differ from rendering, transforms, predicates, and other generated expressions. 
As a result, point selections did not work as expected for marks using escaped field names.

### History!

In 2019, [#5351](https://github.com/vega/vega-lite/pull/5351) changed selection field access to manual bracket lookup to support flattened fields such as `nested.a`. This fixed nested selections but bypassed the shared helper that interprets escaped field names. 
Escaped bracket support was later added in [#5730](https://github.com/vega/vega-lite/pull/5730), but point selections did not inherit the fix when selection types were consolidated in [#6927](https://github.com/vega/vega-lite/pull/6927).

<img alt="2026-07-29-escape-brackets-selection" src="https://github.com/user-attachments/assets/ad6f472c-b3f0-4aa0-8228-c607808c713f" />

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [ ] `npm test` runs successfully
- For new features:
  - [x] Has unit tests.
  - [ ] Has documentation under `site/docs/` + examples.

Tips:

- https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice PR.
- Use draft PR for work in progress PRs / when you want early feedback (https://github.blog/2019-02-14-introducing-draft-pull-requests/).

</details>
