### PR TITLE
fix(scale): evaluate signals in unioned domains, upgrade to TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,6 +1187,37 @@
         "node": ">=22"
       }
     },
+    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "serve": "^14.2.6",
         "terser": "^5.49.0",
         "ts-json-schema-generator": "^2.9.0",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.64.0",
         "vega-cli": "^6.2.0",
         "vega-datasets": "^3.2.1",
@@ -1182,37 +1182,6 @@
       "license": "ISC",
       "dependencies": {
         "@conventional-changelog/template": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
-      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^2.0.0",
-        "argue-cli": "^3.1.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=22"
@@ -10009,6 +9978,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-json-schema-generator/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10062,9 +10045,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "serve": "^14.2.6",
     "terser": "^5.49.0",
     "ts-json-schema-generator": "^2.9.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.64.0",
     "vega-cli": "^6.2.0",
     "vega-datasets": "^3.2.1",

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -14,7 +14,6 @@ import {Axis} from './axis.js';
 import {autoMaxBins, Bin, BinParams, binToString, isBinned, isBinning} from './bin.js';
 import {
   ANGLE,
-  Channel,
   COLOR,
   COLUMN,
   DESCRIPTION,
@@ -1463,7 +1462,7 @@ export function valueArray(
 /**
  * Checks whether a fieldDef for a particular channel requires a computed bin range.
  */
-export function binRequiresRange(fieldDef: FieldDef<string>, channel: Channel): boolean {
+export function binRequiresRange(fieldDef: FieldDef<string>, channel: ExtendedChannel): boolean {
   if (!isBinning(fieldDef.bin)) {
     console.warn('Only call this method for binned field defs.');
     return false;

--- a/src/compile/axis/config.ts
+++ b/src/compile/axis/config.ts
@@ -82,7 +82,7 @@ export function getAxisConfigs(
 }
 
 export function getAxisConfigStyle(axisConfigTypes: string[], config: Config) {
-  const toMerge = [{}];
+  const toMerge = [];
   for (const configType of axisConfigTypes) {
     // TODO: add special casing to add conditional value based on orient signal
     let style = (config as any)[configType]?.style;
@@ -93,7 +93,7 @@ export function getAxisConfigStyle(axisConfigTypes: string[], config: Config) {
       }
     }
   }
-  return Object.assign.apply(null, toMerge);
+  return Object.assign({}, ...toMerge);
 }
 export function getAxisConfig(
   property: keyof AxisConfig<SignalRef>,

--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -167,7 +167,7 @@ export class AggregateNode extends DataFlowNode {
           }
         }
       } else {
-        addDimension(dims, channel as Channel, fieldDef, model);
+        addDimension(dims, channel, fieldDef, model);
       }
     });
 

--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -136,7 +136,7 @@ export class AggregateNode extends DataFlowNode {
       return null;
     }
 
-    model.forEachFieldDef((fieldDef, channel: Channel) => {
+    model.forEachFieldDef((fieldDef, channel) => {
       const {aggregate, field} = fieldDef;
       if (aggregate) {
         if (aggregate === 'count') {
@@ -167,7 +167,7 @@ export class AggregateNode extends DataFlowNode {
           }
         }
       } else {
-        addDimension(dims, channel, fieldDef, model);
+        addDimension(dims, channel as Channel, fieldDef, model);
       }
     });
 

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -1,7 +1,7 @@
 import {BinTransform as VgBinTransform, Transforms as VgTransform} from 'vega';
 import {isString} from 'vega-util';
 import {BinParams, binToString, isBinning, isParameterExtent} from '../../bin.js';
-import {Channel} from '../../channel.js';
+import {ExtendedChannel} from '../../channel.js';
 import {binRequiresRange, FieldName, isTypedFieldDef, normalizeBin, TypedFieldDef, vgField} from '../../channeldef.js';
 import {Config} from '../../config.js';
 import {BinTransform} from '../../transform.js';
@@ -12,7 +12,12 @@ import {parseSelectionExtent} from '../selection/parse.js';
 import {NonPositionScaleChannel, PositionChannel} from './../../channel.js';
 import {DataFlowNode} from './dataflow.js';
 
-function rangeFormula(model: ModelWithField, fieldDef: TypedFieldDef<string>, channel: Channel, config: Config) {
+function rangeFormula(
+  model: ModelWithField,
+  fieldDef: TypedFieldDef<string>,
+  channel: ExtendedChannel,
+  config: Config,
+) {
   if (binRequiresRange(fieldDef, channel)) {
     // read format from axis or legend, if there is no format then use config.numberFormat
 

--- a/src/compile/data/calculate.ts
+++ b/src/compile/data/calculate.ts
@@ -1,5 +1,5 @@
 import {FormulaTransform as VgFormulaTransform} from 'vega';
-import {SingleDefChannel} from '../../channel.js';
+import {ExtendedChannel} from '../../channel.js';
 import {FieldRefOption, isScaleFieldDef, TypedFieldDef, vgField} from '../../channeldef.js';
 import {DateTime} from '../../datetime.js';
 import {fieldFilterExpression} from '../../predicate.js';
@@ -28,7 +28,7 @@ export class CalculateNode extends DataFlowNode {
 
   public static parseAllForSortIndex(parent: DataFlowNode, model: ModelWithField) {
     // get all the encoding with sort fields from model
-    model.forEachFieldDef((fieldDef: TypedFieldDef<string>, channel: SingleDefChannel) => {
+    model.forEachFieldDef((fieldDef, channel) => {
       if (!isScaleFieldDef(fieldDef)) {
         return;
       }
@@ -73,6 +73,6 @@ export class CalculateNode extends DataFlowNode {
   }
 }
 
-export function sortArrayIndexField(fieldDef: TypedFieldDef<string>, channel: SingleDefChannel, opt?: FieldRefOption) {
+export function sortArrayIndexField(fieldDef: TypedFieldDef<string>, channel: ExtendedChannel, opt?: FieldRefOption) {
   return vgField(fieldDef, {prefix: channel, suffix: 'sort_index', ...opt});
 }

--- a/src/compile/data/debug.ts
+++ b/src/compile/data/debug.ts
@@ -24,7 +24,9 @@ export function drawDataflow(roots: readonly DataFlowNode[], size = 500) {
   const dot = dotString(roots);
   const text = new TextEncoder().encode(dot);
   const compressed = deflate(text, {level: 9});
-  const result = btoa(String.fromCharCode.apply(null, compressed)).replace(/\+/g, '-').replace(/\//g, '_');
+  const result = btoa(String.fromCharCode(...compressed))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
   const imageURL = `https://kroki.io/graphviz/png/${result}`;
   console.log('Dataflow visualization: ', imageURL);
   console.log('%c ', `font-size:${size}px; background:url(${imageURL}) no-repeat; background-size:contain`);

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -56,7 +56,7 @@ export class TimeUnitNode extends DataFlowNode {
   }
 
   public static makeFromEncoding(parent: DataFlowNode, model: ModelWithField) {
-    const formula = model.reduceFieldDef((timeUnitComponent: TimeUnitComponent, fieldDef, channel) => {
+    const formula = model.reduceFieldDef((timeUnitComponent: Dict<TimeUnitComponent>, fieldDef, channel) => {
       const {field, timeUnit} = fieldDef;
 
       if (timeUnit) {
@@ -92,7 +92,7 @@ export class TimeUnitNode extends DataFlowNode {
         }
 
         if (component) {
-          (timeUnitComponent as any)[hash(component)] = component;
+          timeUnitComponent[hash(component)] = component;
         }
       }
       return timeUnitComponent;

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -36,7 +36,7 @@ export function facetSortFieldName(
   return vgField(sort, {suffix: `by_${vgField(fieldDef)}`, ...opt});
 }
 
-export class FacetModel extends ModelWithField {
+export class FacetModel extends ModelWithField<EncodingFacetMapping<string, SignalRef>> {
   public readonly facet: EncodingFacetMapping<string, SignalRef>;
 
   public readonly child: Model;

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -663,10 +663,10 @@ export abstract class ModelWithField extends Model {
 
   protected abstract getMapping(): Partial<Record<ExtendedChannel, any>>;
 
-  public reduceFieldDef<T, U>(f: (acc: U, fd: FieldDef<string>, c: Channel) => U, init: T): T {
+  public reduceFieldDef<T, U>(f: (acc: U, fd: FieldDef<string>, c: ExtendedChannel) => U, init: T): T {
     return reduce(
       this.getMapping(),
-      (acc: U, cd: ChannelDef, c: Channel) => {
+      (acc: U, cd: ChannelDef, c: ExtendedChannel) => {
         const fieldDef = getFieldDef(cd);
         if (fieldDef) {
           return f(acc, fieldDef, c);

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -647,7 +647,9 @@ export abstract class Model {
 }
 
 /** Abstract class for UnitModel and FacetModel. Both of which can contain fieldDefs as a part of its own specification. */
-export abstract class ModelWithField extends Model {
+export abstract class ModelWithField<
+  M extends Partial<Record<ExtendedChannel, any>> = Partial<Record<ExtendedChannel, any>>,
+> extends Model {
   public abstract fieldDef(channel: SingleDefChannel): FieldDef<any>;
 
   /** Get "field" reference for Vega */
@@ -661,12 +663,12 @@ export abstract class ModelWithField extends Model {
     return vgField(fieldDef, opt);
   }
 
-  protected abstract getMapping(): Partial<Record<ExtendedChannel, any>>;
+  protected abstract getMapping(): M;
 
-  public reduceFieldDef<T, U>(f: (acc: U, fd: FieldDef<string>, c: ExtendedChannel) => U, init: T): T {
+  public reduceFieldDef<T>(f: (acc: T, fd: FieldDef<string>, c: keyof M) => T, init: T): T {
     return reduce(
       this.getMapping(),
-      (acc: U, cd: ChannelDef, c: ExtendedChannel) => {
+      (acc: T, cd: ChannelDef, c: keyof M) => {
         const fieldDef = getFieldDef(cd);
         if (fieldDef) {
           return f(acc, fieldDef, c);
@@ -677,7 +679,7 @@ export abstract class ModelWithField extends Model {
     );
   }
 
-  public forEachFieldDef(f: (fd: FieldDef<string>, c: ExtendedChannel) => void, t?: any) {
+  public forEachFieldDef(f: (fd: FieldDef<string>, c: keyof M) => void, t?: any) {
     forEach(
       this.getMapping(),
       (cd, c) => {

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -45,6 +45,7 @@ import {
   VgMultiFieldsRefWithSort,
   VgNonUnionDomain,
   VgScaleDataRefWithSort,
+  VgScaleMultiDataRefWithSort,
   VgSortField,
   VgUnionSortField,
 } from '../../vega.schema.js';
@@ -56,7 +57,7 @@ import {OFFSETTED_RECT_END_SUFFIX, OFFSETTED_RECT_START_SUFFIX} from '../data/ti
 import {getScaleDataSourceForHandlingInvalidValues} from '../invalid/datasources.js';
 import {isFacetModel, isUnitModel, Model} from '../model.js';
 import {SignalRefWrapper} from '../signal.js';
-import {Explicit, makeExplicit, makeImplicit, mergeValuesWithExplicit} from '../split.js';
+import {Explicit, makeExplicit, makeImplicit, mergeValuesWithExplicit, SplitParentProperty} from '../split.js';
 import {UnitModel} from '../unit.js';
 import {ScaleComponent, ScaleComponentIndex} from './component.js';
 
@@ -539,8 +540,8 @@ export function canUseUnaggregatedDomain(
 function domainsTieBreaker(
   v1: Explicit<VgNonUnionDomain[]>,
   v2: Explicit<VgNonUnionDomain[]>,
-  property: 'domains',
-  propertyOf: 'scale',
+  property: 'domain' | 'domains',
+  propertyOf: SplitParentProperty,
 ) {
   if (v1.explicit && v2.explicit) {
     log.warn(log.message.mergeConflictingDomainProperty(property, propertyOf, v1.value, v2.value));
@@ -662,7 +663,9 @@ export function mergeDomains(domains: VgNonUnionDomain[]): VgDomain {
     return domain;
   }
 
-  return {fields: uniqueDomains, ...(sort ? {sort} : {})};
+  const domain: VgScaleMultiDataRefWithSort = {fields: uniqueDomains, ...(sort ? {sort} : {})};
+
+  return domain;
 }
 
 /**

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -671,7 +671,7 @@ export function mergeDomains(domains: VgNonUnionDomain[]): VgDomain {
   return domain;
 }
 
-/** Vega ingests an array in `domain.fields` as literal data without evaluating signals inside it. */
+/** A single signal keeps unioned signal domains working across all supported Vega versions. */
 function unionDomainField(domain: VgNonUnionDomain): VgNonUnionDomain {
   if (isArray(domain) && domain.some(isSignalRef)) {
     return {signal: `[${domain.map((v) => (isSignalRef(v) ? v.signal : util.stringify(v))).join(', ')}]`};

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -1,5 +1,5 @@
 import type {SignalRef} from 'vega';
-import {hasOwnProperty, isObject, isString} from 'vega-util';
+import {hasOwnProperty, isArray, isObject, isString} from 'vega-util';
 import {
   Aggregate,
   isAggregateOp,
@@ -663,8 +663,19 @@ export function mergeDomains(domains: VgNonUnionDomain[]): VgDomain {
     return domain;
   }
 
-  const domain: VgScaleMultiDataRefWithSort = {fields: uniqueDomains, ...(sort ? {sort} : {})};
+  const domain: VgScaleMultiDataRefWithSort = {
+    fields: uniqueDomains.map(unionDomainField),
+    ...(sort ? {sort} : {}),
+  };
 
+  return domain;
+}
+
+/** Vega ingests an array in `domain.fields` as literal data without evaluating signals inside it. */
+function unionDomainField(domain: VgNonUnionDomain): VgNonUnionDomain {
+  if (isArray(domain) && domain.some(isSignalRef)) {
+    return {signal: `[${domain.map((v) => (isSignalRef(v) ? v.signal : util.stringify(v))).join(', ')}]`};
+  }
   return domain;
 }
 

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -69,7 +69,7 @@ function parseUnitScaleCore(model: UnitModel): ScaleComponentIndex {
   return scaleComponents;
 }
 
-const scaleTypeTieBreaker = tieBreakByComparing(
+const scaleTypeTieBreaker = tieBreakByComparing<VgScale, ScaleType>(
   (st1: ScaleType, st2: ScaleType) => scaleTypePrecedence(st1) - scaleTypePrecedence(st2),
 );
 

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -64,7 +64,7 @@ export interface SelectionCompiler<T extends SelectionType = SelectionType> {
 }
 
 // Order matters for parsing and assembly.
-export const selectionCompilers: SelectionCompiler[] = [
+export const selectionCompilers: SelectionCompiler<any>[] = [
   point,
   interval,
   project,

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -303,7 +303,7 @@ function channelSignals(
   const vname = proj.signals.visual;
 
   const scaleName = stringValue(scaledInterval ? model.scaleName(channel) : model.projectionName());
-  const scaled = (str: string) => `scale(${scaleName}, ${str})`;
+  const scaled = (str: string | number) => `scale(${scaleName}, ${str})`;
 
   const size = model.getSizeSignalRef(channel === X ? 'width' : 'height').signal;
   const coord = `${channel}(unit)`;

--- a/src/compile/split.ts
+++ b/src/compile/split.ts
@@ -100,12 +100,7 @@ export function makeImplicit<T>(value: T): Explicit<T> {
 export type SplitParentProperty = 'scale' | 'axis' | 'legend' | '';
 
 export function tieBreakByComparing<S, T>(compare: (v1: T, v2: T) => number) {
-  return (
-    v1: Explicit<T>,
-    v2: Explicit<T>,
-    property: keyof S | never,
-    propertyOf: SplitParentProperty,
-  ): Explicit<T> => {
+  return (v1: Explicit<T>, v2: Explicit<T>, property: keyof S, propertyOf: SplitParentProperty): Explicit<T> => {
     const diff = compare(v1.value, v2.value);
     if (diff > 0) {
       return v1;
@@ -138,7 +133,7 @@ export function mergeValuesWithExplicit<S, T>(
     v1: Explicit<T>,
     v2: Explicit<T>,
     property: keyof S,
-    propertyOf: string,
+    propertyOf: SplitParentProperty,
   ) => Explicit<T> = defaultTieBreaker,
 ) {
   if (v1 === undefined || v1.value === undefined) {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -67,7 +67,7 @@ import {CURR} from './selection/point.js';
 /**
  * Internal model of Vega-Lite specification for the compiler.
  */
-export class UnitModel extends ModelWithField {
+export class UnitModel extends ModelWithField<Encoding<string>> {
   public readonly markDef: MarkDef<Mark, SignalRef>;
   public readonly encoding: Encoding<string>;
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -86,7 +86,6 @@ import {
   TimeDef,
   title,
   TooltipFieldDef,
-  TypedFieldDef,
   vgField,
 } from './channeldef.js';
 import {Config} from './config.js';
@@ -621,17 +620,14 @@ export function initEncoding(
           }
         }
         // Array of fieldDefs for detail channel (or production rule)
-        (normalizedEncoding[channel] as any) = array(channelDef).reduce(
-          (defs: FieldDef<string>[], fieldDef: FieldDef<string>) => {
-            if (!isFieldDef(fieldDef)) {
-              log.warn(log.message.emptyFieldDef(fieldDef, channel));
-            } else {
-              defs.push(initFieldDef(fieldDef, channel));
-            }
-            return defs;
-          },
-          [],
-        );
+        (normalizedEncoding[channel] as any) = array(channelDef).reduce((defs: FieldDef<string>[], fieldDef) => {
+          if (!isFieldDef(fieldDef)) {
+            log.warn(log.message.emptyFieldDef(fieldDef, channel));
+          } else {
+            defs.push(initFieldDef(fieldDef, channel));
+          }
+          return defs;
+        }, []);
       }
     } else {
       if (channel === TOOLTIP && channelDef === null) {
@@ -709,7 +705,7 @@ export function forEach<U extends Record<any, any>>(
 
 export function reduce<T, U extends Record<any, any>>(
   mapping: U,
-  f: (acc: any, fd: TypedFieldDef<string>, c: keyof U) => U,
+  f: (acc: any, cd: ChannelDef, c: keyof U) => U,
   init: T,
   thisArg?: any,
 ) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -705,7 +705,7 @@ export function forEach<U extends Record<any, any>>(
 
 export function reduce<T, U extends Record<any, any>>(
   mapping: U,
-  f: (acc: any, cd: ChannelDef, c: keyof U) => U,
+  f: (acc: T, cd: ChannelDef, c: keyof U) => T,
   init: T,
   thisArg?: any,
 ) {

--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -348,7 +348,12 @@ export function mergeConflictingProperty<T>(
   )}). Using ${stringify(v1)}.`;
 }
 
-export function mergeConflictingDomainProperty<T>(property: 'domains', propertyOf: SplitParentProperty, v1: T, v2: T) {
+export function mergeConflictingDomainProperty<T>(
+  property: 'domain' | 'domains',
+  propertyOf: SplitParentProperty,
+  v1: T,
+  v2: T,
+) {
   return `Conflicting ${propertyOf.toString()} property "${property.toString()}" (${stringify(v1)} and ${stringify(
     v2,
   )}). Using the union of the two domains.`;

--- a/src/normalize/toplevelselection.ts
+++ b/src/normalize/toplevelselection.ts
@@ -68,7 +68,7 @@ export class TopLevelSelectionsNormalizer extends SpecMapper<NormalizerParams, N
 for (const method of ['mapFacet', 'mapRepeat', 'mapHConcat', 'mapVConcat', 'mapLayer'] as const) {
   const proto = TopLevelSelectionsNormalizer.prototype[method];
   TopLevelSelectionsNormalizer.prototype[method] = function (spec: BaseSpec, params: NormalizerParams) {
-    return proto.call(this, spec, addSpecNameToParams(spec, params));
+    return Reflect.apply(proto, this, [spec, addSpecNameToParams(spec, params)]);
   };
 }
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -109,7 +109,7 @@ export interface VgValueRef {
 }
 
 // TODO: add vg prefix
-export type VgScaleMultiDataRefWithSort = ScaleMultiDataRef & {
+export type VgScaleMultiDataRefWithSort = Omit<ScaleMultiDataRef, 'fields'> & {
   fields: (any[] | VgScaleDataRefWithSort | SignalRef)[];
   sort?: VgUnionSortField;
 };

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -915,6 +915,29 @@ describe('compile/scale', () => {
       });
     });
 
+    it('should turn a unioned value array containing signals into a single signal', () => {
+      const domain = mergeDomains([
+        [{signal: 'lo'}, {signal: 'hi'}],
+        [0, 5],
+      ]);
+
+      expect(domain).toEqual({fields: [{signal: '[lo, hi]'}, [0, 5]]});
+    });
+
+    it('should keep a unioned value array without signals as an array', () => {
+      const domain = mergeDomains([
+        [1, 2],
+        [0, 5],
+      ]);
+
+      expect(domain).toEqual({
+        fields: [
+          [1, 2],
+          [0, 5],
+        ],
+      });
+    });
+
     it('should merge domains with different data source', () => {
       const domain = mergeDomains([
         {

--- a/test/jest.overrides.ts
+++ b/test/jest.overrides.ts
@@ -1,14 +1,14 @@
 const {warn, error} = console;
 
-console.error = function (msg: string, msg2: string) {
-  // eslint-disable-next-line prefer-rest-params
-  error.apply(console, arguments);
+console.error = function (...args: [msg: string, msg2: string, ...rest: any[]]) {
+  error.apply(console, args);
+  const [msg, msg2] = args;
   throw new Error(`${msg}: ${msg2} -- Please remove unnecessary errors or use log.wrap to consume reasonable errors`);
 };
 
-console.warn = function (msg: string, msg2: string) {
-  // eslint-disable-next-line prefer-rest-params
-  warn.apply(console, arguments);
+console.warn = function (...args: [msg: string, msg2: string, ...rest: any[]]) {
+  warn.apply(console, args);
+  const [msg, msg2] = args;
   throw new Error(`${msg}: ${msg2} -- Please remove unnecessary errors or use log.wrap to consume reasonable errors`);
 };
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Node16",
     "noEmit": false,
 
+    "rootDir": "src",
     "declarationDir": "build",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Two things, both of which fell out of upgrading `typescript` from `~5.9.3` to `~6.0.3`.

## 1. Bug fix: signals in unioned scale domains were silently dropped

Making a type honest (see `VgScaleMultiDataRefWithSort` below) surfaced a real, user-visible bug.

```json
{"params": [{"name": "lo", "value": 2}, {"name": "hi", "value": 8}],
 "layer": [
   {"encoding": {"y": {"field": "v", "type": "quantitative", "scale": {"domain": [{"expr": "lo"}, {"expr": "hi"}]}}}, ...},
   {"encoding": {"y": {"field": "v", "type": "quantitative", "scale": {"domain": [0, 5]}}}, ...}],
 "resolve": {"scale": {"y": "shared"}}}
```

compiled to `"domain": {"fields": [[{"signal":"lo"},{"signal":"hi"}], [0,5]]}`. Running that through Vega, the `y` domain resolved to **`[0,5]` instead of `[0,8]`** — the explicit signal domain contributed nothing and was dropped without any warning. The spec also fails validation against Vega's own `vega-schema.json`.

**Root cause is an asymmetry in Vega's parser** (`packages/vega-parser/src/parsers/scale.js`). A top-level `domain` array goes through `explicitDomain` → `parseLiteral` per element, which resolves `{signal}` (and errors on any other object). But an array nested in `domain.fields` goes through `multipleDomain` → `fieldRef`, whose array branch does a raw `coll.value = {$ingest: data}` with no `parseLiteral` — so signal objects are ingested as literal data and never evaluated, silently. The neighbouring `d.signal` branch does the right thing via `setdata(...)`.

So the same `[{signal: 'lo'}, 5]` syntax means two different things depending on where it appears. **I'm filing a separate PR against vega** to make `fieldRef` resolve signals the way every other literal-array path does.

Vega-Lite still needs to emit something that works today: it peer-depends on `vega ^6.0.0`, and the `{signal: "[...]"}` form is valid under Vega's *current* published schema and works on every 6.x. So this is the portable encoding, not a workaround — it stays correct after the Vega fix lands.

```ts
/** Vega ingests an array in `domain.fields` as literal data without evaluating signals inside it. */
function unionDomainField(domain: VgNonUnionDomain): VgNonUnionDomain {
  if (isArray(domain) && domain.some(isSignalRef)) {
    return {signal: `[${domain.map((v) => (isSignalRef(v) ? v.signal : util.stringify(v))).join(', ')}]`};
  }
  return domain;
}
```

Now emits `{"fields": [{"signal":"[lo, hi]"}, [0,5]]}`, which resolves to the correct `[0,8]` and validates. Only arrays that actually contain signals are rewritten, so **all 633 compiled examples are byte-identical**. Two tests added. The single-domain path was always correct and is untouched.

## 2. TypeScript 6.0

**TS 6.0 enables `strict` by default.** Our `tsconfig.json` never set `strict`, so it was off; it explicitly sets `strictNullChecks: false` (still respected), but everything else in the strict family is now on. Two flags did all the damage:

| flag | errors |
|---|---|
| `strictFunctionTypes` — function parameters checked contravariantly instead of bivariantly | 22 |
| `strictBindCallApply` — `.call`/`.apply`/`.bind` typed precisely instead of `(thisArg: any, ...args: any[]) => any` | 5 |

Confirmed by isolating the flags: `npx tsc --strict false` on the un-fixed tree gives 0 errors. Every one of the 27 was **pre-existing unsoundness that bivariance was hiding**, not a new TS restriction, so the fixes make signatures honest rather than suppressing them.

### Notable fixes

- **`ModelWithField` now carries its mapping type** — `forEachFieldDef`/`reduceFieldDef` yield `keyof M`, so a `UnitModel` gives `Channel` and a `FacetModel` gives `FacetChannel`. This replaces an `as Channel` assertion with a guarantee that follows from the arguments. Two signatures were wrong underneath it: `reduce` declared its callback as returning the *mapping* type rather than the accumulator, and `TimeUnitNode` annotated its accumulator as `TimeUnitComponent` when it is a `Dict` of them — which is exactly why it carried a `(timeUnitComponent as any)[…]`. That cast is gone too.

- **`reduceFieldDef`** previously declared its callback's channel as `Channel`, but it lives on `ModelWithField` and `FacetModel extends ModelWithField`, so `'row' | 'column' | 'facet'` really did flow through. Now truthful via the generic above.

- **`Split` tie-breakers** (`split.ts`, `scale/{domain,parse,properties}.ts`) — `mergeValuesWithExplicit`'s `tieBreaker` parameter declared `propertyOf: string`, but every actual tie-breaker takes the narrower `SplitParentProperty`. Also `domainsTieBreaker` declared `property: 'domains'` while two of its three call sites pass `'domain'` — the type was the lie, not the call, so it's widened to `'domain' | 'domains'`. **No warning message text changes.**

- **`encoding.ts` `reduce`** declared it passes `TypedFieldDef<string>` to its callback; the implementation passes whatever is in the mapping. Corrected to `ChannelDef`. `strictBindCallApply` exposed this via the internal `f.call(...)`.

- **`VgScaleMultiDataRefWithSort`** (`vega.schema.ts`) — intended to override vega's `fields` with a wider type, but `ScaleMultiDataRef & {fields: ...}` *intersects* rather than overrides, producing a `fields` type nearly nothing could satisfy, so the declared `any[]` never took effect. Changed to `Omit<ScaleMultiDataRef, 'fields'> & {...}`, matching the `Omit` idiom already used further down the same file. This is what surfaced the domain bug above.

- **`selectionCompilers`** (`selection/index.ts`) — `SelectionCompiler<T>` uses `T` only in parameter position, so `SelectionCompiler<'point'>` is no longer assignable to `SelectionCompiler<SelectionType>`. All four dispatch loops guard every call behind `c.defined(selCmpt)`, which is exactly the type discriminator. Widened only the array's element type to `SelectionCompiler<any>`, so each compiler module keeps its narrow `<'point'>` / `<'interval'>` annotation and stays fully checked at its definition site. This is the one place the PR loses type safety.

- **`Object.assign.apply(null, toMerge)`** (`axis/config.ts`) → `Object.assign({}, ...toMerge)` with the seed `{}` dropped from the array. Equivalent for both the populated and empty cases.

- **`tsconfig.build.json`** — added `rootDir: "src"`. TS 6 now emits TS5011 during the rollup build asking for it explicitly. Verified the emitted bundles are byte-identical and the 375 `.d.ts` files land in the same places.

## Verification

- `npx tsc` — clean.
- `npx vitest run test/` — 3346 passed.
- `npx vitest run examples/` — 3277 passed.
- `npm run test:runtime -- --browser.headless` — 55 passed, 1 skipped (pre-existing `it.skip`).
- `npm run lint` — clean.
- `npm run build` — succeeds; TS5011 gone.
- `npm run schema` — regenerated `build/vega-lite-schema.json` is **byte-identical** to the committed one.
- **All 633 example specs compile to byte-identical Vega output** vs the committed `examples/compiled/*.vg.json` baseline, before and after the domain fix.

## Toolchain compatibility

`typescript-eslint@8.64` declares `typescript: ">=4.8.4 <6.1.0"`, so 6.0.3 is in range. `ts-json-schema-generator` pins its own `typescript@5.9.3` as a direct dependency, so schema generation is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
