### PR TITLE
fix: honor symbol legend direction config

### DIFF
--- a/src/compile/legend/properties.ts
+++ b/src/compile/legend/properties.ts
@@ -180,7 +180,7 @@ export function getDirection({
 }): Orientation {
   return (
     legend.direction ??
-    legendConfig[legendType ? 'gradientDirection' : 'symbolDirection'] ??
+    legendConfig[legendType === 'gradient' ? 'gradientDirection' : 'symbolDirection'] ??
     defaultDirection(orient, legendType)
   );
 }

--- a/test/compile/legend/assemble.test.ts
+++ b/test/compile/legend/assemble.test.ts
@@ -2,6 +2,31 @@ import {parseLayerModel, parseUnitModelWithScale} from '../../util.js';
 import * as log from '../../../src/log/index.js';
 
 describe('legend/assemble', () => {
+  it.each([
+    {type: 'nominal' as const, direction: 'horizontal'},
+    {type: 'quantitative' as const, direction: 'vertical'},
+  ])('uses the matching legend direction config for $type color', ({type, direction}) => {
+    const model = parseUnitModelWithScale({
+      mark: 'point',
+      encoding: {color: {field: 'value', type}},
+      config: {legend: {symbolDirection: 'horizontal', gradientDirection: 'vertical'}},
+    });
+    model.parseLegends();
+
+    expect(model.assembleLegends()[0].direction).toBe(direction);
+  });
+
+  it('preserves an explicit legend direction over the symbol direction config', () => {
+    const model = parseUnitModelWithScale({
+      mark: 'point',
+      encoding: {color: {field: 'value', type: 'nominal', legend: {direction: 'vertical'}}},
+      config: {legend: {symbolDirection: 'horizontal'}},
+    });
+    model.parseLegends();
+
+    expect(model.assembleLegends()[0].direction).toBe('vertical');
+  });
+
   it('correctly applies labelExpr.', () => {
     const model = parseUnitModelWithScale({
       data: {url: 'data/cars.json'},


### PR DESCRIPTION
## PR Description

Symbol legends currently read `config.legend.gradientDirection` because the legend-type check treats both `'symbol'` and `'gradient'` as truthy. For example, setting `symbolDirection: 'horizontal'` and `gradientDirection: 'vertical'` produces a vertical symbol legend.

Compare the type explicitly so each legend uses its matching direction config. Add assembly regression tests covering symbol and gradient legends with different configured directions, plus precedence of an explicit legend direction.

Validation:
- Confirmed the new symbol-legend test fails before the fix and passes after it.
- All 3,351 unit tests and 3,277 example tests pass.
- TypeScript checking, schema generation, and lint/format checks for both changed files pass.
- Full `npm test` stops on 23 formatting errors in untouched upstream files in this local environment.
- Browser runtime tests have 55 snapshot failures locally; rerunning with the source fix removed reproduces all 55 failures.

No generated schema or snapshot changes are included.

## Checklist

- [x] This PR fixes one issue.
- [x] The title is a concise semantic commit message.
- [ ] `npm test` runs successfully (local baseline failures described above).
